### PR TITLE
feat: fetch/write-split pipeline with batched DB inserts (C0 + C30 bulk)

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -14,7 +14,7 @@ from serverchan import sc_send_summary, sc_send_critical
 from collections import namedtuple, defaultdict, Counter
 from core import TddError, RecordNew
 from service import Service, NewlistArchive, VideoView
-from job import GetNewlistArchiveJob, AddVideoRecordJob, Job, JobPool
+from job import GetNewlistArchiveJob, FetchVideoRecordJob, BatchInsertVideoRecordJob, Job, JobPool
 from task import update_video, add_video, AlreadyExistError
 from timer import Timer
 import logging
@@ -52,6 +52,63 @@ def get_need_insert_aid_list(time_label, is_tid_30, session):
             1, is_tid_30, session)
 
     return aid_list
+
+
+def fetch_and_batch_insert_records(
+        need_insert_aid_list: list, record_queue: Queue, *,
+        job_num: int, fetch_label: str, writer_label: str, logger_name: str,
+        duration_limit_s=60 * 40):
+    """
+    Bulk fetch-then-batch-insert pipeline shared by the C0 and C30 (simple)
+    acquisition paths:
+
+        aid_queue -> FetchVideoRecordJob x job_num (HTTP only)
+                  -> fetched_record_queue
+                  -> BatchInsertVideoRecordJob x 1 (multi-row INSERT, one
+                     commit per batch) -> record_queue (downstream)
+
+    A single writer removes the per-record commit/fsync contention that made
+    db cost ~157ms/record when 150+ workers each committed individually.
+    Returns (fetch_stat, writer_stat) merged JobStats.
+    """
+    log = logging.getLogger(logger_name)
+    service = Service(mode='worker')
+
+    # put aid into queue
+    aid_queue: Queue[int] = Queue()
+    for aid in need_insert_aid_list:
+        aid_queue.put(aid)
+
+    # fetched records flow through here to the single batch writer
+    fetched_record_queue: Queue = Queue()
+
+    fetch_pool = JobPool(
+        [FetchVideoRecordJob(f'job_{i}', aid_queue, fetched_record_queue, service,
+                             duration_limit_s=duration_limit_s)
+         for i in range(job_num)],
+        progress_total=len(need_insert_aid_list),
+        progress_label=fetch_label,
+        logger_name=logger_name)
+    writer_pool = JobPool(
+        [BatchInsertVideoRecordJob('writer_0', fetched_record_queue, record_queue)],
+        progress_total=len(need_insert_aid_list),
+        progress_label=writer_label,
+        progress_interval_s=5.0,  # writer progress is less chatty
+        logger_name=logger_name)
+
+    fetch_pool.start()
+    writer_pool.start()
+
+    fetch_stat = fetch_pool.join()
+    # one sentinel per writer, AFTER all fetch workers finished (FIFO
+    # guarantees it arrives behind every record)
+    fetched_record_queue.put(None)
+    writer_stat = writer_pool.join()
+
+    log.info(fetch_stat.get_summary())
+    log.info(writer_stat.get_summary())
+    log.info(f'{writer_stat.total_count} record(s) fetched, batch inserted and returned.')
+    return fetch_stat, writer_stat
 
 
 class CheckC30NeedInsertButNotFoundAidsJob(Job):
@@ -433,39 +490,16 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
         self.logger.info(
             f'{len(need_insert_aid_list)} aid(s) need insert for time label {self.time_label}.')
 
