### PR TITLE
feat: per-aid stage timing instrumentation (--debug file + live stage averages)

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -2,12 +2,14 @@ from db import Session, DBOperation, TddVideoRecordAbnormalChange
 from threading import Thread
 from queue import Queue
 from util import get_ts_s, get_ts_s_str, a2b, is_all_zero_record, null_or_str, \
-    str_to_ts_s, ts_s_to_str, b2a, zk_calc, get_week_day, logging_init, fullname, get_current_line_no, format_ts_ms
+    str_to_ts_s, ts_s_to_str, b2a, zk_calc, get_week_day, logging_init, fullname, get_current_line_no, \
+    format_ts_ms, SysStatLogger
 import math
 import time
 import datetime
 import os
 import re
+import sys
 from serverchan import sc_send_summary, sc_send_critical
 from collections import namedtuple, defaultdict, Counter
 from core import TddError, RecordNew
@@ -1478,5 +1480,14 @@ if __name__ == '__main__':
     # current time task, only number, ex: 201301311900
     time_task_simple = f'{get_ts_s_str()[:13]}:00'.replace(
         '-', '').replace(' ', '').replace(':', '')
-    logging_init(file_prefix=f'{script_id}_{time_task_simple}')
+
+    # --debug: also write a {prefix}_DEBUG.log with everything (per-aid TIMING,
+    # per-request REQUEST, SYSSTAT samples) for offline bottleneck analysis
+    debug = '--debug' in sys.argv
+    logging_init(file_prefix=f'{script_id}_{time_task_simple}', debug=debug)
+    if debug:
+        logger.info('Debug logging enabled, writing to '
+                    f'{script_id}_{time_task_simple}_DEBUG.log')
+        SysStatLogger().start()  # daemon, samples net/load/mem every 10s
+
     main()

--- a/job/AddVideoRecordJob.py
+++ b/job/AddVideoRecordJob.py
@@ -38,8 +38,10 @@ class AddVideoRecordJob(Job):
             timer = Timer()
             timer.start()
 
+            stage_stat = {}  # per-stage durations, filled by the task (http_ms, db_ms)
             try:
-                new_video_record = add_video_record_via_video_view(aid, self.service, self.session)
+                new_video_record = add_video_record_via_video_view(
+                    aid, self.service, self.session, out_stat=stage_stat)
             except CodeError as e:
                 if self.update_if_code_error:
                     self.logger.info(f'Code error occurred. Now start update video. aid: {aid}')
@@ -79,8 +81,15 @@ class AddVideoRecordJob(Job):
                 self.stat.condition['success'] += 1
 
             timer.stop()
-            self.logger.debug(f'Finish add video record. '
-                              f'aid: {aid}, duration: {format_ts_ms(timer.get_duration_ms())}')
+            # accumulate per-stage durations into the pool stats (JobPool's
+            # heartbeat turns *_ms keys into live per-aid stage averages) and
+            # emit a greppable per-aid line for offline analysis (--debug file)
+            for stage_key, stage_ms in stage_stat.items():
+                self.stat.condition[stage_key] += stage_ms
+            self.logger.debug(
+                f'TIMING aid={aid} '
+                + ' '.join(f'{k[:-3]}={v}ms' for k, v in stage_stat.items())
+                + f' total={timer.get_duration_ms()}ms')
             self.stat.total_count += 1
             self.stat.total_duration_ms += timer.get_duration_ms()
 

--- a/job/JobPool.py
+++ b/job/JobPool.py
@@ -68,11 +68,25 @@ class JobPool:
         for key in self.ensure_conditions:
             if key not in merged.condition:
                 merged.condition[key] = 0
+        # overall per-aid stage averages for the whole pool run
+        stage_ms = {k: v for k, v in merged.condition.items() if k.endswith('_ms')}
+        if stage_ms and merged.total_count > 0:
+            stage_str = ', '.join(
+                f'{k[:-3]} {self._fmt_ms(v / merged.total_count)}/aid'
+                for k, v in sorted(stage_ms.items()))
+            self.logger.info(
+                f'STAGE AVG {self.progress_label}: {stage_str} '
+                f'(over {merged.total_count} aids)')
         return merged
