### PR TITLE
perf: C30 fetch workers 150 -> 250, derive pool_maxsize from job_num

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -72,7 +72,13 @@ def fetch_and_batch_insert_records(
     Returns (fetch_stat, writer_stat) merged JobStats.
     """
     log = logging.getLogger(logger_name)
-    service = Service(mode='worker')
+    # pool_maxsize MUST cover job_num: every worker hits the same worker host,
+    # and urllib3 caps connections per host at pool_maxsize. Exceed it and the
+    # surplus connections are opened-then-discarded -- a TLS handshake per
+    # request (~5KB out vs ~500B), which would multiply outbound ~10x on a box
+    # whose ~3Mbps upload is already the throughput ceiling. Derive it from
+    # job_num so bumping workers can't silently break keep-alive.
+    service = Service(mode='worker', pool_maxsize=job_num + 32)
 
     # put aid into queue
     aid_queue: Queue[int] = Queue()
@@ -862,12 +868,15 @@ class C30PipelineRunner(Thread):
             f'{len(need_insert_aid_list)} aid(s) need insert for time label {self.time_label}.')
 
         # bulk fetch -> single batch writer -> self.record_queue.
-        # 150 fetch workers (vs C0's 50): this is C30's primary path over a
-        # much larger aid set (~65k+/163k+). Note get_video_view is a single
-        # endpoint, so scaling is sub-linear -- watch the PROGRESS rate.
+        # 250 fetch workers (vs C0's 50): this is C30's primary path over a
+        # much larger aid set (~65k+/163k+). Scaling is sub-linear -- the
+        # trimmed worker is a single endpoint, and the box's ~3Mbps OUTBOUND
+        # (request headers + ACKs, ~500B/fetch) caps throughput somewhere
+        # around 400-600/s regardless of worker count. Watch the PROGRESS rate
+        # and SYSSTAT tx: if tx pins at ~3Mbps, more workers won't help.
         fetch_and_batch_insert_records(
             need_insert_aid_list, self.record_queue,
-            job_num=150,
+            job_num=250,
             fetch_label='simple-fetch',
             writer_label='simple-db-writer',
             logger_name='C30PipelineRunner',


### PR DESCRIPTION
## Result: 335/s -> ~537/s, and we found the actual ceiling

Measured on the 08:00 run (163,257 C30 aids), server tmp branch:

| | 150 workers (07:00) | 250 workers (08:00) |
|---|---|---|
| C30 throughput | 335/s | **~537/s** (peak 614/s) |
| C30 fetch phase | 3m 16s (65k aids) | **5m 4s (163k aids)** |
| `STAGE AVG simple-fetch` | 445 ms/aid | 464 ms/aid |
| SYSSTAT tx | 1.9–2.6 Mbps | **3.0–3.35 Mbps (pinned)** |
| deadline evictions | 0 | 0 |
| whole run | 5m 42s | 8m 27s (163k, vs 13m 39s for the same aid count pre-#29/#30) |

**At ~537/s a ~1M-aid full scan projects to ~31 min — inside the 40-minute cap.**

## Outbound bandwidth is now the wall — do not raise this further

`tx` pinned at 3.0–3.35 Mbps for the entire fetch phase while `rx` idled at 6–10 Mbps. The box's ~3 Mbps upload is saturated by request headers + TCP ACKs (~500B per fetch). More workers past this point deepen the queue and inflate latency without adding throughput. If more headroom is ever needed the lever is **bytes per request** (the ~110-byte random User-Agent, the 60-char Lambda hostname), not more threads.

## The `pool_maxsize` footgun this also fixes

`fetch_and_batch_insert_records` built `Service(mode='worker')` with the default `pool_maxsize=256`, while **every** worker hits the same worker host — urllib3 caps connections per host at `pool_maxsize`, so >256 workers would open-then-discard the surplus: a **TLS handshake per request** (~5KB out vs ~500B), i.e. ~10x the outbound bytes on the exact resource that binds. Bumping `job_num` without this would have made things dramatically *worse*, and silently.

Now derived as `pool_maxsize=job_num + 32`. Verified on the 08:00 run: **307 `Starting new HTTPS` events total** (≈250 C30 + 50 C0 workers, i.e. one per worker, not per request) and **0** "Connection pool is full" discards.

## Follow-up (not in this PR)

The DB writer showed strain at the higher arrival rate — `batch_insert_fail: 1` in C0 (up to 1000 records dropped from `tdd_video_record` for that label), `batch_insert_retry_ok: 2` in C30, and writer db time up from ~0ms/aid to 14ms/aid (C0) / 2ms/aid (C30). The single `BatchInsertVideoRecordJob` may now be the next bottleneck behind the fetchers. To be investigated separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)