### PR TITLE
fix: cap C0 fetch duration at 40m (04:00 overrun)

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -444,7 +444,8 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
         # create jobs and run them with a per-second progress heartbeat
         job_num = 50
         job_list = [
-            AddVideoRecordJob(f'job_{i}', aid_queue, video_record_queue, service)
+            AddVideoRecordJob(f'job_{i}', aid_queue, video_record_queue, service,
+                              duration_limit_s=60 * 40)  # 40 minutes, cap the 04:00 full scan
             for i in range(job_num)
         ]
         pool = JobPool(


### PR DESCRIPTION
## Problem
The 2026-07-12 04:00 run took **1h52m**. 04:00 is the full-scan hour, and `C0DataAcquisitionJob`'s `AddVideoRecordJob` was created **without `duration_limit_s`**, so C0 drained its entire ~90k queue uncapped (04:00 → 05:50 = **1h50m**). The upstream waits on C0's `join()`, so the whole run blew past the hour. (C30 already caps at 40m — it stopped at 04:42.)

## Fix
One-liner: give C0's `AddVideoRecordJob` the same `duration_limit_s=60*40` as `process_simple`. Plain hours are unaffected (C0 has ~a few thousand aids, finishes in minutes); the cap only bites at 04:00.

## Not addressed (follow-ups)
- The 04:00 **full scan is infeasible** anyway (C30 did ~9.5% of 1M in its cap) — needs the rolling-shard scheduler.
- The 04:00 **activity-update query times out** (`Lost connection` on the `tdd_video_record JOIN tdd_video` weekly-delta) — separate optimization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)