+
+    @staticmethod
+    def _fmt_ms(ms: float) -> str:
+        return f'{ms / 1000:.2f}s' if ms >= 1000 else f'{ms:.0f}ms'
 
     def _report_progress(self):
         last_done = 0
         last_ts = time.time()
+        last_stage_ms = {}
         while True:
             # wait() returns True if stopped, False on interval timeout; this
             # keeps a steady cadence and still emits one final line on stop.
@@ -88,12 +102,25 @@ class JobPool:
             else:
                 msg = f'PROGRESS {self.progress_label}: {done} done, {rate:.0f}/s'
             if self.progress_show_conditions:
+                conditions = sum((job.stat.condition for job in self.jobs), Counter())
+                # keys ending in _ms are per-stage duration totals (see
+                # AddVideoRecordJob): show them as per-aid averages over THIS
+                # interval, so a stage getting slower is visible live.
+                stage_ms = {k: v for k, v in conditions.items() if k.endswith('_ms')}
+                delta_done = done - last_done
+                if stage_ms and delta_done > 0:
+                    stage_str = ', '.join(
+                        f'{k[:-3]} {self._fmt_ms((v - last_stage_ms.get(k, 0)) / delta_done)}/aid'
+                        for k, v in sorted(stage_ms.items()))
+                    msg = f'{msg} | {stage_str}'
+                last_stage_ms = stage_ms
                 # live breakdown of the jobs' own condition counters, e.g.
                 # "missing_video_record_get: 11000, update_exception: 1300"
-                conditions = sum((job.stat.condition for job in self.jobs), Counter())
-                if conditions:
+                counts = Counter({k: v for k, v in conditions.items()
+                                  if not k.endswith('_ms')})
+                if counts:
                     cond_str = ', '.join(
-                        f'{k}: {v}' for k, v in conditions.most_common())
+                        f'{k}: {v}' for k, v in counts.most_common())
                     msg = f'{msg} | {cond_str}'
             self.logger.info(msg)
             last_done, last_ts = done, now

--- a/service/Service.py
+++ b/service/Service.py
@@ -157,6 +157,7 @@ class Service:
                            * 0.5 + 0.75) * colddown_factor)
 
             # try to get response
+            trial_start = time.perf_counter()
             try:
                 r = self._session.get(url, params=params, headers=headers,
                                       timeout=timeout)
@@ -166,14 +167,20 @@ class Service:
                     f'url: {url}, params: {params}, trial: {trial}, error: {e}'
                 )
                 continue
+            trial_ms = int((time.perf_counter() - trial_start) * 1000)
 
             # check status code
             if r.status_code != 200:
                 logger.debug(
                     f'Fail to get response with status code {r.status_code}. '
-                    f'url: {url}, params: {params}, trial: {trial}'
+                    f'url: {url}, params: {params}, trial: {trial}, duration: {trial_ms}ms'
                 )
                 continue
+
+            # greppable per-request line (REQUEST): trial > 1 means retries
+            # happened; duration is the pure network round-trip of this trial
+            logger.debug(
+                f'REQUEST url: {url}, params: {params}, trial: {trial}, duration: {trial_ms}ms')
 
             # parse response
             if parser is None:

--- a/task/task.py
+++ b/task/task.py
@@ -7,6 +7,7 @@ from core import TddError, RecordNew
 from .error import AlreadyExistError, NotExistError
 
 import logging
+import time
 
 logger = logging.getLogger('task')
 
@@ -19,12 +20,20 @@ __all__ = ['add_video_record_via_video_view',
            'get_video_tags_str']
 
 
-def add_video_record_via_video_view(aid: int, service: Service, session: Session) -> RecordNew:
+def add_video_record_via_video_view(aid: int, service: Service, session: Session,
+                                    out_stat: dict = None) -> RecordNew:
+    # out_stat (optional): filled with per-stage durations for instrumentation,
+    # keys 'http_ms' (view fetch incl retries) and 'db_ms' (insert + commit).
+    # Same pattern as update_video's out_context.
+
     # get video view
