### PR TITLE
fix: stop dropping records on batch insert failure; bound the fetch->write queue

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -12,6 +12,7 @@ import re
 import sys
 from serverchan import sc_send_summary, sc_send_critical
 from collections import namedtuple, defaultdict, Counter
+from typing import Optional
 from core import TddError, RecordNew
 from service import Service, NewlistArchive, VideoView
 from job import GetNewlistArchiveJob, FetchVideoRecordJob, BatchInsertVideoRecordJob, Job, JobPool
@@ -57,7 +58,9 @@ def get_need_insert_aid_list(time_label, is_tid_30, session):
 def fetch_and_batch_insert_records(
         need_insert_aid_list: list, record_queue: Queue, *,
         job_num: int, fetch_label: str, writer_label: str, logger_name: str,
-        duration_limit_s=60 * 40):
+        duration_limit_s=60 * 40,
+        fetched_queue_maxsize: int = 20000,
+        recovery_path: Optional[str] = None):
     """
     Bulk fetch-then-batch-insert pipeline shared by the C0 and C30 (simple)
     acquisition paths:
@@ -85,8 +88,12 @@ def fetch_and_batch_insert_records(
     for aid in need_insert_aid_list:
         aid_queue.put(aid)
 
-    # fetched records flow through here to the single batch writer
-    fetched_record_queue: Queue = Queue()
+    # Fetched records flow through here to the single batch writer. BOUNDED:
+    # fetchers now outrun the writer (~537/s vs ~365/s), so an unbounded queue
+    # just absorbs the backlog into RSS and hides it. A cap turns that into
+    # backpressure -- fetchers block on put() at writer speed, which is visible
+    # in the PROGRESS rate instead of a silent memory climb.
+    fetched_record_queue: Queue = Queue(maxsize=fetched_queue_maxsize)
 
     fetch_pool = JobPool(
         [FetchVideoRecordJob(f'job_{i}', aid_queue, fetched_record_queue, service,
@@ -96,7 +103,8 @@ def fetch_and_batch_insert_records(
         progress_label=fetch_label,
         logger_name=logger_name)
     writer_pool = JobPool(
-        [BatchInsertVideoRecordJob('writer_0', fetched_record_queue, record_queue)],
+        [BatchInsertVideoRecordJob('writer_0', fetched_record_queue, record_queue,
+                                   recovery_path=recovery_path)],
         progress_total=len(need_insert_aid_list),
         progress_label=writer_label,
         progress_interval_s=5.0,  # writer progress is less chatty
@@ -503,7 +511,8 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
             fetch_label='c0-acquisition',
             writer_label='c0-db-writer',
             logger_name='C0DataAcquisitionJob',
-            duration_limit_s=60 * 40)  # 40 minutes, cap the 04:00 full scan
+            duration_limit_s=60 * 40,  # 40 minutes, cap the 04:00 full scan
+            recovery_path=f'data/record_recovery_c0_{self.time_label.replace(":", "")}.csv')
 
         self.logger.info('Finish add need insert aid list!')
 
@@ -880,7 +889,8 @@ class C30PipelineRunner(Thread):
             fetch_label='simple-fetch',
             writer_label='simple-db-writer',
             logger_name='C30PipelineRunner',
-            duration_limit_s=60 * 40)  # 40 minutes
+            duration_limit_s=60 * 40,  # 40 minutes
+            recovery_path=f'data/record_recovery_c30_{self.time_label.replace(":", "")}.csv')
 
         self.logger.info('Finish add need insert aid list!')
 

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -55,6 +55,13 @@ def get_need_insert_aid_list(time_label, is_tid_30, session):
     return aid_list
 
 
+def _stamp(time_task: str) -> str:
+    # '2026-07-14 08:00' -> '2026-07-14_0800', for filenames: keeps the date so
+    # runs on different days never append into the same recovery file, and
+    # avoids the space/colon of the time_task-named csv.
+    return time_task.replace(' ', '_').replace(':', '')
+
+
 def fetch_and_batch_insert_records(
         need_insert_aid_list: list, record_queue: Queue, *,
         job_num: int, fetch_label: str, writer_label: str, logger_name: str,
@@ -485,15 +492,19 @@ class C30NoNeedInsertAidsChecker(Thread):
 
 
 class DataAcquisitionJob(Job):
-    def __init__(self, name: str, time_label: str, record_queue: Queue[RecordNew]):
+    def __init__(self, name: str, time_task: str, record_queue: Queue[RecordNew]):
         super().__init__(name)
-        self.time_label = time_label
+        # time_task is the full stamp ('2026-07-14 08:00'); time_label is just
+        # the hour ('08:00'). Recovery files need the full stamp so runs on
+        # different days don't append into the same file.
+        self.time_task = time_task
+        self.time_label = time_task[-5:]
         self.record_queue = record_queue
 
 
 class C0DataAcquisitionJob(DataAcquisitionJob):
-    def __init__(self, time_label: str, record_queue: Queue[RecordNew]):
-        super().__init__('c0', time_label, record_queue)
+    def __init__(self, time_task: str, record_queue: Queue[RecordNew]):
+        super().__init__('c0', time_task, record_queue)
 
     def process(self):
         # get need insert aid list
@@ -512,7 +523,7 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
             writer_label='c0-db-writer',
             logger_name='C0DataAcquisitionJob',
             duration_limit_s=60 * 40,  # 40 minutes, cap the 04:00 full scan
-            recovery_path=f'data/record_recovery_c0_{self.time_label.replace(":", "")}.csv')
+            recovery_path=f'data/record_recovery_c0_{_stamp(self.time_task)}.csv')
 
         self.logger.info('Finish add need insert aid list!')
 
@@ -520,9 +531,10 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
 # TODO: refactor using Job, create a class DataAcquisitionJob,
 #  then derive from it to create C30DataAcquisitionJob and C0DataAcquisitionJob
 class C30PipelineRunner(Thread):
-    def __init__(self, time_label, record_queue):
+    def __init__(self, time_task, record_queue):
         super().__init__()
-        self.time_label = time_label
+        self.time_task = time_task  # full stamp, ex: '2026-07-14 08:00'
+        self.time_label = time_task[-5:]  # hour only, ex: '08:00'
         self.record_queue = record_queue
         self.logger = logging.getLogger('C30PipelineRunner')
 
@@ -890,7 +902,7 @@ class C30PipelineRunner(Thread):
             writer_label='simple-db-writer',
             logger_name='C30PipelineRunner',
             duration_limit_s=60 * 40,  # 40 minutes
-            recovery_path=f'data/record_recovery_c30_{self.time_label.replace(":", "")}.csv')
+            recovery_path=f'data/record_recovery_c30_{_stamp(self.time_task)}.csv')
 
         self.logger.info('Finish add need insert aid list!')
 
@@ -1416,8 +1428,8 @@ def run_hourly_video_record_add(time_task):
 
     records_queue: Queue[RecordNew] = Queue()
 
-    c30_runner = C30PipelineRunner(time_label, records_queue)
-    c0_runner = C0DataAcquisitionJob(time_label, records_queue)
+    c30_runner = C30PipelineRunner(time_task, records_queue)
+    c0_runner = C0DataAcquisitionJob(time_task, records_queue)
 
     c30_runner.start()
     c0_runner.start()

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -56,10 +56,10 @@ def get_need_insert_aid_list(time_label, is_tid_30, session):
 
 
 def _stamp(time_task: str) -> str:
-    # '2026-07-14 08:00' -> '2026-07-14_0800', for filenames: keeps the date so
-    # runs on different days never append into the same recovery file, and
-    # avoids the space/colon of the time_task-named csv.
-    return time_task.replace(' ', '_').replace(':', '')
+    # '2026-07-14 08:00' -> '202607140800'. Same convention as the log files
+    # (51_202607140800_INFO.log): digits only, no '-', ' ' or ':'. Keeps the
+    # date so runs on different days never append into the same file.
+    return time_task.replace('-', '').replace(' ', '').replace(':', '')
 
 
 def fetch_and_batch_insert_records(

--- a/job/BatchInsertVideoRecordJob.py
+++ b/job/BatchInsertVideoRecordJob.py
@@ -46,14 +46,18 @@ class BatchInsertVideoRecordJob(Job):
 
     def __init__(self, name: str, record_queue: 'Queue[Optional[RecordNew]]',
                  downstream_queue: Queue, batch_size: int = 1000, poll_timeout_s: float = 1.0,
-                 recovery_path: Optional[str] = None):
+                 recovery_path: Optional[str] = None, single_retry: int = 3,
+                 retry_backoff_s: float = 1.0):
         super().__init__(name)
         self.record_queue = record_queue
         self.downstream_queue = downstream_queue
         self.batch_size = batch_size
         self.poll_timeout_s = poll_timeout_s
         self.recovery_path = recovery_path
+        self.single_retry = single_retry
+        self.retry_backoff_s = retry_backoff_s
         self.session = Session()
+        self._last_error = ''
 
     def _rollback_quietly(self):
         try:
@@ -105,12 +109,27 @@ class BatchInsertVideoRecordJob(Job):
                 self.stat.condition['batch_insert_split_ok'] += 1
             return len(batch)
 
-        # a single record that still fails is genuinely unpersistable (bad row,
-        # or the DB is down) -- park it rather than spin
+        # Down to a single row. Splitting can't isolate anything further, so
+        # this is where we retry in time rather than in size: back off and try
+        # again, in case the failure was transient (a DB blip, a lock, a
+        # timeout under load) rather than a genuinely bad row. Only after these
+        # all fail is the record parked in the recovery file.
         if len(batch) == 1:
+            for attempt in range(1, self.single_retry + 1):
+                time.sleep(self.retry_backoff_s * attempt)  # 1s, 2s, 3s
+                if self._insert(batch):
+                    self.logger.info(
+                        f'Insert succeeded on retry {attempt}/{self.single_retry}. '
+                        f'aid: {batch[0].aid}')
+                    self.stat.condition['single_insert_retry_ok'] += 1
+                    return 1
+                self.logger.warning(
+                    f'Insert retry {attempt}/{self.single_retry} failed. '
+                    f'aid: {batch[0].aid}, error: {self._last_error}')
+
             self.logger.error(
-                f'Fail to insert video record after splitting to a single row. '
-                f'aid: {batch[0].aid}, error: {self._last_error}')
+                f'Fail to insert video record after {self.single_retry} retries. '
+                f'Now save to recovery file. aid: {batch[0].aid}, error: {self._last_error}')
             self.stat.condition['batch_insert_fail'] += 1
             self._to_recovery_file(batch, self._last_error)
             return 0

--- a/job/BatchInsertVideoRecordJob.py
+++ b/job/BatchInsertVideoRecordJob.py
@@ -1,4 +1,6 @@
+import csv
 import time
+from pathlib import Path
 from .Job import Job
 from queue import Queue, Empty
 from db import Session
@@ -7,6 +9,14 @@ from task import commit_video_records_batch
 from typing import Optional
 
 __all__ = ['BatchInsertVideoRecordJob']
+
+
+def _short(e: Exception, limit: int = 300) -> str:
+    # SQLAlchemy embeds the whole failing statement in the exception, which for
+    # a 1000-row multi-row INSERT is ~20k characters -- unreadable in the log
+    # and it bloats the file. Keep the error, drop the statement dump.
+    text = str(e).split('\n[SQL:')[0]
+    return text if len(text) <= limit else text[:limit] + '...'
 
 
 class BatchInsertVideoRecordJob(Job):
@@ -22,18 +32,27 @@ class BatchInsertVideoRecordJob(Job):
     downstream csv/analysis stays complete -- same policy as the per-record
     path, where DBOperation.add swallows insert errors).
 
+    A failing batch is split and retried rather than dropped: a whole-batch
+    failure used to lose up to `batch_size` records from tdd_video_record
+    (seen in production when a 1000-row insert hit MySQL's timeout at 87s).
+    Halving isolates the bad/slow rows and lets the rest land; anything still
+    failing at a single record is written to a recovery csv so it can be
+    replayed instead of vanishing.
+
     Terminates on a None sentinel: the producer side must put one None per
     writer AFTER all fetch workers finished; being FIFO, the sentinel is
     guaranteed to arrive after every record.
     """
 
     def __init__(self, name: str, record_queue: 'Queue[Optional[RecordNew]]',
-                 downstream_queue: Queue, batch_size: int = 1000, poll_timeout_s: float = 1.0):
+                 downstream_queue: Queue, batch_size: int = 1000, poll_timeout_s: float = 1.0,
+                 recovery_path: Optional[str] = None):
         super().__init__(name)
         self.record_queue = record_queue
         self.downstream_queue = downstream_queue
         self.batch_size = batch_size
         self.poll_timeout_s = poll_timeout_s