-        service = Service(mode='worker')
-
-        # put aid into queue
-        aid_queue: Queue[int] = Queue()
-        for aid in need_insert_aid_list:
-            aid_queue.put(aid)
-
-        # create video record queue
-        video_record_queue: Queue[RecordNew] = Queue()
-
-        # create jobs and run them with a per-second progress heartbeat
-        job_num = 50
-        job_list = [
-            AddVideoRecordJob(f'job_{i}', aid_queue, video_record_queue, service,
-                              duration_limit_s=60 * 40)  # 40 minutes, cap the 04:00 full scan
-            for i in range(job_num)
-        ]
-        pool = JobPool(
-            job_list,
-            progress_total=len(need_insert_aid_list),
-            progress_label='c0-acquisition',
-            logger_name='C0DataAcquisitionJob')
-        pool.start()
-        job_stat_merged = pool.join()
+        # bulk fetch -> single batch writer -> self.record_queue
+        fetch_and_batch_insert_records(
+            need_insert_aid_list, self.record_queue,
+            job_num=50,
+            fetch_label='c0-acquisition',
+            writer_label='c0-db-writer',
+            logger_name='C0DataAcquisitionJob',
+            duration_limit_s=60 * 40)  # 40 minutes, cap the 04:00 full scan
 
         self.logger.info('Finish add need insert aid list!')
-        self.logger.info(job_stat_merged.get_summary())
-
-        # forward the fetched records (already lightweight RecordNew)
-        while not video_record_queue.empty():
-            self.record_queue.put(video_record_queue.get())
-        self.logger.info(
-            f'{self.record_queue.qsize()} record(s) parsed and returned.')
 
 
 # TODO: refactor using Job, create a class DataAcquisitionJob,
@@ -827,45 +861,19 @@ class C30PipelineRunner(Thread):
         self.logger.info(
             f'{len(need_insert_aid_list)} aid(s) need insert for time label {self.time_label}.')
 
-        service = Service(mode='worker')
-
-        # put aid into queue
-        aid_queue: Queue[int] = Queue()
-        for aid in need_insert_aid_list:
-            aid_queue.put(aid)
-
-        # create video record queue
-        video_record_queue: Queue[RecordNew] = Queue()
-
-        # create jobs and run them with a per-second progress heartbeat.
-        # 150 workers (vs C0's 50): this is now C30's primary fetch path over a
-        # much larger aid set (~65k+), and at ~0.25 aids/s/worker that covers a
-        # plain hour within the 40-min cap. Note get_video_view is a single
+        # bulk fetch -> single batch writer -> self.record_queue.
+        # 150 fetch workers (vs C0's 50): this is C30's primary path over a
+        # much larger aid set (~65k+/163k+). Note get_video_view is a single
         # endpoint, so scaling is sub-linear -- watch the PROGRESS rate.
-        job_num = 150
-        job_list = [
-            AddVideoRecordJob(
-                f'job_{i}', aid_queue, video_record_queue, service,
-                duration_limit_s=60 * 40)  # 40 minutes
-            for i in range(job_num)
-        ]
-        pool = JobPool(
-            job_list,
-            progress_total=len(need_insert_aid_list),
-            progress_label='simple-fetch',
-            logger_name='C30PipelineRunner')
-        pool.start()
-        job_stat_merged = pool.join()
+        fetch_and_batch_insert_records(
+            need_insert_aid_list, self.record_queue,
+            job_num=150,
+            fetch_label='simple-fetch',
+            writer_label='simple-db-writer',
+            logger_name='C30PipelineRunner',
+            duration_limit_s=60 * 40)  # 40 minutes
 
         self.logger.info('Finish add need insert aid list!')
-        self.logger.info(job_stat_merged.get_summary())
-
-        # forward the fetched records (already lightweight RecordNew)
-        record_cnt = 0
-        while not video_record_queue.empty():
-            self.record_queue.put(video_record_queue.get())
-            record_cnt += 1
-        self.logger.info(f'{record_cnt} record(s) parsed and returned.')
 
     def run(self):
         self.logger.info('c30 video pipeline start')

--- a/job/BatchInsertVideoRecordJob.py
+++ b/job/BatchInsertVideoRecordJob.py
@@ -36,6 +36,12 @@ class BatchInsertVideoRecordJob(Job):
         self.poll_timeout_s = poll_timeout_s
         self.session = Session()
 
+    def _rollback_quietly(self):
+        try:
+            self.session.rollback()
+        except Exception:
+            pass
+
     def _flush(self, batch: list):
         if not batch:
             return
@@ -43,14 +49,23 @@ class BatchInsertVideoRecordJob(Job):
         try:
             commit_video_records_batch(batch, self.session)
         except Exception as e:
-            # Recover the session so a failed batch does not leave it in an
-            # invalid-transaction state; records are still forwarded downstream.
+            # Recover the session, then retry ONCE: a transient DB blip would
+            # otherwise lose the whole batch from tdd_video_record (the batch
+            # is one statement in one transaction, so the failed attempt is
+            # rolled back atomically -- no partial insert, no duplication).
+            self._rollback_quietly()
+            self.logger.warning(
+                f'Batch insert failed, retrying once. size: {len(batch)}, error: {e}')
             try:
-                self.session.rollback()
-            except Exception:
-                pass
-            self.logger.error(f'Fail to batch insert {len(batch)} video record(s). error: {e}')
-            self.stat.condition['batch_insert_fail'] += 1
+                commit_video_records_batch(batch, self.session)
+            except Exception as e2:
+                self._rollback_quietly()
+                self.logger.error(
+                    f'Fail to batch insert {len(batch)} video record(s) after retry. '
+                    f'aids: {batch[0].aid}..{batch[-1].aid}, error: {e2}')
+                self.stat.condition['batch_insert_fail'] += 1
+            else:
+                self.stat.condition['batch_insert_retry_ok'] += 1
         else:
             self.stat.condition['batch_insert'] += 1
         flush_ms = int((time.perf_counter() - flush_start) * 1000)

--- a/job/BatchInsertVideoRecordJob.py
+++ b/job/BatchInsertVideoRecordJob.py
@@ -1,0 +1,90 @@
+import time
+from .Job import Job
+from queue import Queue, Empty
+from db import Session
+from core import RecordNew
+from task import commit_video_records_batch
+from typing import Optional
+
+__all__ = ['BatchInsertVideoRecordJob']
+
+
+class BatchInsertVideoRecordJob(Job):
+    """
+    Dedicated DB writer: drains RecordNew from record_queue and persists them
+    with multi-row INSERTs, one commit per batch (commit_video_records_batch).
+    Profiling showed per-record commits under high fetch concurrency cost
+    ~157ms/record from commit/fsync contention; a single writer with batches
+    removes that entirely.
+
+    Each record is forwarded to downstream_queue after its batch is processed
+    (insert failures are logged and counted, records still forwarded so the
+    downstream csv/analysis stays complete -- same policy as the per-record
+    path, where DBOperation.add swallows insert errors).
+
+    Terminates on a None sentinel: the producer side must put one None per
+    writer AFTER all fetch workers finished; being FIFO, the sentinel is
+    guaranteed to arrive after every record.
+    """
+
+    def __init__(self, name: str, record_queue: 'Queue[Optional[RecordNew]]',
+                 downstream_queue: Queue, batch_size: int = 1000, poll_timeout_s: float = 1.0):
+        super().__init__(name)
+        self.record_queue = record_queue
+        self.downstream_queue = downstream_queue
+        self.batch_size = batch_size
+        self.poll_timeout_s = poll_timeout_s
+        self.session = Session()
+
+    def _flush(self, batch: list):
+        if not batch:
+            return
+        flush_start = time.perf_counter()
+        try:
+            commit_video_records_batch(batch, self.session)
+        except Exception as e:
+            # Recover the session so a failed batch does not leave it in an
+            # invalid-transaction state; records are still forwarded downstream.
+            try:
+                self.session.rollback()
+            except Exception:
+                pass
+            self.logger.error(f'Fail to batch insert {len(batch)} video record(s). error: {e}')
+            self.stat.condition['batch_insert_fail'] += 1
+        else:
+            self.stat.condition['batch_insert'] += 1
+        flush_ms = int((time.perf_counter() - flush_start) * 1000)
+
+        for record in batch:
+            self.downstream_queue.put(record)
+
+        # db_ms feeds JobPool's heartbeat as per-record stage average
+        self.stat.condition['db_ms'] += flush_ms
+        self.logger.debug(f'BATCH size={len(batch)} db={flush_ms}ms')
+        self.stat.total_count += len(batch)
+        self.stat.total_duration_ms += flush_ms
+
+    def process(self):
+        batch = []
+        while True:
+            try:
+                item = self.record_queue.get(timeout=self.poll_timeout_s)
+            except Empty:
+                # queue momentarily empty: flush what we have so records don't
+                # sit here while fetching is slow
+                self._flush(batch)
+                batch = []
+                continue
+
+            if item is None:  # sentinel: all producers finished
+                self._flush(batch)
+                batch = []
+                break
+
+            batch.append(item)
+            if len(batch) >= self.batch_size:
+                self._flush(batch)
+                batch = []
+
+    def cleanup(self):
+        self.session.close()

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -1,7 +1,7 @@
 from .Job import Job
 from service import Service, CodeError
 from timer import Timer