+    stage_start = time.perf_counter()
     try:
         video_view = service.get_video_view({'aid': aid})
     except ServiceError as e:
         raise e
+    if out_stat is not None:
+        out_stat['http_ms'] = int((time.perf_counter() - stage_start) * 1000)
 
     added = get_ts_s()
     view = -1 if video_view.stat.view == '--' else video_view.stat.view
@@ -48,7 +57,10 @@ def add_video_record_via_video_view(aid: int, service: Service, session: Session
         vv=video_view.stat.vv,
     )
     # TODO: use new db operation which can raise exception
+    stage_start = time.perf_counter()
     DBOperation.add(new_video_record, session)
+    if out_stat is not None:
+        out_stat['db_ms'] = int((time.perf_counter() - stage_start) * 1000)
 
     # return the lightweight, session-independent record built from video_view
     # (never read back the committed ORM row, which expires on commit / detaches)

--- a/util/__init__.py
+++ b/util/__init__.py
@@ -1,5 +1,6 @@
 from .abid import *
 from .logging_init import *
 from .script import *
+from .sysstat import *
 from .timeutil import *
 from .util import *

--- a/util/logging_init.py
+++ b/util/logging_init.py
@@ -24,7 +24,15 @@ class UnescapeFormatter(logging.Formatter):
 def logging_init(format=DEFAULT_LOG_FORMAT,
                  unescape=True,
                  console_handler_enable=True, console_handler_level=logging.INFO,
-                 file_prefix='default', file_handler_levels=(logging.INFO, logging.WARNING)):
+                 file_prefix='default', file_handler_levels=(logging.INFO, logging.WARNING),
+                 debug=False):
+    # debug=True adds a {file_prefix}_DEBUG.log file handler capturing ALL log
+    # records (DEBUG and above, every logger). Opt-in only: the file is large
+    # (per-aid TIMING lines, per-request Service lines, SYSSTAT samples), meant
+    # for offline analysis of a specific run.
+    if debug:
+        file_handler_levels = (logging.DEBUG,) + tuple(file_handler_levels)
+
     handlers = []
 
     if console_handler_enable:

--- a/util/sysstat.py
+++ b/util/sysstat.py
@@ -1,0 +1,74 @@
+import logging
+import os
+import time
+from threading import Thread
+
+__all__ = ['SysStatLogger']
+
+logger = logging.getLogger('sysstat')
+
+
+class SysStatLogger(Thread):
+    """
+    Sample system-level stats (network throughput, load, available memory)
+    every `interval_s` seconds and emit one greppable DEBUG line per sample:
+
+        SYSSTAT rx=2.13Mbps tx=0.41Mbps load1=1.25 mem_avail=812MB
+
+    Reads /proc directly (Linux only; exits silently elsewhere). Daemon thread:
+    start() and forget, it dies with the process. Intended to be started only
+    when debug logging is enabled, to correlate fetch slowdowns with network /
+    CPU / memory pressure.
+    """
+
+    def __init__(self, interval_s: float = 10.0):
+        super().__init__(daemon=True)
+        self.interval_s = interval_s
+
+    @staticmethod
+    def _read_net_bytes():
+        # sum rx/tx bytes over all interfaces except loopback
+        rx, tx = 0, 0
+        with open('/proc/net/dev') as f:
+            for line in f.readlines()[2:]:
+                iface, data = line.split(':', 1)
+                if iface.strip() == 'lo':
+                    continue
+                fields = data.split()
+                rx += int(fields[0])
+                tx += int(fields[8])
+        return rx, tx
+
+    @staticmethod
+    def _read_load1():
+        with open('/proc/loadavg') as f:
+            return float(f.read().split()[0])
+
+    @staticmethod
+    def _read_mem_avail_mb():
+        with open('/proc/meminfo') as f:
+            for line in f:
+                if line.startswith('MemAvailable:'):
+                    return int(line.split()[1]) // 1024
+        return -1
+
+    def run(self):
+        if not os.path.exists('/proc/net/dev'):
+            logger.debug('SYSSTAT unsupported on this platform (no /proc), sampler exits.')
+            return
+
+        prev_rx, prev_tx = self._read_net_bytes()
+        prev_ts = time.time()
+        while True:
+            time.sleep(self.interval_s)
+            try:
+                rx, tx = self._read_net_bytes()
+                now = time.time()
+                dt = max(0.001, now - prev_ts)
+                rx_mbps = (rx - prev_rx) * 8 / dt / 1e6
+                tx_mbps = (tx - prev_tx) * 8 / dt / 1e6
+                prev_rx, prev_tx, prev_ts = rx, tx, now
+                logger.debug(f'SYSSTAT rx={rx_mbps:.2f}Mbps tx={tx_mbps:.2f}Mbps '
+                             f'load1={self._read_load1():.2f} mem_avail={self._read_mem_avail_mb()}MB')
+            except Exception as e:
+                logger.debug(f'SYSSTAT sample failed: {e}')