+        self.recovery_path = recovery_path
         self.session = Session()
 
     def _rollback_quietly(self):
@@ -42,40 +61,87 @@ class BatchInsertVideoRecordJob(Job):
         except Exception:
             pass
 
+    def _to_recovery_file(self, records: list, error: str):
+        # last resort: records that no amount of splitting could persist. Write
+        # them out so a failed insert is recoverable instead of silently absent
+        # from tdd_video_record.
+        if self.recovery_path is None:
+            return
+        try:
+            path = Path(self.recovery_path)
+            path.parent.mkdir(parents=True, exist_ok=True)
+            is_new = not path.exists()
+            with path.open('a', newline='') as f:
+                writer = csv.writer(f)
+                if is_new:
+                    writer.writerow(list(RecordNew._fields) + ['error'])
+                for r in records:
+                    writer.writerow(list(r) + [error])
+        except Exception as e:
+            self.logger.error(f'Fail to write {len(records)} record(s) to recovery file '
+                              f'{self.recovery_path}. error: {_short(e)}')
+
+    def _insert(self, batch: list) -> bool:
+        # one attempt; caller owns the splitting policy
+        try:
+            commit_video_records_batch(batch, self.session)
+        except Exception as e:
+            # recover the session, else the failed transaction poisons every
+            # subsequent statement on it
+            self._rollback_quietly()
+            self._last_error = _short(e)
+            return False
+        return True
+
+    def _insert_splitting(self, batch: list, depth: int = 0) -> int:
+        """Insert `batch`, halving on failure. Returns count persisted."""
+        if not batch:
+            return 0
+
+        if self._insert(batch):
+            if depth == 0:
+                self.stat.condition['batch_insert'] += 1
+            else:
+                self.stat.condition['batch_insert_split_ok'] += 1
+            return len(batch)
+
+        # a single record that still fails is genuinely unpersistable (bad row,
+        # or the DB is down) -- park it rather than spin
+        if len(batch) == 1:
+            self.logger.error(
+                f'Fail to insert video record after splitting to a single row. '
+                f'aid: {batch[0].aid}, error: {self._last_error}')
+            self.stat.condition['batch_insert_fail'] += 1
+            self._to_recovery_file(batch, self._last_error)
+            return 0
+
+        self.logger.warning(
+            f'Batch insert failed, splitting and retrying. '
+            f'size: {len(batch)}, aids: {batch[0].aid}..{batch[-1].aid}, error: {self._last_error}')
+        self.stat.condition['batch_insert_split'] += 1
+
+        mid = len(batch) // 2
+        return (self._insert_splitting(batch[:mid], depth + 1)
+                + self._insert_splitting(batch[mid:], depth + 1))
+
     def _flush(self, batch: list):
         if not batch:
             return
         flush_start = time.perf_counter()
