### PR TITLE
fix: return lightweight RecordNew from task; confine ORM to the INSERT

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -1,4 +1,4 @@
-from db import Session, DBOperation, TddVideoRecordAbnormalChange, TddVideoRecord
+from db import Session, DBOperation, TddVideoRecordAbnormalChange
 from threading import Thread
 from queue import Queue
 from util import get_ts_s, get_ts_s_str, a2b, is_all_zero_record, null_or_str, \
@@ -10,10 +10,9 @@ import os
 import re
 from serverchan import sc_send_summary, sc_send_critical
 from collections import namedtuple, defaultdict, Counter
-from core import TddError
+from core import TddError, RecordNew
 from service import Service, NewlistArchive, VideoView
 from job import GetNewlistArchiveJob, AddVideoRecordJob, Job, JobPool
-from typing import NamedTuple, Optional
 from task import update_video, add_video, AlreadyExistError
 from timer import Timer
 import logging
@@ -33,25 +32,6 @@ RecordSpeed = namedtuple('RecordSpeed', [
     'start_ts', 'end_ts', 'timespan', 'per_seconds', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share', 'like'])
 RecordSpeedRatio = namedtuple('RecordSpeedRatio', [
     'view', 'danmaku', 'reply', 'favorite', 'coin', 'share', 'like', 'inf_magic_num'])
-
-
-# TODO: rename back to Record after all old Record is removed
-class RecordNew(NamedTuple):
-    added: int
-    aid: int
-    bvid: str
-    view: int
-    danmaku: int
-    reply: int
-    favorite: int
-    coin: int
-    share: int
-    like: int
-    dislike: int
-    now_rank: int
-    his_rank: int
-    vt: Optional[int]
-    vv: Optional[int]
 
 
 def get_need_insert_aid_list(time_label, is_tid_30, session):
@@ -459,7 +439,7 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
             aid_queue.put(aid)
 
         # create video record queue
-        video_record_queue: Queue[TddVideoRecord] = Queue()
+        video_record_queue: Queue[RecordNew] = Queue()
 
         # create jobs and run them with a per-second progress heartbeat
         job_num = 50
@@ -478,26 +458,9 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
         self.logger.info('Finish add need insert aid list!')
         self.logger.info(job_stat_merged.get_summary())
 
-        # parse tdd video record to record
+        # forward the fetched records (already lightweight RecordNew)
         while not video_record_queue.empty():
-            video_record = video_record_queue.get()
-            self.record_queue.put(RecordNew(
-                added=video_record.added,
-                aid=video_record.aid,
-                bvid=a2b(video_record.aid),
-                view=video_record.view,
-                danmaku=video_record.danmaku,
-                reply=video_record.reply,
-                favorite=video_record.favorite,
-                coin=video_record.coin,
-                share=video_record.share,
-                like=video_record.like,
-                dislike=video_record.dislike,
-                now_rank=video_record.now_rank,
-                his_rank=video_record.his_rank,
-                vt=video_record.vt,
-                vv=video_record.vv,
-            ))
+            self.record_queue.put(video_record_queue.get())
         self.logger.info(
             f'{self.record_queue.qsize()} record(s) parsed and returned.')
 
@@ -869,7 +832,7 @@ class C30PipelineRunner(Thread):
             aid_queue.put(aid)
 
         # create video record queue
-        video_record_queue: Queue[TddVideoRecord] = Queue()
+        video_record_queue: Queue[RecordNew] = Queue()
 
         # create jobs and run them with a per-second progress heartbeat.
         # 150 workers (vs C0's 50): this is now C30's primary fetch path over a
@@ -894,27 +857,10 @@ class C30PipelineRunner(Thread):
         self.logger.info('Finish add need insert aid list!')
         self.logger.info(job_stat_merged.get_summary())
 
-        # parse tdd video record to record
+        # forward the fetched records (already lightweight RecordNew)
         record_cnt = 0
         while not video_record_queue.empty():
-            video_record = video_record_queue.get()
-            self.record_queue.put(RecordNew(
-                added=video_record.added,
-                aid=video_record.aid,
-                bvid=a2b(video_record.aid),
-                view=video_record.view,
-                danmaku=video_record.danmaku,
-                reply=video_record.reply,
-                favorite=video_record.favorite,
-                coin=video_record.coin,
-                share=video_record.share,
-                like=video_record.like,
-                dislike=video_record.dislike,
-                now_rank=video_record.now_rank,
-                his_rank=video_record.his_rank,
-                vt=video_record.vt,
-                vv=video_record.vv,
-            ))
+            self.record_queue.put(video_record_queue.get())
             record_cnt += 1
         self.logger.info(f'{record_cnt} record(s) parsed and returned.')
 

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,1 +1,2 @@
 from .error import *
+from .record import *

--- a/core/record.py
+++ b/core/record.py
@@ -1,0 +1,27 @@
+from typing import NamedTuple, Optional
+
+__all__ = ['RecordNew']
+
+
+# Lightweight, immutable, session-independent video record DTO. This is the type
+# that flows through the app (fetch -> queue -> csv/db archive -> analysis); ORM
+# objects (db.TddVideoRecord) are confined to the persistence call inside task
+# functions and never leave them. Kept here in `core` as a global domain type
+# (distinct from the API-response DTOs in service.response).
+# TODO: fold the legacy `Record` namedtuple in 51 into this once migrated.
+class RecordNew(NamedTuple):
+    added: int
+    aid: int
+    bvid: str
+    view: int
+    danmaku: int
+    reply: int
+    favorite: int
+    coin: int
+    share: int
+    like: int
+    dislike: int
+    now_rank: int
+    his_rank: int
+    vt: Optional[int]
+    vv: Optional[int]

--- a/job/AddVideoRecordJob.py
+++ b/job/AddVideoRecordJob.py
@@ -2,7 +2,8 @@ from .Job import Job
 from service import Service, CodeError
 from timer import Timer
 from queue import Queue
-from db import Session, TddVideoRecord
+from db import Session
+from core import RecordNew
 from util import format_ts_ms, get_ts_s, ts_s_to_str
 from task import add_video_record_via_video_view, update_video
 from typing import Optional
@@ -11,7 +12,7 @@ __all__ = ['AddVideoRecordJob']
 
 
 class AddVideoRecordJob(Job):
-    def __init__(self, name: str, aid_queue: Queue[int], video_record_queue: Queue[TddVideoRecord], service: Service,
+    def __init__(self, name: str, aid_queue: Queue[int], video_record_queue: Queue[RecordNew], service: Service,
                  update_if_code_error: bool = True, duration_limit_s: Optional[int] = None):
         super().__init__(name)
         self.aid_queue = aid_queue

--- a/task/task.py
+++ b/task/task.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm.session import Session
 from db import DBOperation, TddVideo, TddVideoRecord, TddVideoLog, TddVideoStaff, TddMember, TddMemberFollowerRecord, \
     TddMemberLog, TddSprintVideoRecord
 from util import get_ts_s, a2b, same_pic_url
-from core import TddError
+from core import TddError, RecordNew
 from .error import AlreadyExistError, NotExistError
 
 import logging
@@ -19,18 +19,22 @@ __all__ = ['add_video_record_via_video_view',
            'get_video_tags_str']
 
 
-def add_video_record_via_video_view(aid: int, service: Service, session: Session) -> TddVideoRecord:
+def add_video_record_via_video_view(aid: int, service: Service, session: Session) -> RecordNew:
     # get video view
     try:
         video_view = service.get_video_view({'aid': aid})
     except ServiceError as e:
         raise e
 
-    # assemble video record
+    added = get_ts_s()
+    view = -1 if video_view.stat.view == '--' else video_view.stat.view
+
+    # assemble and persist the record. The ORM object is confined to this
+    # function -- it exists only to run the INSERT and never leaves.
     new_video_record = TddVideoRecord(
         aid=aid,
-        added=get_ts_s(),
-        view=-1 if video_view.stat.view == '--' else video_view.stat.view,
+        added=added,
+        view=view,
         danmaku=video_view.stat.danmaku,
         reply=video_view.stat.reply,
         favorite=video_view.stat.favorite,
@@ -43,12 +47,28 @@ def add_video_record_via_video_view(aid: int, service: Service, session: Session
         vt=video_view.stat.vt,
         vv=video_view.stat.vv,
     )
-
-    # add to db
     # TODO: use new db operation which can raise exception
     DBOperation.add(new_video_record, session)
 
-    return new_video_record
+    # return the lightweight, session-independent record built from video_view
+    # (never read back the committed ORM row, which expires on commit / detaches)
+    return RecordNew(
+        added=added,
+        aid=aid,
+        bvid=video_view.bvid.lstrip('BV'),
+        view=view,
+        danmaku=video_view.stat.danmaku,
+        reply=video_view.stat.reply,
+        favorite=video_view.stat.favorite,
+        coin=video_view.stat.coin,
+        share=video_view.stat.share,
+        like=video_view.stat.like,
+        dislike=video_view.stat.dislike,
+        now_rank=video_view.stat.now_rank,
+        his_rank=video_view.stat.his_rank,
+        vt=video_view.stat.vt,
+        vv=video_view.stat.vv,
+    )
 
 
 def commit_video_record_via_video_view(video_view: VideoView, added: int, session: Session) -> TddVideoRecord:


### PR DESCRIPTION
Supersedes #22 (same empty-CSV fix, cleaner architecture).

## Symptom
The 02:00 simple-path run fetched 65,633 records but the CSV, hourly table, and analysis came out **empty** (`0 records received`). Primary `tdd_video_record` was fine.

## Root cause
`process_simple` / `C0` passed **`TddVideoRecord` ORM objects** across the worker→parse-loop boundary. With `expire_on_commit=True`, they're expired after commit and **detached** once the worker session closes, so the parse loop raised `DetachedInstanceError` → thread died → 0 records. (C0 had done this silently all along, masked by the comprehensive path.)

## The boundary: where does ORM stop?
**At the task-layer INSERT.** The ORM object is a persistence detail; it should never travel. This PR enforces that:

- **`RecordNew` promoted to a global domain DTO** in `core` (`core.record`) — distinct from the API-response DTOs in `service.response`.
- **`add_video_record_via_video_view`** builds `TddVideoRecord` *only* to run `DBOperation.add`, and returns a lightweight, session-independent **`RecordNew`** built from `video_view`. The ORM object never leaves the function.
- **`AddVideoRecordJob`** queues `RecordNew` (the job calls the task, not the service directly).
- The two **51 parse loops** just forward `RecordNew`; the local `RecordNew` class and the ORM→`RecordNew` conversion are gone.

So above the task layer — job → queue → CSV/db archive → analysis — everything is the lightweight `RecordNew`; ORM is confined to the DB call. No `expire_on_commit` change.

## Testing
Compiles; `51` imports and uses the *same* `core.record.RecordNew` (`is` check). Mock end-to-end: `add_video_record_via_video_view` returns a `RecordNew` (from `video_view`), with `view=='--'`→`-1` and bvid stripping.

## Follow-up
The 2026-07-12 02:00 archive/hourly is empty; backfill from `tdd_video_record` if desired. The legacy `Record` namedtuple in 51 could fold into `core.record.RecordNew` later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)