### PR TITLE
feat: JobPool with per-second progress heartbeat (C30 missing-recovery)

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -12,7 +12,7 @@ from serverchan import sc_send_summary, sc_send_critical
 from collections import namedtuple, defaultdict, Counter
 from core import TddError
 from service import Service, NewlistArchive, VideoView
-from job import GetNewlistArchiveJob, JobStat, AddVideoRecordJob, Job
+from job import GetNewlistArchiveJob, JobStat, AddVideoRecordJob, Job, JobPool
 from typing import NamedTuple, Optional
 from task import update_video, add_video, AlreadyExistError
 from timer import Timer
@@ -776,17 +776,19 @@ class C30PipelineRunner(Thread):
         # create jobs
         check_c30_need_insert_but_not_found_aid_job_num = min(
             100, max(len(need_insert_but_record_not_found_aid_list) // 10, 1))  # [1, 100]
-        check_c30_need_insert_but_not_found_aid_job_list = []
-        for i in range(check_c30_need_insert_but_not_found_aid_job_num):
-            check_c30_need_insert_but_not_found_aid_job_list.append(
-                CheckC30NeedInsertButNotFoundAidsJob(
-                    f'job_{i}', need_insert_but_not_found_aid_queue, missing_record_queue, service))
+        check_c30_need_insert_but_not_found_aid_job_list = [
+            CheckC30NeedInsertButNotFoundAidsJob(
+                f'job_{i}', need_insert_but_not_found_aid_queue, missing_record_queue, service)
+            for i in range(check_c30_need_insert_but_not_found_aid_job_num)
+        ]
 
-        # start jobs
-        for job in check_c30_need_insert_but_not_found_aid_job_list:
-            job.start()
-        logger.info(
-            f'{check_c30_need_insert_but_not_found_aid_job_num} job(s) started.')
+        # start jobs, with a per-second progress heartbeat (greppable: PROGRESS)
+        check_c30_pool = JobPool(
+            check_c30_need_insert_but_not_found_aid_job_list,
+            progress_total=len(need_insert_but_record_not_found_aid_list),
+            progress_label='check-c30-missing',
+            logger_name='C30PipelineRunner')
+        check_c30_pool.start()
 
         # check no need insert records
         # if time label is 04:00, we need to add all video records into tdd_video_record table,
@@ -807,20 +809,8 @@ class C30PipelineRunner(Thread):
                 no_need_insert_aid_list)
             c30_no_need_insert_aids_checker.start()
 
-        # wait for jobs
-        for job in check_c30_need_insert_but_not_found_aid_job_list:
-            job.join()
-
-        # collect statistics
-        check_c30_need_insert_but_not_found_aid_job_stat_list: list[JobStat] = [
-        ]
-        for job in check_c30_need_insert_but_not_found_aid_job_list:
-            check_c30_need_insert_but_not_found_aid_job_stat_list.append(
-                job.stat)
-
-        # merge statistics counters
-        check_c30_need_insert_but_not_found_aid_job_stat_merged = sum(
-            check_c30_need_insert_but_not_found_aid_job_stat_list, JobStat())
+        # wait for jobs (also stops the progress heartbeat) and merge their stats
+        check_c30_need_insert_but_not_found_aid_job_stat_merged = check_c30_pool.join()
 
         self.logger.info(f'Finish check c30 need insert but not found aid!')
         self.logger.info(

--- a/job/JobPool.py
+++ b/job/JobPool.py
@@ -1,0 +1,90 @@
+import time
+import logging
+from collections import Counter
+from threading import Thread, Event
+from typing import Optional
+from .Job import Job
+from .JobStat import JobStat
+
+__all__ = ['JobPool']
+
+
+class JobPool:
+    """
+    Run a group of Jobs that share the same work, encapsulating the repeated
+    start -> (optional progress heartbeat) -> join -> merge-stats lifecycle.
+
+    Progress is a pool-level concern (a single Job knows neither the total work
+    nor its siblings), so it lives here and is derived from each job's own
+    `stat.total_count`. When enabled it emits one greppable line per interval:
+
+        PROGRESS <label>: <done> done, <left> left (<pct>%), <rate>/s
+
+    Use start() then join() (rather than a single blocking call) so the caller
+    can run other work concurrently between them.
+    """
+
+    def __init__(self, jobs: list[Job], *,
+                 progress_label: str,
+                 progress_total: Optional[int] = None,
+                 progress_interval_s: float = 1.0,
+                 progress_show_conditions: bool = True,
+                 logger_name: str = 'JobPool'):
+        # progress_label is required (keyword-only, no default) so every pool's
+        # heartbeat is uniquely identifiable when several run concurrently.
+        self.jobs = jobs
+        self.progress_label = progress_label
+        self.progress_total = progress_total
+        self.progress_interval_s = progress_interval_s
+        self.progress_show_conditions = progress_show_conditions
+        self.logger = logging.getLogger(logger_name)
+        self._stop_event = Event()
+        self._progress_thread: Optional[Thread] = None
+
+    def start(self) -> 'JobPool':
+        for job in self.jobs:
+            job.start()
+        self.logger.info(f'{len(self.jobs)} job(s) started.')
+        if self.progress_interval_s and self.progress_interval_s > 0:
+            self._progress_thread = Thread(target=self._report_progress, daemon=True)
+            self._progress_thread.start()
+        return self
+
+    def join(self) -> JobStat:
+        for job in self.jobs:
+            job.join()
+        # stop and drain the heartbeat so a final line reflects the end state
+        self._stop_event.set()
+        if self._progress_thread is not None:
+            self._progress_thread.join()
+        return sum((job.stat for job in self.jobs), JobStat())
+
+    def _report_progress(self):
+        last_done = 0
+        last_ts = time.time()
+        while True:
+            # wait() returns True if stopped, False on interval timeout; this
+            # keeps a steady cadence and still emits one final line on stop.
+            stopped = self._stop_event.wait(self.progress_interval_s)
+            done = sum(job.stat.total_count for job in self.jobs)
+            now = time.time()
+            rate = (done - last_done) / max(0.001, now - last_ts)
+            if self.progress_total:
+                left = self.progress_total - done
+                pct = done / self.progress_total * 100
+                msg = (f'PROGRESS {self.progress_label}: {done} done, {left} left '
+                       f'({pct:.1f}%), {rate:.0f}/s')
+            else:
+                msg = f'PROGRESS {self.progress_label}: {done} done, {rate:.0f}/s'
+            if self.progress_show_conditions:
+                # live breakdown of the jobs' own condition counters, e.g.
+                # "missing_video_record_get: 11000, update_exception: 1300"
+                conditions = sum((job.stat.condition for job in self.jobs), Counter())
+                if conditions:
+                    cond_str = ', '.join(
+                        f'{k}: {v}' for k, v in conditions.most_common())
+                    msg = f'{msg} | {cond_str}'
+            self.logger.info(msg)
+            last_done, last_ts = done, now
+            if stopped:
+                break

--- a/job/__init__.py
+++ b/job/__init__.py
@@ -6,5 +6,6 @@ from .AddVideoFromArchiveJob import *
 from .GetNewlistArchiveJob import *
 from .Job import *
 from .JobStat import *
+from .JobPool import *
 from .UpdateMemberJob import *
 from .UpdateVideoJob import *


### PR DESCRIPTION
## What

Adds `job/JobPool`, a small abstraction over the `start → join → merge-stats` lifecycle that was copy-pasted ~5× in `51_hourly-video-record-add.py`, and uses it to add a live progress heartbeat to the C30 "add missing videos" phase.

While a pool runs it emits one greppable line per second:

```
PROGRESS check-c30-missing: 12345 done, 53349 left (18.8%), 78/s | missing_video_record_get: 11040, update_exception: 1290, 0_update: 1050
```

Watch live with `tail -f <log> | grep PROGRESS` (or `grep "PROGRESS check-c30-missing"` to isolate one stream when several pools run concurrently).

## Design notes

- **Progress is pool-level, not per-`Job`.** A single `Job` knows neither the total work nor its siblings — but it already tracks `stat.total_count` and a `stat.condition` Counter. `JobPool` sums those each tick, so `done` = actually-completed and the breakdown adapts to whatever conditions the job type records (no per-site wiring).
- **`start()`/`join()` are separate** so callers can run concurrent work between them (the 04:00 no-need-insert checker still runs during the phase).
- **`progress_label` is a required keyword-only argument** — every concurrent pool's heartbeat is uniquely identifiable by construction, so `grep "PROGRESS <label>"` always isolates one stream. Omitting it raises `TypeError` at construction.
- `join()` stops the heartbeat and returns the merged `JobStat`.

## Scope

Only the C30 `CheckC30NeedInsertButNotFoundAidsJob` phase is migrated here (net −9 lines at that call site). The other four pool sites (`c0-acquisition`, `newlist-archive`, `all-zero-check`, `simple-fetch`) can adopt `JobPool` in a follow-up and get progress heartbeats for free.

## Testing

Verified in isolation with real `Job` subclasses: heartbeat cadence, merged `total_count`, merged condition breakdown, concurrent pools distinguished by label, and that omitting `progress_label` raises.

🤖 Generated with [Claude Code](https://claude.com/claude-code)