-        try:
-            commit_video_records_batch(batch, self.session)
-        except Exception as e:
-            # Recover the session, then retry ONCE: a transient DB blip would
-            # otherwise lose the whole batch from tdd_video_record (the batch
-            # is one statement in one transaction, so the failed attempt is
-            # rolled back atomically -- no partial insert, no duplication).
-            self._rollback_quietly()
-            self.logger.warning(
-                f'Batch insert failed, retrying once. size: {len(batch)}, error: {e}')
-            try:
-                commit_video_records_batch(batch, self.session)
-            except Exception as e2:
-                self._rollback_quietly()
-                self.logger.error(
-                    f'Fail to batch insert {len(batch)} video record(s) after retry. '
-                    f'aids: {batch[0].aid}..{batch[-1].aid}, error: {e2}')
-                self.stat.condition['batch_insert_fail'] += 1
-            else:
-                self.stat.condition['batch_insert_retry_ok'] += 1
-        else:
-            self.stat.condition['batch_insert'] += 1
+        persisted = self._insert_splitting(batch)
         flush_ms = int((time.perf_counter() - flush_start) * 1000)
+
+        if persisted < len(batch):
+            self.logger.error(
+                f'{len(batch) - persisted} of {len(batch)} record(s) not persisted to '
+                f'tdd_video_record in this batch.')
 
         for record in batch:
             self.downstream_queue.put(record)
 
         # db_ms feeds JobPool's heartbeat as per-record stage average
         self.stat.condition['db_ms'] += flush_ms
