### PR TITLE
perf: wall-clock deadline on Service._get body download, scaled by response size

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -26,7 +26,7 @@ class Service:
 
     def __init__(
             self, headers: Optional[dict] = None, retry: int = 3, timeout: float = 5.0, colddown_factor: float = 1.0,
-            mode: RequestMode = 'direct', pool_maxsize: int = 256
+            mode: RequestMode = 'direct', pool_maxsize: int = 256, deadline: float = 10.0
     ):
         # set default config
         self._headers = headers if headers is not None else {}
@@ -34,6 +34,9 @@ class Service:
         self._timeout = timeout
         self._colddown_factor = colddown_factor
         self._mode = mode
+        # total wall-clock budget per trial, see _get() for why this differs
+        # from timeout
+        self._deadline = deadline
 
         # pooled session for HTTP keep-alive: reuse TCP+TLS connections across
         # requests instead of a fresh handshake per call (big win when many
@@ -126,11 +129,15 @@ class Service:
     def get_default_mode(self) -> RequestMode:
         return self._mode
 
+    def get_default_deadline(self) -> float:
+        return self._deadline
+
     # default config getters end
 
     def _get(
             self, url: str, params: Optional[dict] = None, headers: Optional[dict] = None,
             retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
+            deadline: Optional[float] = None,
             parser: Optional[Callable[[str], Optional[dict]]] = None
     ) -> Optional[dict]:
         # assemble headers
@@ -146,6 +153,7 @@ class Service:
         retry = retry if retry is not None else self._retry
         timeout = timeout if timeout is not None else self._timeout
         colddown_factor = colddown_factor if colddown_factor is not None else self._colddown_factor
+        deadline = deadline if deadline is not None else self._deadline
 
         # go request
         response = None
@@ -160,13 +168,51 @@ class Service:
             trial_start = time.perf_counter()
             try:
                 r = self._session.get(url, params=params, headers=headers,
-                                      timeout=timeout)
+                                      timeout=timeout, stream=True)
             except requests.exceptions.RequestException as e:
                 logger.debug(
                     f'Fail to get response. '
                     f'url: {url}, params: {params}, trial: {trial}, error: {e}'
                 )
                 continue
+
+            # `timeout` above only bounds the gap between individual socket
+            # reads. A response that trickles bytes slower than that gap but
+            # never actually stalls sails right through it -- observed in
+            # production as 100+ second single-trial requests against the
+            # worker Lambda, each one parking a fetch thread the whole time.
+            # Enforce a real wall-clock budget across the whole download and
+            # abandon (close) the connection the moment it's blown, so the
+            # thread is freed instead of stuck waiting on a slow socket.
+            body = bytearray()
+            deadline_exceeded = False
+            try:
+                for chunk in r.iter_content(chunk_size=65536):
+                    body += chunk
+                    if time.perf_counter() - trial_start > deadline:
+                        deadline_exceeded = True
+                        break
+            except requests.exceptions.RequestException as e:
+                r.close()
+                logger.debug(
+                    f'Fail to read response body. '
+                    f'url: {url}, params: {params}, trial: {trial}, error: {e}'
+                )
+                continue
+            if deadline_exceeded:
+                r.close()
+                trial_ms = int((time.perf_counter() - trial_start) * 1000)
+                logger.debug(
+                    f'Deadline exceeded while downloading response body. '
+                    f'url: {url}, params: {params}, trial: {trial}, deadline: {deadline}s, duration: {trial_ms}ms'
+                )
+                continue
+            # populate requests' internal cache with what we already
+            # downloaded, so r.json()/r.text below read it directly instead
+            # of trying to re-read the now-exhausted stream
+            r._content = bytes(body)
+            r._content_consumed = True
+
             trial_ms = int((time.perf_counter() - trial_start) * 1000)
 
             # check status code

--- a/service/Service.py
+++ b/service/Service.py
@@ -26,7 +26,8 @@ class Service:
 
     def __init__(
             self, headers: Optional[dict] = None, retry: int = 3, timeout: float = 5.0, colddown_factor: float = 1.0,
-            mode: RequestMode = 'direct', pool_maxsize: int = 256, deadline: float = 10.0
+            mode: RequestMode = 'direct', pool_maxsize: int = 256, deadline: float = 10.0,
+            min_throughput_bps: float = 80_000.0
     ):
         # set default config
         self._headers = headers if headers is not None else {}
@@ -37,6 +38,12 @@ class Service:
         # total wall-clock budget per trial, see _get() for why this differs
         # from timeout
         self._deadline = deadline
+        # some responses (season/multi-part videos) run 200KB-2.8MB against a
+        # typical few-KB payload; production measured p10 throughput of 94.5
+        # KB/s on those, so a flat deadline kills healthy large transfers
+        # (measured: 1974/1975 deadline hits were >200KB, not stalls). Deadline
+        # scales with Content-Length at this floor, see _get()
+        self._min_throughput_bps = min_throughput_bps
 
         # pooled session for HTTP keep-alive: reuse TCP+TLS connections across
         # requests instead of a fresh handshake per call (big win when many