### PR DESCRIPTION
Groundwork for the next milestone (**full 04:00 scan inside 40 min**): we know the run is too slow, but not *which stage* is the bottleneck or whether it degrades over time. This PR measures; optimizations come after, compared against these metrics.

## What you get

**INFO (always on, lean):** the PROGRESS heartbeat now shows **live per-aid stage averages over each interval** — the direct answer to "does the worker get slower over time" and "is db insert the problem":
```
PROGRESS simple-fetch: 39015 done, 26674 left (59.4%), 93/s | db 9ms/aid, http 1.31s/aid | success: 39015
```
Plus one end-of-pool summary:
```
STAGE AVG simple-fetch: db 9ms/aid, http 1.29s/aid (over 65687 aids)
```

**DEBUG (opt-in via `--debug`, separate `{prefix}_DEBUG.log`):**
- `TIMING aid=N http=1320ms db=9ms total=1335ms` — one line per aid
- `REQUEST url … trial: N, duration: …ms` — per HTTP trial in `Service._get` (separates retry storms from slow single responses)
- `SYSSTAT rx=2.13Mbps tx=0.41Mbps load1=1.25 mem_avail=812MB` — every 10s via `util.SysStatLogger` (`/proc`-based, no-op off Linux) → correlates slowdowns with network/CPU/memory
- plus all existing debug lines, interleaved for context

## How it works
- `add_video_record_via_video_view(out_stat=)` fills `http_ms` / `db_ms` per aid (same pattern as `update_video`'s `out_context`; return type unchanged).
- `AddVideoRecordJob` accumulates the ms into `stat.condition`; `JobPool` renders `*_ms` keys as per-interval averages in the heartbeat and hides the raw totals from the condition list.
- `logging_init(debug=True)` adds a DEBUG file handler (`…_DEBUG.log`, superset of INFO); `51_` enables it + the sysstat sampler **only when started with `--debug`**.

## Usage
```
python 51_hourly-video-record-add.py --debug
```
Expect a large DEBUG file on a full scan (~1M+ lines, gzips well) — that's the point; it's opt-in. To profile the 04:00 run, add `--debug` to that cron entry temporarily.

## Testing
End-to-end mock run (4 workers × 40 aids): TIMING lines correct per aid, heartbeat shows `db 3ms/aid, http 24ms/aid`, STAGE AVG matches merged totals. DEBUG file wiring verified (INFO stays clean, DEBUG is a superset); sysstat exits cleanly on non-Linux; `51_` imports; all files compile.

## What the diagnosis will look like
- `http/aid` climbing across the run + `REQUEST trial>1` lines ⇒ endpoint throttle/retries (hypothesis 1)
- `db/aid` high or climbing ⇒ per-aid insert cost, batching candidate (hypothesis 2)
- SYSSTAT `rx/tx` pinned near the link cap or `load1`/memory pressure ⇒ host limits (hypothesis 3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)