### PR TITLE
fix: build video record from video_view, not the committed ORM row (empty CSV)

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -1,4 +1,4 @@
-from db import Session, DBOperation, TddVideoRecordAbnormalChange, TddVideoRecord
+from db import Session, DBOperation, TddVideoRecordAbnormalChange
 from threading import Thread
 from queue import Queue
 from util import get_ts_s, get_ts_s_str, a2b, is_all_zero_record, null_or_str, \
@@ -11,7 +11,7 @@ import re
 from serverchan import sc_send_summary, sc_send_critical
 from collections import namedtuple, defaultdict, Counter
 from core import TddError
-from service import Service, NewlistArchive, VideoView
+from service import Service, NewlistArchive, VideoView, VideoViewStat
 from job import GetNewlistArchiveJob, AddVideoRecordJob, Job, JobPool
 from typing import NamedTuple, Optional
 from task import update_video, add_video, AlreadyExistError
@@ -459,7 +459,7 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
             aid_queue.put(aid)
 
         # create video record queue
-        video_record_queue: Queue[TddVideoRecord] = Queue()
+        video_record_queue: Queue[tuple[int, int, str, VideoViewStat]] = Queue()
 
         # create jobs and run them with a per-second progress heartbeat
         job_num = 50
@@ -480,23 +480,23 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
 
         # parse tdd video record to record
         while not video_record_queue.empty():
-            video_record = video_record_queue.get()
+            added, aid, bvid, stat = video_record_queue.get()
             self.record_queue.put(RecordNew(
-                added=video_record.added,
-                aid=video_record.aid,
-                bvid=a2b(video_record.aid),
-                view=video_record.view,
-                danmaku=video_record.danmaku,
-                reply=video_record.reply,
-                favorite=video_record.favorite,
-                coin=video_record.coin,
-                share=video_record.share,
-                like=video_record.like,
-                dislike=video_record.dislike,
-                now_rank=video_record.now_rank,
-                his_rank=video_record.his_rank,
-                vt=video_record.vt,
-                vv=video_record.vv,
+                added=added,
+                aid=aid,
+                bvid=bvid,
+                view=-1 if stat.view == '--' else stat.view,
+                danmaku=stat.danmaku,
+                reply=stat.reply,
+                favorite=stat.favorite,
+                coin=stat.coin,
+                share=stat.share,
+                like=stat.like,
+                dislike=stat.dislike,
+                now_rank=stat.now_rank,
+                his_rank=stat.his_rank,
+                vt=stat.vt,
+                vv=stat.vv,
             ))
         self.logger.info(
             f'{self.record_queue.qsize()} record(s) parsed and returned.')
@@ -869,7 +869,7 @@ class C30PipelineRunner(Thread):
             aid_queue.put(aid)
 
         # create video record queue
-        video_record_queue: Queue[TddVideoRecord] = Queue()
+        video_record_queue: Queue[tuple[int, int, str, VideoViewStat]] = Queue()
 
         # create jobs and run them with a per-second progress heartbeat.
         # 150 workers (vs C0's 50): this is now C30's primary fetch path over a
@@ -897,23 +897,23 @@ class C30PipelineRunner(Thread):
         # parse tdd video record to record
         record_cnt = 0
         while not video_record_queue.empty():
-            video_record = video_record_queue.get()
+            added, aid, bvid, stat = video_record_queue.get()
             self.record_queue.put(RecordNew(
-                added=video_record.added,
-                aid=video_record.aid,
-                bvid=a2b(video_record.aid),
-                view=video_record.view,
-                danmaku=video_record.danmaku,
-                reply=video_record.reply,
-                favorite=video_record.favorite,
-                coin=video_record.coin,
-                share=video_record.share,
-                like=video_record.like,
-                dislike=video_record.dislike,
-                now_rank=video_record.now_rank,
-                his_rank=video_record.his_rank,
-                vt=video_record.vt,
-                vv=video_record.vv,
+                added=added,
+                aid=aid,
+                bvid=bvid,
+                view=-1 if stat.view == '--' else stat.view,
+                danmaku=stat.danmaku,
+                reply=stat.reply,
+                favorite=stat.favorite,
+                coin=stat.coin,
+                share=stat.share,
+                like=stat.like,
+                dislike=stat.dislike,
+                now_rank=stat.now_rank,
+                his_rank=stat.his_rank,
+                vt=stat.vt,
+                vv=stat.vv,
             ))
             record_cnt += 1
         self.logger.info(f'{record_cnt} record(s) parsed and returned.')