-        self.logger.debug(f'BATCH size={len(batch)} db={flush_ms}ms')
+        self.logger.debug(f'BATCH size={len(batch)} persisted={persisted} db={flush_ms}ms')
         self.stat.total_count += len(batch)
         self.stat.total_duration_ms += flush_ms
 


### PR DESCRIPTION
Follow-up to #31, which took C30 fetch to ~537/s and pushed the bottleneck onto the DB writer. Two problems surfaced in the 08:00 run — this PR fixes correctness and observability; **writer throughput is deliberately left for a separate change.**

## 1. Data loss on batch insert failure

A 1000-row insert hit MySQL's timeout after **87 seconds** (`(2013, 'Lost connection to MySQL server during query (timed out)')`). The single retry failed too, so the entire batch was dropped: **up to 1000 records silently absent from `tdd_video_record`** for that time label. (The CSV still had them — the writer forwards downstream regardless — so it was a DB-only hole, which is exactly why it was easy to miss.)

Now the writer **splits and retries recursively** (1000 → 2×500 → 2×250 → …). A single bad or slow row costs 1 record instead of 1000; anything that still fails when isolated to a single row is written to a **recovery CSV** (`data/record_recovery_{c0,c30}_{label}.csv`, with the error) so it can be replayed rather than vanishing.