-from queue import Queue
+from queue import Queue, Empty
 from db import Session
 from core import RecordNew
 from util import format_ts_ms, get_ts_s, ts_s_to_str
@@ -45,12 +45,18 @@ class FetchVideoRecordJob(Job):
             self.duration_limit_due_ts_s = get_ts_s() + self.duration_limit_s
             self.logger.info(f'Duration limit due at {ts_s_to_str(self.duration_limit_due_ts_s)}.')
 
-        while not self.aid_queue.empty():
+        while True:
             if self.duration_limit_due_ts_s is not None and get_ts_s() >= self.duration_limit_due_ts_s:
                 self.logger.info(f'Duration limit reached. Now exit.')
                 break
 
-            aid = self.aid_queue.get()
+            # get_nowait instead of empty()+get(): the latter races when several
+            # workers see the same last item -- the losers block in get() forever
+            # and the pool join never returns
+            try:
+                aid = self.aid_queue.get_nowait()
+            except Empty:
+                break
             self.logger.debug(f'Now start fetch video record. aid: {aid}')
             timer = Timer()
             timer.start()

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -1,0 +1,108 @@
+from .Job import Job
+from service import Service, CodeError
+from timer import Timer
+from queue import Queue
+from db import Session
+from core import RecordNew
+from util import format_ts_ms, get_ts_s, ts_s_to_str
+from task import fetch_video_record_via_video_view, update_video
+from typing import Optional
+
+__all__ = ['FetchVideoRecordJob']
+
+
+class FetchVideoRecordJob(Job):
+    """
+    Fetch-only worker: HTTP fetch -> RecordNew -> record_queue. Persisting is
+    left to a BatchInsertVideoRecordJob draining the queue, so fetch workers
+    hold no DB connection and per-record commit contention disappears. This is
+    the bulk counterpart of AddVideoRecordJob (which stays the right choice for
+    small aid batches).
+
+    A DB session is opened lazily, only if the CodeError -> update_video
+    fallback fires (a small fraction of aids).
+    """
+
+    def __init__(self, name: str, aid_queue: Queue[int], record_queue: 'Queue[Optional[RecordNew]]',
+                 service: Service,
+                 update_if_code_error: bool = True, duration_limit_s: Optional[int] = None):
+        super().__init__(name)
+        self.aid_queue = aid_queue
+        self.record_queue = record_queue
+        self.service = service
+        self.session = None  # lazy, most workers never need one
+        self.update_if_code_error = update_if_code_error
+        self.duration_limit_s = duration_limit_s
+        self.duration_limit_due_ts_s = None
+
+    def _get_session(self):
+        if self.session is None:
+            self.session = Session()
+        return self.session
+
+    def process(self):
+        if self.duration_limit_s is not None:
+            self.duration_limit_due_ts_s = get_ts_s() + self.duration_limit_s
+            self.logger.info(f'Duration limit due at {ts_s_to_str(self.duration_limit_due_ts_s)}.')
+
+        while not self.aid_queue.empty():
+            if self.duration_limit_due_ts_s is not None and get_ts_s() >= self.duration_limit_due_ts_s:
+                self.logger.info(f'Duration limit reached. Now exit.')
+                break
+
+            aid = self.aid_queue.get()
+            self.logger.debug(f'Now start fetch video record. aid: {aid}')
+            timer = Timer()
+            timer.start()
+
+            stage_stat = {}  # per-stage durations, filled by the task (http_ms)
+            try:
+                record = fetch_video_record_via_video_view(
+                    aid, self.service, out_stat=stage_stat)
+            except CodeError as e:
+                if self.update_if_code_error:
+                    self.logger.info(f'Code error occurred. Now start update video. aid: {aid}')
+                    try:
+                        tdd_video_logs = update_video(aid, self.service, self._get_session())
+                    except Exception as e2:
+                        # Recover the session so a failed DB op does not leave
+                        # it in an invalid-transaction state that would cascade
+                        # to every subsequent aid in this worker.
+                        try:
+                            self.session.rollback()
+                        except Exception:
+                            pass
+                        self.logger.error(f'Fail to update video info. aid: {aid}, error: {e2}')
+                        self.stat.condition['update_exception'] += 1
+                    else:
+                        for log in tdd_video_logs:
+                            self.logger.info(
+                                f'Update video info. aid: {aid}, attr: {log.attr}, {log.oldval} -> {log.newval}')
+                        self.logger.debug(f'{len(tdd_video_logs)} log(s) found. aid: {aid}')
+                        self.stat.condition[f'{len(tdd_video_logs)}_update'] += 1
+                else:
+                    self.logger.error(f'Fail to fetch video record. aid: {aid}, error: {e}')
+                self.stat.condition['code_error'] += 1
+            except Exception as e:
+                self.logger.error(f'Fail to fetch video record. aid: {aid}, error: {e}')
+                self.stat.condition['other_exception'] += 1
+            else:
+                self.record_queue.put(record)
+                self.stat.condition['success'] += 1
+
+            timer.stop()
+            # accumulate per-stage durations into the pool stats (JobPool's
+            # heartbeat turns *_ms keys into live per-aid stage averages) and
+            # emit a greppable per-aid line for offline analysis (--debug file)
+            for stage_key, stage_ms in stage_stat.items():
+                self.stat.condition[stage_key] += stage_ms
+            self.logger.debug(
+                f'TIMING aid={aid} '
+                + ' '.join(f'{k[:-3]}={v}ms' for k, v in stage_stat.items())
+                + f' total={timer.get_duration_ms()}ms')
+            self.stat.total_count += 1
+            self.stat.total_duration_ms += timer.get_duration_ms()
+
+    def cleanup(self):
+        if self.session is not None:
+            self.session.close()