--- a/job/AddVideoRecordJob.py
+++ b/job/AddVideoRecordJob.py
@@ -1,17 +1,18 @@
 from .Job import Job
-from service import Service, CodeError
+from service import Service, CodeError, VideoViewStat
 from timer import Timer
 from queue import Queue
-from db import Session, TddVideoRecord
+from db import Session
 from util import format_ts_ms, get_ts_s, ts_s_to_str
-from task import add_video_record_via_video_view, update_video
+from task import commit_video_record_via_video_view, update_video
 from typing import Optional
 
 __all__ = ['AddVideoRecordJob']
 
 
 class AddVideoRecordJob(Job):
-    def __init__(self, name: str, aid_queue: Queue[int], video_record_queue: Queue[TddVideoRecord], service: Service,
+    def __init__(self, name: str, aid_queue: Queue[int],
+                 video_record_queue: 'Queue[tuple[int, int, str, VideoViewStat]]', service: Service,
                  update_if_code_error: bool = True, duration_limit_s: Optional[int] = None):
         super().__init__(name)
         self.aid_queue = aid_queue
@@ -38,7 +39,9 @@ class AddVideoRecordJob(Job):
             timer.start()
 
             try:
-                new_video_record = add_video_record_via_video_view(aid, self.service, self.session)
+                video_view = self.service.get_video_view({'aid': aid})
+                added = get_ts_s()
+                commit_video_record_via_video_view(video_view, added, self.session)
             except CodeError as e:
                 if self.update_if_code_error:
                     self.logger.info(f'Code error occurred. Now start update video. aid: {aid}')
@@ -73,8 +76,11 @@ class AddVideoRecordJob(Job):
                 self.logger.error(f'Fail to add video record. aid: {aid}, error: {e}')
                 self.stat.condition['other_exception'] += 1
             else:
-                self.video_record_queue.put(new_video_record)
-                self.logger.debug(f'New video record {new_video_record} added. aid: {aid}')
+                # queue a session-independent snapshot built from the in-memory
+                # video_view -- NOT the committed ORM row, whose attributes expire
+                # on commit and detach once the worker session closes.
+                self.video_record_queue.put(
+                    (added, aid, video_view.bvid.lstrip('BV'), video_view.stat))
                 self.stat.condition['success'] += 1
 
             timer.stop()


### PR DESCRIPTION
## Symptom
The 02:00 simple-path run fetched 65,633 records but the CSV, hourly table, and abnormal-change analysis all came out **empty**:
```
Finish upstream data acquisition pipelines! 0 records received
will save 0 records into file data/2026-07-12 02:00.csv
```
(The primary `tdd_video_record` was fine — the jobs insert directly.)

## Root cause
`process_simple` / `C0DataAcquisitionJob` handed **`TddVideoRecord` ORM objects** across the worker→parse-loop boundary. With the default `expire_on_commit=True`, an object is **expired** after commit and **detached** once the worker session closes (`cleanup()`), so the parse loop raised `DetachedInstanceError` on the first record → the pipeline thread died → **0 records returned**.

This had **silently zeroed C0 all along** (same `AddVideoRecordJob` pattern); the CSVs were carried entirely by the comprehensive path (which builds `RecordNew` from `video_view`, not from an ORM row). Now that C30 is on the same simple path, the whole file went empty.

## Fix
Source the record from the in-memory `video_view` (session-independent), exactly like the comprehensive path already does:
- `AddVideoRecordJob` fetches `video_view`, inserts the ORM row via the existing `commit_video_record_via_video_view` (**db/task still return ORM**), then queues a light `(added, aid, bvid, VideoViewStat)` tuple.
- The two 51 parse loops build the **51-local** `RecordNew` from that tuple — no ORM attribute access, no session dependency.

Constraints honored: `RecordNew` stays 51-local · `db`/`task` return ORM · **no `expire_on_commit` change** · queue holds light tuples (not heavy ORM rows).

`add_video_record_via_video_view` (== `get_video_view` + `commit_video_record_via_video_view`) is now unused; left in place as public API.

## Testing
Compiles; `51` imports (`RecordNew.__module__ == 's51'`, `expire_on_commit` still default `True`). Mock end-to-end: the worker queues the session-independent tuple and the 51 side rebuilds `RecordNew` correctly (incl. `view=='--'`→`-1` and bvid stripping).

## Follow-up
The 2026-07-12 02:00 archive/hourly for C30 is empty; can be backfilled from `tdd_video_record` if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)