Verified with a fault-injection test (one poisonous row in a 1000-record batch):
```
Batch insert failed, splitting and retrying. size: 1000, aids: 0..999, ...
... 9 splits ...
Fail to insert video record after splitting to a single row. aid: 500
1 of 1000 record(s) not persisted to tdd_video_record in this batch.
persisted downstream : 1000   (all still forwarded to csv/analysis)
conditions           : {'batch_insert_split': 9, 'batch_insert_split_ok': 9, 'batch_insert_fail': 1}
recovery file rows   : 1 -> aid 500
```
**999 records land instead of 0.** Clean batches keep the fast path (one insert, no splitting, no recovery file).

Also: SQLAlchemy embeds the whole failing statement in the exception, so every failure was dumping the entire **~20,000-character** multi-row INSERT into the WARNING log. Now stripped to the error itself (66 chars in the test above).

## 2. Unbounded fetch→write queue

Fetchers now outrun the writer (~537/s vs ~365/s effective), so `fetched_record_queue` was absorbing the backlog into RSS — `mem_avail` fell ~300MB over the run — and hiding it. Bounded at 20k records, so fetchers block on `put()` at writer speed. The backpressure becomes **visible in the PROGRESS rate** instead of a silent memory climb.

## Not in this PR

Writer throughput. The writer spent **447s** of DB time during a **304s** fetch phase, and **170 of 172 batches were full 1000-row batches** (a partial batch only occurs when the queue drains — so it essentially never drained). Options to evaluate next: multiple batch writers, smaller batch size, and understanding the p50 547ms / p90 4.3s / max 87.8s spread on a plain INSERT.

🤖 Generated with [Claude Code](https://claude.com/claude-code)