### PR TITLE
feat: remove RecordsSaveToDbRunner (deprecate tdd_video_record_hourly)

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -962,77 +962,6 @@ class RecordsSaveToFileRunner(Thread):
 
 
 # TODO: change to record new
-class RecordsSaveToDbRunner(Thread):
-    def __init__(self, records, time_label):
-        super().__init__()
-        self.records = records
-        self.time_label = time_label
-        self.logger = logging.getLogger('RecordsSaveToDbRunner')
-
-    def run(self):
-        self.logger.info('Now start saving records to db...')
-        session = Session()
-        sql_prefix = 'insert into ' \
-                     'tdd_video_record_hourly(added, bvid, `view`, danmaku, reply, favorite, coin, share, `like`) ' \
-                     'values '
-        sql = sql_prefix
-        for idx, record in enumerate(self.records, 1):
-            sql += '(%d, "%s", %d, %d, %d, %d, %d, %d, %d), ' % (
-                record.added, record.bvid,
-                record.view, record.danmaku, record.reply, record.favorite, record.coin, record.share, record.like
-            )
-            if idx % 1000 == 0:
-                sql = sql[:-2]  # remove ending comma and space
-                session.execute(sql)
-                session.commit()
-                sql = sql_prefix
-                if idx % 10000 == 0:
-                    self.logger.info('%d / %d done' % (idx, len(self.records)))
-        if sql != sql_prefix:
-            sql = sql[:-2]  # remove ending comma and space
-            session.execute(sql)
-            session.commit()
-        self.logger.info('%d / %d done' %
-                         (len(self.records), len(self.records)))
-        session.close()
-        self.logger.info('Finish save %d records into db!' % len(self.records))
-
-        # TODO ugly design, should be separated into another class
-        if self.time_label == '23:00':
-            try:
-                session.execute(
-                    'drop table if exists tdd_video_record_hourly_4')
-                self.logger.info('drop table tdd_video_record_hourly_4')
-
-                session.execute(
-                    'rename table tdd_video_record_hourly_3 to tdd_video_record_hourly_4')
-                self.logger.info(
-                    'rename table tdd_video_record_hourly_3 to tdd_video_record_hourly_4')
-
-                session.execute(
-                    'rename table tdd_video_record_hourly_2 to tdd_video_record_hourly_3')
-                self.logger.info(
-                    'rename table tdd_video_record_hourly_2 to tdd_video_record_hourly_3')
-
-                session.execute(
-                    'rename table tdd_video_record_hourly to tdd_video_record_hourly_2')
-                self.logger.info(
-                    'rename table tdd_video_record_hourly to tdd_video_record_hourly_2')
-
-                session.execute(
-                    'create table tdd_video_record_hourly like tdd_video_record_hourly_2')
-                self.logger.info(
-                    'create table tdd_video_record_hourly like tdd_video_record_hourly_2')
-            except Exception as e:
-                session.rollback()
-                self.logger.error(
-                    'Error occur when executing change tdd_video_record_hourly table. Detail: %s' % e)
-            else:
-                self.logger.info(
-                    'Finish change tdd_video_record_hourly table!')
-
-
-# TODO: change to record new
 class RecentRecordsAnalystRunner(Thread):
     def __init__(self, records, time_task, data_folder='data/', recent_file_num=2):
         super().__init__()
@@ -1503,7 +1432,6 @@ def run_hourly_video_record_add(time_task):
     logger.info('Now start downstream data analysis pipelines...')
     data_analysis_pipeline_runner_list = [
         RecordsSaveToFileRunner(records, time_task),
-        RecordsSaveToDbRunner(records, time_label),
         RecentRecordsAnalystRunner(records, time_task),
         RecentActivityFreqUpdateRunner(time_label),
     ]


### PR DESCRIPTION
Part 1/3 of deprecating `tdd_video_record_hourly` (spider · backend · frontend).

## Why deprecate
- **Its purpose is gone.** The table existed to keep hourly-granularity records for *all* c30 videos — which only the bulk newlist API could supply. On the view-only per-aid path, the records handed downstream are exactly the set already inserted into `tdd_video_record`, so the hourly table is a strict duplicate subset (~3–4 days retention, 9 columns) with zero unique data.
- **It's already broken in prod.** The 23:00 rotation is a non-atomic 5-statement DDL sequence that aborts on first failure and can't self-heal; repeated partial failures consumed the rotation tables (prod DB now has only the base table — `_2/_3/_4` gone), so the v2 backend `/record/hourly` endpoints have been 500-ing. Nobody noticed — confirming the feature's value.
- **It loses data silently.** The insert loop has no try/except; on the 2026-07-13 04:00 run the thread died mid-save (`Lost connection`), committing only ~350k of 523,978 rows with no error in the log.

## Change
Delete `RecordsSaveToDbRunner` (insert loop + 23:00 rotation) and its entry in the downstream runner list. `RecordsSaveToFileRunner` (CSV archive), `RecentRecordsAnalystRunner`, and `RecentActivityFreqUpdateRunner` are untouched.

**Operational win:** 04:00 downstream drops from ~20 min to ~2 min; the run goes back well under the hour.

## Paired PRs
- tdd-backend: remove the `/record/hourly` endpoints (currently 500-ing)
- tdd-frontend: remove the "Last 3 Days Hourly Data" checkbox (its call already fails)
- Afterwards, DB cleanup: `DROP TABLE tdd_video_record_hourly;`

## Testing
Compiles; module imports; zero remaining references to `RecordsSaveToDbRunner` / `tdd_video_record_hourly` in the repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)