### PR TITLE
fix: stop DB session cascade in C30/C0 per-aid fetch

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -90,7 +90,7 @@ class CheckC30NeedInsertButNotFoundAidsJob(Job):
         self.record_queue = record_queue
         self.service = service
         self.session = Session()
-        self._duration_limit_s = 60 * 30  # 30 minutes
+        self._duration_limit_s = 60 * 40  # 40 minutes, hard stop
 
     def process(self):
         # TMP duration limit
@@ -115,6 +115,14 @@ class CheckC30NeedInsertButNotFoundAidsJob(Job):
                     aid, self.service, self.session, out_context=update_video_context)
                 video_view: VideoView = update_video_context['video_view']
             except Exception as e:
+                # Roll back so a failed DB op (e.g. a transient 'too many
+                # connections') does not leave this worker's session in an
+                # invalid-transaction state, which would otherwise poison every
+                # subsequent aid and surface as bogus NotExistError cascades.
+                try:
+                    self.session.rollback()
+                except Exception:
+                    pass
                 self.logger.error(
                     f'Fail to update video info. aid: {aid}, error: {e}')
                 self.stat.condition['update_exception'] += 1

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -745,8 +745,9 @@ class C30PipelineRunner(Thread):
                 self.logger.error('Exception: %s' % str(e))
         self.logger.info('%d / %d done' %
                          (len(need_insert_aid_list), len(need_insert_aid_list)))
-        self.logger.info('Finish inserting records! %d records added, %d aids left' % (
-            len(need_insert_aid_list), len(need_insert_but_record_not_found_aid_list)))
+        self.logger.info('Finish inserting records! %d records added, %d aids not found (record missing)' % (
+            len(need_insert_aid_list) - len(need_insert_but_record_not_found_aid_list),
+            len(need_insert_but_record_not_found_aid_list)))
         # TODO: extract to util funtion end
 
         # check need insert but not found aid list
@@ -879,8 +880,9 @@ class C30PipelineRunner(Thread):
                 self.logger.error('Exception: %s' % str(e))
         self.logger.info('%d / %d done' %
                          (len(missing_record_list), len(missing_record_list)))
-        self.logger.info('Finish inserting missing records! %d records added, %d aids left' % (
-            len(missing_record_list), len(need_insert_but_record_not_found_aid_list)))
+        self.logger.info('Finish inserting missing records! %d missing records added, %d aids still unresolved' % (
+            len(missing_record_list),
+            len(need_insert_but_record_not_found_aid_list) - len(missing_record_list)))
         # TODO: extract to util funtion end
 
         self.logger.info(

--- a/db/operation.py
+++ b/db/operation.py
@@ -26,6 +26,16 @@ class DBOperation:
         except Exception as e:
             logger_db.error('Exception: %s, params: %s' %
                             (e, {'aid': aid}), exc_info=True)
+            # Roll back so a transient failure (e.g. 'too many connections')
+            # does not leave the session stuck in an invalid transaction that
+            # breaks every following query on it. NOTE: on failure this still
+            # returns None, which callers like update_video treat as "not
+            # exist" -- an infra error can thus be mislabeled; revisit if that
+            # distinction matters.
+            try:
+                session.rollback()
+            except Exception:
+                pass
             return None
 
     @classmethod

--- a/job/AddVideoRecordJob.py
+++ b/job/AddVideoRecordJob.py
@@ -45,6 +45,13 @@ class AddVideoRecordJob(Job):
                     try:
                         tdd_video_logs = update_video(aid, self.service, self.session)
                     except Exception as e2:
+                        # Recover the session so a failed DB op does not leave
+                        # it in an invalid-transaction state that would cascade
+                        # to every subsequent aid in this worker.
+                        try:
+                            self.session.rollback()
+                        except Exception:
+                            pass
                         self.logger.error(f'Fail to update video info. aid: {aid}, error: {e2}')
                         self.stat.condition['update_exception'] += 1
                     else:
@@ -57,6 +64,12 @@ class AddVideoRecordJob(Job):
                     self.logger.error(f'Fail to add video record. aid: {aid}, error: {e}')
                 self.stat.condition['code_error'] += 1
             except Exception as e:
+                # Recover the session so a failed DB op does not leave it in an
+                # invalid-transaction state that would cascade to subsequent aids.
+                try:
+                    self.session.rollback()
+                except Exception:
+                    pass
                 self.logger.error(f'Fail to add video record. aid: {aid}, error: {e}')
                 self.stat.condition['other_exception'] += 1
             else:


### PR DESCRIPTION
## Background

Script `51` (hourly video record add) has been logging a ~92% failure rate in the C30 "add missing videos" phase since the bulk newlist API went unstable. Diagnosis of the `51_202607100100_INFO.log` showed the failures are **not** API errors — they're a DB session cascade.

## Diagnosis

Of 60,745 `update_exception`s that hour:

| Underlying exception | Count | Share |
|---|---|---|
| `InvalidRequestError: Can't reconnect until invalid transaction is rolled back` | 57,952 | 95% |
| `OperationalError (1040, 'Too many connections')` | 2,786 | 4.6% |
| `Lost connection to MySQL` | ~7 | — |

`NotExistError` count mapped **1:1** to these DB failures — none were genuinely "video not in table".

**Cause:** each worker reuses one `Session` for its whole aid loop. When a DB op failed (mostly a transient "too many connections"), the session was left in an invalid-transaction state and **never rolled back**, so every subsequent aid on that worker failed. One blip poisoned a worker for the rest of the run, turning ~2,800 real failures into ~58,000 cascading ones. `query_video_via_aid` then swallowed the error and returned `None`, which `update_video` mislabeled as `NotExistError`.

## Changes

- **`CheckC30NeedInsertButNotFoundAidsJob`** — roll back the session on failure so a single blip no longer poisons the worker.
- **`AddVideoRecordJob`** (C0 path) — same defensive rollback on the failure paths (identical latent bug).
- **`query_video_via_aid`** — roll back on query failure so it self-heals for all callers; documented that it still returns `None` on infra failure (mislabeled as not-exist) for a future revisit.
- **Hard stop** raised 30m → 40m for the C30 add-missing phase.
- **Log polish** — the two "N records added / N aids left" lines now report accurate counts (actually-inserted, and still-unresolved) instead of static totals.

## Not addressed (follow-up)

The **trigger** (Bug A) — ~150 concurrent sessions (100 CheckC30 + 50 C0) can still momentarily exceed MySQL `max_connections`. With rollback those now fail-and-recover per-aid instead of cascading, so expect a small residual rate, not 92%. Capping total concurrent sessions is the next lever.

## Observe after merge

- `update_exception` should drop from ~60k toward near-zero; `missing_video_record_get` should rise sharply.
- Watch whether the phase now hits the 40m "Duration limit reached" cap and how many aids remain — that's the real per-run capacity ceiling for the redesign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)