--- a/job/__init__.py
+++ b/job/__init__.py
@@ -3,6 +3,8 @@ from .AddSprintVideoRecordJob import *
 from .AddVideoJob import *
 from .AddVideoRecordJob import *
 from .AddVideoFromArchiveJob import *
+from .BatchInsertVideoRecordJob import *
+from .FetchVideoRecordJob import *
 from .GetNewlistArchiveJob import *
 from .Job import *
 from .JobStat import *

--- a/task/task.py
+++ b/task/task.py
@@ -2,7 +2,7 @@ from service import Service, ServiceError, CodeError, VideoView, NewlistArchiveS
 from sqlalchemy.orm.session import Session
 from db import DBOperation, TddVideo, TddVideoRecord, TddVideoLog, TddVideoStaff, TddMember, TddMemberFollowerRecord, \
     TddMemberLog, TddSprintVideoRecord
-from util import get_ts_s, a2b, same_pic_url
+from util import get_ts_s, a2b, same_pic_url, null_or_str
 from core import TddError, RecordNew
 from .error import AlreadyExistError, NotExistError
 
@@ -12,6 +12,8 @@ import time
 logger = logging.getLogger('task')
 
 __all__ = ['add_video_record_via_video_view',
+           'fetch_video_record_via_video_view',
+           'commit_video_records_batch',
            'commit_video_record_via_video_view',
            'commit_video_record_via_newlist_archive_stat',
            'add_sprint_video_record_via_video_view',
@@ -20,11 +22,13 @@ __all__ = ['add_video_record_via_video_view',
            'get_video_tags_str']
 
 
-def add_video_record_via_video_view(aid: int, service: Service, session: Session,
-                                    out_stat: dict = None) -> RecordNew:
-    # out_stat (optional): filled with per-stage durations for instrumentation,
-    # keys 'http_ms' (view fetch incl retries) and 'db_ms' (insert + commit).
-    # Same pattern as update_video's out_context.
+def fetch_video_record_via_video_view(aid: int, service: Service,
+                                      out_stat: dict = None) -> RecordNew:
+    # Fetch-only: build a lightweight, session-independent record from the
+    # video view WITHOUT touching the DB. Pair with a writer that persists
+    # records (single-record add_video_record_via_video_view, or the batched
+    # commit_video_records_batch for bulk pipelines).
+    # out_stat (optional): filled with 'http_ms' (view fetch incl retries).
 
     # get video view
     stage_start = time.perf_counter()
@@ -38,32 +42,6 @@ def add_video_record_via_video_view(aid: int, service: Service, session: Session
     added = get_ts_s()
     view = -1 if video_view.stat.view == '--' else video_view.stat.view
 
-    # assemble and persist the record. The ORM object is confined to this
-    # function -- it exists only to run the INSERT and never leaves.
-    new_video_record = TddVideoRecord(
-        aid=aid,
-        added=added,
-        view=view,
-        danmaku=video_view.stat.danmaku,
-        reply=video_view.stat.reply,
-        favorite=video_view.stat.favorite,
-        coin=video_view.stat.coin,
-        share=video_view.stat.share,
-        like=video_view.stat.like,
-        dislike=video_view.stat.dislike,
-        now_rank=video_view.stat.now_rank,
-        his_rank=video_view.stat.his_rank,
-        vt=video_view.stat.vt,
-        vv=video_view.stat.vv,
-    )
-    # TODO: use new db operation which can raise exception
-    stage_start = time.perf_counter()
-    DBOperation.add(new_video_record, session)
-    if out_stat is not None:
-        out_stat['db_ms'] = int((time.perf_counter() - stage_start) * 1000)
-
-    # return the lightweight, session-independent record built from video_view
-    # (never read back the committed ORM row, which expires on commit / detaches)
     return RecordNew(
         added=added,
         aid=aid,
@@ -81,6 +59,71 @@ def add_video_record_via_video_view(aid: int, service: Service, session: Session
         vt=video_view.stat.vt,
         vv=video_view.stat.vv,
     )
+
+
+def add_video_record_via_video_view(aid: int, service: Service, session: Session,
+                                    out_stat: dict = None) -> RecordNew:
+    # Fetch + persist one record. Good for small aid batches; bulk pipelines
+    # should use fetch_video_record_via_video_view + commit_video_records_batch
+    # to avoid per-record commit contention.
+    # out_stat (optional): filled with per-stage durations for instrumentation,
+    # keys 'http_ms' (view fetch incl retries) and 'db_ms' (insert + commit).
+    # Same pattern as update_video's out_context.
+    record = fetch_video_record_via_video_view(aid, service, out_stat=out_stat)
+
+    # persist. The ORM object is confined to this function -- it exists only
+    # to run the INSERT and never leaves.
+    new_video_record = TddVideoRecord(
+        aid=record.aid,
+        added=record.added,
+        view=record.view,
+        danmaku=record.danmaku,
+        reply=record.reply,
+        favorite=record.favorite,
+        coin=record.coin,
+        share=record.share,
+        like=record.like,
+        dislike=record.dislike,
+        now_rank=record.now_rank,
+        his_rank=record.his_rank,
+        vt=record.vt,
+        vv=record.vv,
+    )
+    # TODO: use new db operation which can raise exception
+    stage_start = time.perf_counter()
+    DBOperation.add(new_video_record, session)
+    if out_stat is not None:
+        out_stat['db_ms'] = int((time.perf_counter() - stage_start) * 1000)
+
+    return record
+
+
+def commit_video_records_batch(records: list, session: Session, out_stat: dict = None) -> None:
+    # Persist many RecordNew with ONE multi-row INSERT and ONE commit. This is
+    # the bulk counterpart of add_video_record_via_video_view: profiling showed
+    # per-record commits under high concurrency cost ~157ms/record (p50 17ms,
+    # p90 458ms -- commit/fsync contention), which a single writer with batches
+    # avoids. Raises on failure; the caller owns rollback/retry policy.
+    # out_stat (optional): filled with 'db_ms' (insert + commit).
+    if not records:
+        return
+
+    stage_start = time.perf_counter()
+    sql = 'insert into ' \
+          'tdd_video_record(added, aid, `view`, danmaku, reply, favorite, coin, share, `like`, ' \
+          'dislike, now_rank, his_rank, vt, vv) ' \
+          'values '
+    sql += ', '.join(
+        '(%d, %d, %d, %d, %d, %d, %d, %d, %d, %s, %s, %s, %s, %s)' % (
+            r.added, r.aid,
+            r.view, r.danmaku, r.reply, r.favorite, r.coin, r.share, r.like,
+            null_or_str(r.dislike), null_or_str(r.now_rank), null_or_str(r.his_rank),
+            null_or_str(r.vt), null_or_str(r.vv))
+        for r in records)
+    session.execute(sql)
+    session.commit()
+    if out_stat is not None:
+        out_stat['db_ms'] = int((time.perf_counter() - stage_start) * 1000)
 
 
 def commit_video_record_via_video_view(video_view: VideoView, added: int, session: Session) -> TddVideoRecord:


### PR DESCRIPTION
Optimization #1 from the 08:00 profiling run, toward the **04:00-in-40min** milestone.

## Why
The profiled stage split showed **db insert+commit = 157ms/record avg (21% of per-aid time)** — but with **p50=17ms vs p90=458ms**: the cost is commit/fsync **contention** from 150+ workers each committing per record, not row cost. A single writer with batches removes it.

## Design
```
aid_queue → FetchVideoRecordJob × N (HTTP only) → record queue
          → BatchInsertVideoRecordJob × 1 (multi-row INSERT, ONE commit per 1000)
          → downstream record_queue
```
- **`FetchVideoRecordJob`** — fetch-only worker; holds **no DB connection** (opens a session lazily only for the rare `CodeError → update_video` fallback). Emits `TIMING`/`http_ms` like before.
- **`BatchInsertVideoRecordJob`** — dedicated writer; drains the queue, `commit_video_records_batch` (raw multi-row SQL, one commit), flushes partial batches when the queue idles (≤1s staleness), terminates on a `None` sentinel (FIFO ⇒ arrives after every record), forwards records downstream. Failed batches are logged/counted and records still forwarded (same policy as the per-record path). Reports `db_ms` → the `PROGRESS <label>-db-writer` heartbeat shows live ms/record.
- **Tasks:** new `fetch_video_record_via_video_view` (fetch-only) + `commit_video_records_batch` (bulk persist). `add_video_record_via_video_view` now composes fetch + single insert — **behavior unchanged** (regression-tested: same RecordNew, same ORM insert values, `'--'`→`-1`).
- **`AddVideoRecordJob` untouched** — remains the right tool for small batches (`42_add-video-record-from-file`).
- 51's C0 + `process_simple` now share one helper (`fetch_and_batch_insert_records`); labels: `c0-acquisition`/`c0-db-writer`, `simple-fetch`/`simple-db-writer`.

## Expected effect
- per-aid ~745ms → ~590ms ⇒ **~200/s → ~250/s** on the bulk path (verify via `STAGE AVG` before/after — same-hour comparison).
- Side effect: concurrent MySQL sessions from 51 drop from ~200 to ~a couple (fetch workers no longer hold connections).

## Testing
- SQL generation verified (columns, `None`→`null` for vt/vv).
- Mock end-to-end (4 fetchers + 1 writer, 2050 aids): batches `[1000, 1000, 50]`, sentinel termination, downstream completeness 2050/2050, `http_ms`/`db_ms` stats populated, both heartbeats render.
- Single-record task regression + `51` module import + all files compile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)