@@ -184,12 +191,26 @@ class Service:
             # Enforce a real wall-clock budget across the whole download and
             # abandon (close) the connection the moment it's blown, so the
             # thread is freed instead of stuck waiting on a slow socket.
+            #
+            # A flat budget isn't enough though: some responses (season /
+            # multi-part videos) run 200KB-2.8MB against a typical few-KB
+            # payload, and legitimately need more wall-clock time under
+            # concurrent load. Scale the budget by the declared response size
+            # so those aren't killed mid-transfer.
+            trial_deadline = deadline
+            content_length = r.headers.get('Content-Length')
+            if content_length is not None:
+                try:
+                    trial_deadline = max(deadline, int(content_length) / self._min_throughput_bps)
+                except ValueError:
+                    pass
+
             body = bytearray()
             deadline_exceeded = False
             try:
                 for chunk in r.iter_content(chunk_size=65536):
                     body += chunk
-                    if time.perf_counter() - trial_start > deadline:
+                    if time.perf_counter() - trial_start > trial_deadline:
                         deadline_exceeded = True
                         break
             except requests.exceptions.RequestException as e:
@@ -204,7 +225,8 @@ class Service:
                 trial_ms = int((time.perf_counter() - trial_start) * 1000)
                 logger.debug(
                     f'Deadline exceeded while downloading response body. '
-                    f'url: {url}, params: {params}, trial: {trial}, deadline: {deadline}s, duration: {trial_ms}ms'
+                    f'url: {url}, params: {params}, trial: {trial}, deadline: {trial_deadline:.1f}s, '
+                    f'content_length: {content_length}, duration: {trial_ms}ms'
                 )
                 continue
             # populate requests' internal cache with what we already


### PR DESCRIPTION
## Problem: tail-latency collapse in C30 bulk fetch

Sustained fetch runs degraded 10-17x within minutes, while the median request stayed healthy. From the 2026-07-13 13:00 run (65,684 aids, no other scripts running):

| minute | done/s | p50 | p90 | % of 150-thread pool stuck on >20s requests |
|---|---|---|---|---|
| 13:01 | 237/s | 515ms | 1.15s | 3% |
| 13:05 | 67/s | 718ms | 4.1s | 28% |
| 13:10 | 32/s | 916ms | 11.2s | 53% |
| 13:14 | 11/s | 977ms | 18.8s | 69% |

p50 never exceeded 1s across the entire run — only the tail grew (p99 9s → 77s, max 120s). A handful of 60-120s requests each park a fetch thread 60-120x longer than a normal request, so they progressively eat the pool (Little's law). Same fingerprint in the 12:00 and 14:00 runs; CPU (load1 ≤ 0.5), memory (2.3GB+ free), DB (0ms/aid since #28), and retry counts (~0.1%) all ruled out.

**Root cause:** `requests`' `timeout=5.0` only bounds the gap between socket reads — it is not a total deadline. A response that trickles bytes never times out: production logs show 100+ second requests completing on `trial: 1` with no error.

## Fix 1: total wall-clock deadline (f53906f)

Stream the body (`stream=True` + `iter_content`) and enforce a real wall-clock budget (default 10s) across the whole download; on breach, close and abandon the connection so the thread is freed, and let the normal retry loop handle it.

**Result — 04:00 full scan (999,344 C30 aids), 2026-07-14 vs 2026-07-13:**

| | 07-13 (before¹) | 07-14 (after) |
|---|---|---|
| total run | 1h 1m 14s | 43m 47s |
| C30 fetched in 40-min window | 433,810 (43%) | 615,522 (62%) |
| avg per aid | 829ms | 567ms |
| sustained throughput | collapsed within minutes | 300-370/s held for ~28 min |

¹ 07-13 04:00 predates the #28 batching sync, so the delta includes both changes; the collapse-free 28-minute plateau is attributable to the deadline (every prior sustained run collapsed within ~5 minutes regardless of batching).

## Fix 2: scale deadline by response size (ca9a42a)

The first experiment run exposed a flat-deadline casualty: of 1,975 deadline hits, **1,974 were responses >200KB** (median 1.5MB, max 2.8MB — season/multi-part videos), not stalls. 270 aids (0.044%) exhausted all 3 retries and were dropped.

Scale the per-trial budget by `Content-Length` with an 80KB/s throughput floor (measured p10 on completed large transfers: 94.5KB/s). Typical few-KB responses keep the tight 10s deadline; a 2.8MB response gets ~35s.

**Result — 05:00 run (65,682 aids): 100% success, 0 dropped.** 49 deadline evictions, all recovered on retry. 632ms/aid, C30 fetch done in under 5 minutes, whole run 6m58s.

## Follow-up

The oversized responses themselves (bloat fields like `ugc_season`/`honor_reply` that the record path discards) are addressed separately by a trimmed video-view worker endpoint; this deadline stays as the safety net for genuine hangs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)