### PR TITLE
fix: deadlock between fetchers and the batch writer (hung the 04:00 full scan)

### DIFF
--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -1,7 +1,7 @@
 from .Job import Job
 from service import Service, CodeError
 from timer import Timer
-from queue import Queue, Empty
+from queue import Queue, Empty, Full
 from db import Session
 from core import RecordNew
 from util import format_ts_ms, get_ts_s, ts_s_to_str
@@ -19,26 +19,66 @@ class FetchVideoRecordJob(Job):
     the bulk counterpart of AddVideoRecordJob (which stays the right choice for
     small aid batches).
 
-    A DB session is opened lazily, only if the CodeError -> update_video
-    fallback fires (a small fraction of aids).
+    Fetchers hold NO pooled DB connection: the rare CodeError -> update_video
+    fallback takes a short-lived session and returns it immediately. Holding one
+    per worker deadlocked the 2026-07-15 04:00 full scan -- see
+    _update_video_with_own_session.
     """
+
+    # give up on a record after this long stuck on a full queue, so a dead
+    # writer can never hang the pool indefinitely (belt-and-braces: the
+    # duration limit normally ends the wait first)
+    MAX_PUT_WAIT_S = 300.0
 
     def __init__(self, name: str, aid_queue: Queue[int], record_queue: 'Queue[Optional[RecordNew]]',
                  service: Service,
-                 update_if_code_error: bool = True, duration_limit_s: Optional[int] = None):
+                 update_if_code_error: bool = True, duration_limit_s: Optional[int] = None,
+                 put_timeout_s: float = 30.0):
         super().__init__(name)
         self.aid_queue = aid_queue
         self.record_queue = record_queue
         self.service = service
-        self.session = None  # lazy, most workers never need one
         self.update_if_code_error = update_if_code_error
         self.duration_limit_s = duration_limit_s
         self.duration_limit_due_ts_s = None
+        self.put_timeout_s = put_timeout_s
 
-    def _get_session(self):
-        if self.session is None:
-            self.session = Session()
-        return self.session
+    def _update_video_with_own_session(self, aid: int):
+        """
+        Run the CodeError -> update_video fallback on a SHORT-LIVED session.
+
+        This must NOT hold a pooled connection for the worker's lifetime. It
+        used to: a lazy self.session was opened on the first CodeError and kept
+        until cleanup(). With 250 workers against a 200-connection pool
+        (pool_size=50 + max_overflow=150), a full scan spreads enough CodeErrors
+        across workers that every worker eventually pins a connection -- the
+        pool is then exhausted, the batch writer cannot get a connection to
+        drain record_queue, record_queue fills to its cap, and every fetcher
+        blocks forever in put() while still holding the connections the writer
+        needs. That is a deadlock, and it hung the 2026-07-15 04:00 full scan.
+
+        A fetcher needs the DB for well under 1% of aids, so it takes a
+        connection only for that call and gives it straight back.
+        """
+        session = Session()
+        try:
+            return update_video(aid, self.service, session)
+        except Exception:
+            try:
+                session.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            session.close()  # back to the pool immediately
+
+    def _put_record(self, record) -> bool:
+        """Bounded put with a timeout. False -> queue still full, caller decides."""
+        try:
+            self.record_queue.put(record, timeout=self.put_timeout_s)
+            return True
+        except Full:
+            return False
 
     def process(self):
         if self.duration_limit_s is not None:
@@ -69,15 +109,10 @@ class FetchVideoRecordJob(Job):
                 if self.update_if_code_error:
                     self.logger.info(f'Code error occurred. Now start update video. aid: {aid}')
                     try:
-                        tdd_video_logs = update_video(aid, self.service, self._get_session())
+                        # short-lived session: rollback + close are handled
+                        # inside, so no pooled connection outlives this call
+                        tdd_video_logs = self._update_video_with_own_session(aid)
                     except Exception as e2:
-                        # Recover the session so a failed DB op does not leave
-                        # it in an invalid-transaction state that would cascade
-                        # to every subsequent aid in this worker.
-                        try:
-                            self.session.rollback()
-                        except Exception:
-                            pass
                         self.logger.error(f'Fail to update video info. aid: {aid}, error: {e2}')
                         self.stat.condition['update_exception'] += 1
                     else:
@@ -93,7 +128,27 @@ class FetchVideoRecordJob(Job):
                 self.logger.error(f'Fail to fetch video record. aid: {aid}, error: {e}')
                 self.stat.condition['other_exception'] += 1
             else:
-                self.record_queue.put(record)
+                # record_queue is BOUNDED, so put() can block when the writer
+                # falls behind -- that backpressure is intentional. What is not
+                # acceptable is blocking FOREVER: if every writer dies (or
+                # cannot get a DB connection), an unbounded wait here hangs the
+                # whole pool past the hour, and the duration-limit check at the
+                # top of the loop is never reached again. Time out, re-check the
+                # deadline, and give up on the record rather than the run.
+                put_wait_s = 0.0
+                while not self._put_record(record):
+                    put_wait_s += self.put_timeout_s
+                    hit_deadline = (self.duration_limit_due_ts_s is not None
+                                    and get_ts_s() >= self.duration_limit_due_ts_s)
+                    if hit_deadline or put_wait_s >= self.MAX_PUT_WAIT_S:
+                        self.logger.error(
+                            f'Record queue still full after {put_wait_s:.0f}s -- writer stalled '
+                            f'or dead. Dropping record and exiting. aid: {aid}')
+                        self.stat.condition['record_dropped_queue_full'] += 1
+                        return
+                    self.logger.warning(
+                        f'Record queue full for {put_wait_s:.0f}s -- writer is stalled or dead. '
+                        f'Still waiting. aid: {aid}')
                 self.stat.condition['success'] += 1
 
             timer.stop()
@@ -109,6 +164,3 @@ class FetchVideoRecordJob(Job):
             self.stat.total_count += 1
             self.stat.total_duration_ms += timer.get_duration_ms()
 
-    def cleanup(self):
-        if self.session is not None:
-            self.session.close()


### PR DESCRIPTION
## What happened

The **2026-07-15 04:00 full scan hung for 90+ minutes** at 72.6% (725,436 of 998,558 aids) and had to be killed. Fetch and writer both sat at **0/s** from ~04:41 onward.

This is a regression from #31 + #32 combined. Neither is wrong alone; together they close a circular wait.

## Root cause: fetchers hold the connections the writer needs

1. **`FetchVideoRecordJob` pinned a pooled DB connection.** It opened a lazy session on its first `CodeError` and held it until `cleanup()`. The full scan hit **465 CodeErrors spread across all 250 workers** (#31 raised 150 → 250), so essentially every worker ended up holding one — **250 workers against a 200-connection pool** (`pool_size=50 + max_overflow=150`).
2. **Pool exhausted → the writer starved.** `BatchInsertVideoRecordJob` couldn't get a connection to drain `record_queue`:
   ```
   QueuePool limit of size 50 overflow 150 reached, connection timed out, timeout 60
   ```
3. **`record_queue` filled to its 20,000 cap** (#32 bounded it), so every fetcher blocked **forever** in `put()` — *while still holding the connections the writer needed to make room*. Deadlock.

The evidence matches exactly: fetch stopped at 725,436, writer at 704,000 — a gap of **21,436 ≈ the 20,000 cap**.

**The unbounded queue had been masking (1)**: fetchers never blocked, so they always finished and released their connections. Bounding it is what closed the cycle. I flagged this as a risk ("R3 — writer deadlock") when writing the merge plan and said *"not fixed here"*. That was wrong; it bit within a day.

## Fixes

**1. Fetchers hold no pooled connection.** The `CodeError → update_video` fallback runs on a short-lived session, closed immediately in a `finally`. A fetcher needs the DB on <1% of aids — holding a connection for the other 99% is what exhausted the pool.

**2. `put()` cannot block forever.** Bounded-queue `put()` now takes a timeout and re-checks the duration limit. A stalled or dead writer costs a dropped record (counted as `record_dropped_queue_full`), not the entire run. Backpressure is preserved — only the *unbounded* wait is gone.

## Verified

- **Deadlock repro** (full queue, no writer draining — the exact 04:00 condition): worker now exits cleanly instead of hanging.
  ```
  thread still alive (HUNG)?   False
  conditions                 : {'record_dropped_queue_full': 1}
  ```
- **Connection hoarding** (50 aids, *all* taking the CodeError path): peak **1** concurrent session, **0** leaked.
- **Healthy path** (100 aids, no errors): **0** DB sessions opened, 100 records produced.

## Impact / damage

04:00 wrote 704k of 998k C30 records; 273k aids got no record for that label, and 14 records are parked in `data/record_recovery_c30_202607150400.csv`. Hourly runs were never affected (they generate far fewer CodeErrors, so they never exhaust the pool) — 05:00 completed normally in 4 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)