### PR TITLE
refactor: delegate CodeError video updates to a bounded UpdateVideoJob pool

### DIFF
--- a/15_update-video-info.py
+++ b/15_update-video-info.py
@@ -1,7 +1,7 @@
 from db import DBOperation, Session
 from service import Service
 from serverchan import sc_send_summary
-from util import logging_init, get_week_day, fullname
+from util import logging_init, get_week_day, fullname, b2a
 from timer import Timer
 from queue import Queue
 from job import UpdateVideoJob, JobStat
@@ -38,17 +38,26 @@ def update_video_info():
 
     logger.info(f'Will update {len(bvids)} videos info.')
 
-    # put bvid into queue
-    bvid_queue: Queue[str] = Queue()
+    # put aid into queue. UpdateVideoJob takes aids (it used to take bvids and
+    # b2a them itself); converting here keeps the job free of that concern and
+    # lets 51_ feed it aids straight from the fetch pipeline.
+    aid_queue: Queue[int] = Queue()
     for bvid in bvids:
-        bvid_queue.put(bvid)
-    logger.info(f'{bvid_queue.qsize()} bvids put into queue.')
+        aid_queue.put(b2a(bvid))
+    # one sentinel per worker: UpdateVideoJob is now sentinel-terminated (an
+    # empty queue means "wait", so it can also run alongside a live producer in
+    # 51_). This also retires the old `while not queue.empty(): queue.get()`
+    # loop, which races -- two workers both see a non-empty queue, both call
+    # get(), and the loser blocks forever on the last item.
+    job_num = 20
+    for _ in range(job_num):
+        aid_queue.put(None)
+    logger.info(f'{len(bvids)} aids put into queue.')
 
     # create jobs
-    job_num = 20
     job_list = []
     for i in range(job_num):
-        job_list.append(UpdateVideoJob(f'job_{i}', bvid_queue, service))
+        job_list.append(UpdateVideoJob(f'job_{i}', aid_queue, service))
 
     # start jobs
     for job in job_list:

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -121,6 +121,10 @@ def fetch_and_batch_insert_records(
     # it stays tiny (~465 aids across a 1M-aid full scan).
     code_error_aid_queue: Queue = Queue()
 
+    # ensure_conditions: seed the keys that matter with 0 so they ALWAYS show in
+    # the summary. A Counter omits a key it never saw, so without this you cannot
+    # tell "nothing failed" from "the counter does not exist" -- exactly the
+    # distinction you need when scanning a log for data loss.
     fetch_pool = JobPool(
         [FetchVideoRecordJob(f'job_{i}', aid_queue, fetched_record_queue, service,
                              code_error_aid_queue=code_error_aid_queue,
@@ -128,6 +132,8 @@ def fetch_and_batch_insert_records(
          for i in range(job_num)],
         progress_total=len(need_insert_aid_list),
         progress_label=fetch_label,
+        ensure_conditions=['success', 'code_error', 'other_exception',
+                           'record_dropped_queue_full', 'duration_limit_reached'],
         logger_name=logger_name)
     writer_pool = JobPool(
         [BatchInsertVideoRecordJob('writer_0', fetched_record_queue, record_queue,
@@ -135,6 +141,8 @@ def fetch_and_batch_insert_records(
         progress_total=len(need_insert_aid_list),
         progress_label=writer_label,
         progress_interval_s=5.0,  # writer progress is less chatty
+        ensure_conditions=['batch_insert', 'batch_insert_split', 'batch_insert_split_ok',
+                           'single_insert_retry_ok', 'batch_insert_fail'],
         logger_name=logger_name)
     # bounded DB concurrency: update_job_num connections, not job_num
     update_pool = JobPool(
@@ -144,6 +152,7 @@ def fetch_and_batch_insert_records(
         progress_total=None,  # total is unknown until fetching is done
         progress_label=update_label,
         progress_interval_s=5.0,
+        ensure_conditions=['update_exception', 'duration_limit_reached'],
         logger_name=logger_name)
 
     fetch_pool.start()
@@ -159,9 +168,11 @@ def fetch_and_batch_insert_records(
     writer_stat = writer_pool.join()
     update_stat = update_pool.join()
 
-    log.info(fetch_stat.get_summary())
-    log.info(writer_stat.get_summary())
-    log.info(update_stat.get_summary())
+    # label each summary: a run emits three of these and they are otherwise
+    # indistinguishable in the log
+    log.info(fetch_stat.get_summary(fetch_label))
+    log.info(writer_stat.get_summary(writer_label))
+    log.info(update_stat.get_summary(update_label))
     log.info(f'{writer_stat.total_count} record(s) fetched, batch inserted and returned.')
     log.info(f'{update_stat.total_count} code-error video(s) updated.')
     return fetch_stat, writer_stat, update_stat

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -15,7 +15,7 @@ from collections import namedtuple, defaultdict, Counter
 from typing import Optional
 from core import TddError, RecordNew
 from service import Service, NewlistArchive, VideoView
-from job import GetNewlistArchiveJob, FetchVideoRecordJob, BatchInsertVideoRecordJob, Job, JobPool
+from job import GetNewlistArchiveJob, FetchVideoRecordJob, BatchInsertVideoRecordJob, UpdateVideoJob, Job, JobPool
 from task import update_video, add_video, AlreadyExistError
 from timer import Timer
 import logging
@@ -67,19 +67,33 @@ def fetch_and_batch_insert_records(
         job_num: int, fetch_label: str, writer_label: str, logger_name: str,
         duration_limit_s=60 * 40,
         fetched_queue_maxsize: int = 20000,
-        recovery_path: Optional[str] = None):
+        recovery_path: Optional[str] = None,
+        update_job_num: int = 10, update_label: str = 'video-update'):
     """
     Bulk fetch-then-batch-insert pipeline shared by the C0 and C30 (simple)
     acquisition paths:
 
-        aid_queue -> FetchVideoRecordJob x job_num (HTTP only)
-                  -> fetched_record_queue
-                  -> BatchInsertVideoRecordJob x 1 (multi-row INSERT, one
-                     commit per batch) -> record_queue (downstream)
+        aid_queue -> FetchVideoRecordJob x job_num (HTTP only, ZERO DB)
+                  |
+                  +-- ok        -> fetched_record_queue
+                  |                 -> BatchInsertVideoRecordJob x 1
+                  |                    (multi-row INSERT, one commit per batch)
+                  |                    -> record_queue (downstream)
+                  |
+                  +-- CodeError -> code_error_aid_queue
+                                    -> UpdateVideoJob x update_job_num (DB)
 
     A single writer removes the per-record commit/fsync contention that made
     db cost ~157ms/record when 150+ workers each committed individually.
-    Returns (fetch_stat, writer_stat) merged JobStats.
+
+    The update pool runs CONCURRENTLY with the fetch pool (so it does not extend
+    the run) and carries the SAME duration_limit_s, so the whole upstream stage
+    is hard-capped. Refreshing tdd_video.code for a dead aid is what drops it out
+    of future need_insert lists, so it is load-bearing -- but it is DB work, and
+    doing it inline on a fetch worker let all 250 fetchers hit the DB at once,
+    which deadlocked the 2026-07-15 04:00 full scan.
+
+    Returns (fetch_stat, writer_stat, update_stat) merged JobStats.
     """
     log = logging.getLogger(logger_name)
     # pool_maxsize MUST cover job_num: every worker hits the same worker host,
@@ -102,8 +116,14 @@ def fetch_and_batch_insert_records(
     # in the PROGRESS rate instead of a silent memory climb.
     fetched_record_queue: Queue = Queue(maxsize=fetched_queue_maxsize)
 
+    # CodeError aids (deleted / hidden / -403) go here for the update pool.
+    # Unbounded on purpose: it must never exert backpressure on a fetcher, and
+    # it stays tiny (~465 aids across a 1M-aid full scan).
+    code_error_aid_queue: Queue = Queue()
+
     fetch_pool = JobPool(
         [FetchVideoRecordJob(f'job_{i}', aid_queue, fetched_record_queue, service,
+                             code_error_aid_queue=code_error_aid_queue,
                              duration_limit_s=duration_limit_s)
          for i in range(job_num)],
         progress_total=len(need_insert_aid_list),
@@ -116,20 +136,35 @@ def fetch_and_batch_insert_records(
         progress_label=writer_label,
         progress_interval_s=5.0,  # writer progress is less chatty
         logger_name=logger_name)
+    # bounded DB concurrency: update_job_num connections, not job_num
+    update_pool = JobPool(
+        [UpdateVideoJob(f'updater_{i}', code_error_aid_queue, service,
+                        duration_limit_s=duration_limit_s)
+         for i in range(update_job_num)],
+        progress_total=None,  # total is unknown until fetching is done
+        progress_label=update_label,
+        progress_interval_s=5.0,
+        logger_name=logger_name)
 
     fetch_pool.start()
     writer_pool.start()
+    update_pool.start()
 
     fetch_stat = fetch_pool.join()
-    # one sentinel per writer, AFTER all fetch workers finished (FIFO
-    # guarantees it arrives behind every record)
+    # one sentinel per consumer, AFTER all fetch workers finished (FIFO
+    # guarantees each sentinel arrives behind every item that worker could take)
     fetched_record_queue.put(None)
+    for _ in range(update_job_num):
+        code_error_aid_queue.put(None)
     writer_stat = writer_pool.join()
+    update_stat = update_pool.join()
 
     log.info(fetch_stat.get_summary())
     log.info(writer_stat.get_summary())
+    log.info(update_stat.get_summary())
     log.info(f'{writer_stat.total_count} record(s) fetched, batch inserted and returned.')
-    return fetch_stat, writer_stat
+    log.info(f'{update_stat.total_count} code-error video(s) updated.')
+    return fetch_stat, writer_stat, update_stat
 
 
 class CheckC30NeedInsertButNotFoundAidsJob(Job):
@@ -523,7 +558,8 @@ class C0DataAcquisitionJob(DataAcquisitionJob):
             writer_label='c0-db-writer',
             logger_name='C0DataAcquisitionJob',
             duration_limit_s=60 * 40,  # 40 minutes, cap the 04:00 full scan
-            recovery_path=f'data/record_recovery_c0_{_stamp(self.time_task)}.csv')
+            recovery_path=f'data/record_recovery_c0_{_stamp(self.time_task)}.csv',
+            update_job_num=5, update_label='c0-video-update')
 
         self.logger.info('Finish add need insert aid list!')
 
@@ -902,7 +938,8 @@ class C30PipelineRunner(Thread):
             writer_label='simple-db-writer',
             logger_name='C30PipelineRunner',
             duration_limit_s=60 * 40,  # 40 minutes
-            recovery_path=f'data/record_recovery_c30_{_stamp(self.time_task)}.csv')
+            recovery_path=f'data/record_recovery_c30_{_stamp(self.time_task)}.csv',
+            update_job_num=10, update_label='c30-video-update')
 
         self.logger.info('Finish add need insert aid list!')
 

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -2,10 +2,9 @@ from .Job import Job
 from service import Service, CodeError
 from timer import Timer
 from queue import Queue, Empty, Full
-from db import Session
 from core import RecordNew
 from util import format_ts_ms, get_ts_s, ts_s_to_str
-from task import fetch_video_record_via_video_view, update_video
+from task import fetch_video_record_via_video_view
 from typing import Optional
 
 __all__ = ['FetchVideoRecordJob']
@@ -19,10 +18,14 @@ class FetchVideoRecordJob(Job):
     the bulk counterpart of AddVideoRecordJob (which stays the right choice for
     small aid batches).
 
-    Fetchers hold NO pooled DB connection: the rare CodeError -> update_video
-    fallback takes a short-lived session and returns it immediately. Holding one
-    per worker deadlocked the 2026-07-15 04:00 full scan -- see
-    _update_video_with_own_session.
+    Fetchers touch NO DB, at all -- they do not even import Session. An aid whose
+    view call returns a CodeError (deleted / hidden / -403) is pushed to
+    code_error_aid_queue for a bounded UpdateVideoJob pool to refresh, instead of
+    the fetcher running update_video itself. Doing it inline meant any of the 250
+    fetchers could grab a pooled connection (and, before that, pin one for its
+    whole life) -- unbounded DB concurrency from the fetch tier, which is what
+    deadlocked the 2026-07-15 04:00 full scan. It also cost a fetch slot and
+    pulled a FULL (untrimmed, up to 2.8MB) view payload per code error.
     """
 
     # give up on a record after this long stuck on a full queue, so a dead
@@ -32,45 +35,19 @@ class FetchVideoRecordJob(Job):
 
     def __init__(self, name: str, aid_queue: Queue[int], record_queue: 'Queue[Optional[RecordNew]]',
                  service: Service,
-                 update_if_code_error: bool = True, duration_limit_s: Optional[int] = None,
+                 code_error_aid_queue: 'Optional[Queue[Optional[int]]]' = None,
+                 duration_limit_s: Optional[int] = None,
                  put_timeout_s: float = 30.0):
         super().__init__(name)
         self.aid_queue = aid_queue
         self.record_queue = record_queue
         self.service = service
-        self.update_if_code_error = update_if_code_error
+        # where CodeError aids go for a bounded UpdateVideoJob pool to refresh.
+        # None -> code errors are only counted (no metadata refresh).
+        self.code_error_aid_queue = code_error_aid_queue
         self.duration_limit_s = duration_limit_s
         self.duration_limit_due_ts_s = None
         self.put_timeout_s = put_timeout_s
-
-    def _update_video_with_own_session(self, aid: int):
-        """
-        Run the CodeError -> update_video fallback on a SHORT-LIVED session.
-
-        This must NOT hold a pooled connection for the worker's lifetime. It
-        used to: a lazy self.session was opened on the first CodeError and kept
-        until cleanup(). With 250 workers against a 200-connection pool
-        (pool_size=50 + max_overflow=150), a full scan spreads enough CodeErrors
-        across workers that every worker eventually pins a connection -- the
-        pool is then exhausted, the batch writer cannot get a connection to
-        drain record_queue, record_queue fills to its cap, and every fetcher
-        blocks forever in put() while still holding the connections the writer
-        needs. That is a deadlock, and it hung the 2026-07-15 04:00 full scan.
-
-        A fetcher needs the DB for well under 1% of aids, so it takes a
-        connection only for that call and gives it straight back.
-        """
-        session = Session()
-        try:
-            return update_video(aid, self.service, session)
-        except Exception:
-            try:
-                session.rollback()
-            except Exception:
-                pass
-            raise
-        finally:
-            session.close()  # back to the pool immediately
 
     def _put_record(self, record) -> bool:
         """Bounded put with a timeout. False -> queue still full, caller decides."""
@@ -106,21 +83,13 @@ class FetchVideoRecordJob(Job):
                 record = fetch_video_record_via_video_view(
                     aid, self.service, out_stat=stage_stat)
             except CodeError as e:
-                if self.update_if_code_error:
-                    self.logger.info(f'Code error occurred. Now start update video. aid: {aid}')
-                    try:
-                        # short-lived session: rollback + close are handled
-                        # inside, so no pooled connection outlives this call
-                        tdd_video_logs = self._update_video_with_own_session(aid)
-                    except Exception as e2:
-                        self.logger.error(f'Fail to update video info. aid: {aid}, error: {e2}')
-                        self.stat.condition['update_exception'] += 1
-                    else:
-                        for log in tdd_video_logs:
-                            self.logger.info(
-                                f'Update video info. aid: {aid}, attr: {log.attr}, {log.oldval} -> {log.newval}')
-                        self.logger.debug(f'{len(tdd_video_logs)} log(s) found. aid: {aid}')
-                        self.stat.condition[f'{len(tdd_video_logs)}_update'] += 1
+                # hand off to the UpdateVideoJob pool: refreshing tdd_video.code
+                # is what drops this aid out of future need_insert lists, but it
+                # is DB work and must not happen on a fetch worker
+                if self.code_error_aid_queue is not None:
+                    self.code_error_aid_queue.put(aid)
+                    self.logger.debug(
+                        f'Code error, queued for video update. aid: {aid}, error: {e}')
                 else:
                     self.logger.error(f'Fail to fetch video record. aid: {aid}, error: {e}')
                 self.stat.condition['code_error'] += 1

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -88,7 +88,7 @@ class FetchVideoRecordJob(Job):
                 # is DB work and must not happen on a fetch worker
                 if self.code_error_aid_queue is not None:
                     self.code_error_aid_queue.put(aid)
-                    self.logger.debug(
+                    self.logger.info(
                         f'Code error, queued for video update. aid: {aid}, error: {e}')
                 else:
                     self.logger.error(f'Fail to fetch video record. aid: {aid}, error: {e}')

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -64,7 +64,12 @@ class FetchVideoRecordJob(Job):
 
         while True:
             if self.duration_limit_due_ts_s is not None and get_ts_s() >= self.duration_limit_due_ts_s:
-                self.logger.info(f'Duration limit reached. Now exit.')
+                self.logger.info(f'Duration limit reached. Now exit. '
+                                 f'{self.aid_queue.qsize()} aid(s) left unfetched.')
+                # surface the cut in the pool summary, not just in a log line:
+                # on the 04:00 full scan this is THE number that says whether we
+                # finished inside the 40-minute window
+                self.stat.condition['duration_limit_reached'] += 1
                 break
 
             # get_nowait instead of empty()+get(): the latter races when several

--- a/job/JobStat.py
+++ b/job/JobStat.py
@@ -21,10 +21,14 @@ class JobStat:
             return 0
         return self.total_duration_ms // self.total_count
 
-    def get_summary(self, separator=', ') -> str:
+    def get_summary(self, label: Optional[str] = None, separator=', ') -> str:
+        # label identifies WHICH pool this is (matching its PROGRESS / STAGE AVG
+        # lines). A run emits several of these -- fetch, db-writer, video-update
+        # -- and without it they are indistinguishable in the log.
+        header = '## job stat summary' if label is None else f'## job stat summary [{label}]'
         time_str = f'total count: {self.total_count}, average duration: {format_ts_ms(self.get_avg_duration_ms())}'
         condition_str = separator.join([f'- {key}: {value}' for key, value in self.condition.items()])
-        return separator.join(['## job stat summary', time_str, '### conditions', condition_str])
+        return separator.join([header, time_str, '### conditions', condition_str])
 
     def __add__(self, other):
         new_job_stat = JobStat()

--- a/job/UpdateVideoJob.py
+++ b/job/UpdateVideoJob.py
@@ -82,7 +82,7 @@ class UpdateVideoJob(Job):
                 except Exception:
                     pass
                 self.logger.error(f'Fail to update video info. aid: {aid}, error: {e}')
-                self.stat.condition['exception'] += 1
+                self.stat.condition['update_exception'] += 1
             else:
                 for log in tdd_video_logs:
                     self.logger.info(f'Update video info. aid: {aid}, '

--- a/job/UpdateVideoJob.py
+++ b/job/UpdateVideoJob.py
@@ -1,42 +1,98 @@
 from .Job import Job
 from db import Session
 from service import Service
-from queue import Queue
+from queue import Queue, Empty
 from task import update_video
 from timer import Timer
-from util import b2a, format_ts_ms
+from util import format_ts_ms, get_ts_s, ts_s_to_str
+from typing import Optional
 
 __all__ = ['UpdateVideoJob']
 
 
 class UpdateVideoJob(Job):
-    def __init__(self, name: str, bvid_queue: Queue[str], service: Service):
+    """
+    Refresh tdd_video metadata for aids drained from aid_queue.
+
+    Two producers use this:
+    - 15_update-video-info.py: pre-fills the queue, then puts one sentinel per
+      worker.
+    - 51_hourly-video-record-add.py: FetchVideoRecordJob pushes an aid here
+      whenever the view api returns a CodeError (deleted / hidden / -403 video).
+      Writing tdd_video.code is what drops that aid out of future need_insert
+      lists (they filter code == 0), so this is load-bearing, not just
+      housekeeping. Running it HERE rather than inline in the fetcher keeps
+      fetchers 100% DB-free and caps DB concurrency from this path at the
+      worker count instead of letting all 250 fetchers hit the DB at will --
+      that unbounded coupling is what deadlocked the 2026-07-15 04:00 scan.
+
+    Terminates on a None sentinel, so it can run CONCURRENTLY with a producer
+    (an empty queue means "wait", not "done"). Producers must put one None per
+    worker after they finish; being FIFO, each sentinel arrives behind every
+    aid. `duration_limit_s` is a hard stop so this can never push the run past
+    its window.
+    """
+
+    def __init__(self, name: str, aid_queue: 'Queue[Optional[int]]', service: Service,
+                 duration_limit_s: Optional[int] = None, poll_timeout_s: float = 1.0):
         super().__init__(name)
-        self.bvid_queue = bvid_queue
+        self.aid_queue = aid_queue
         self.service = service
+        self.duration_limit_s = duration_limit_s
+        self.duration_limit_due_ts_s = None
+        self.poll_timeout_s = poll_timeout_s
         self.session = Session()
 
     def process(self):
-        while not self.bvid_queue.empty():
-            bvid = self.bvid_queue.get()
-            self.logger.debug(f'Now start update video info. bvid: {bvid}')
+        if self.duration_limit_s is not None:
+            self.duration_limit_due_ts_s = get_ts_s() + self.duration_limit_s
+            self.logger.info(f'Duration limit due at {ts_s_to_str(self.duration_limit_due_ts_s)}.')
+
+        while True:
+            if (self.duration_limit_due_ts_s is not None
+                    and get_ts_s() >= self.duration_limit_due_ts_s):
+                self.logger.info(f'Duration limit reached. Now exit. '
+                                 f'{self.aid_queue.qsize()} aid(s) left unprocessed.')
+                self.stat.condition['duration_limit_reached'] += 1
+                break
+
+            # blocking get with timeout, NOT `while not empty(): get()`: the
+            # latter races -- two workers both see a non-empty queue, both call
+            # get(), and the loser blocks forever on the last item. A timeout
+            # also lets us re-check the duration limit while idle.
+            try:
+                aid = self.aid_queue.get(timeout=self.poll_timeout_s)
+            except Empty:
+                continue  # producer may still be running; sentinel ends us
+
+            if aid is None:  # sentinel: producer finished
+                break
+
+            self.logger.debug(f'Now start update video info. aid: {aid}')
             timer = Timer()
             timer.start()
 
             try:
-                tdd_video_logs = update_video(b2a(bvid), self.service, self.session)
+                tdd_video_logs = update_video(aid, self.service, self.session)
             except Exception as e:
-                self.logger.error(f'Fail to update video info. bvid: {bvid}, error: {e}')
+                # roll back, else the failed transaction poisons this session
+                # and every subsequent aid on this worker fails too
+                try:
+                    self.session.rollback()
+                except Exception:
+                    pass
+                self.logger.error(f'Fail to update video info. aid: {aid}, error: {e}')
                 self.stat.condition['exception'] += 1
             else:
                 for log in tdd_video_logs:
-                    self.logger.info(f'Update video info. bvid: {bvid}, attr: {log.attr}, {log.oldval} -> {log.newval}')
-                self.logger.debug(f'{len(tdd_video_logs)} log(s) found. bvid: {bvid}')
+                    self.logger.info(f'Update video info. aid: {aid}, '
+                                     f'attr: {log.attr}, {log.oldval} -> {log.newval}')
+                self.logger.debug(f'{len(tdd_video_logs)} log(s) found. aid: {aid}')
                 self.stat.condition[f'{len(tdd_video_logs)}_update'] += 1
 
             timer.stop()
             self.logger.debug(f'Finish update video info. '
-                              f'bvid: {bvid}, duration: {format_ts_ms(timer.get_duration_ms())}')
+                              f'aid: {aid}, duration: {format_ts_ms(timer.get_duration_ms())}')
             self.stat.total_count += 1
             self.stat.total_duration_ms += timer.get_duration_ms()
 


### PR DESCRIPTION
Follow-up to #33, which fixed the *symptom* of the 04:00 deadlock. This removes the *cause*.

## The problem: fetchers were doing DB work

#28 established a clean invariant — **fetchers do HTTP only, never touch the DB**. The inline `CodeError → update_video` call was the one place that broke it, and that's exactly what deadlocked the 2026-07-15 04:00 full scan. Three costs beyond the deadlock:

1. **Unbounded DB concurrency from the fetch tier.** Any of the 250 fetchers could independently decide to hit the DB. Nothing capped it.
2. **It burned a fetch slot** on seconds of DB work — one of only 250 slots otherwise turning over every ~500ms.
3. **It reintroduced the payload bloat #30 just removed.** `update_video` calls the **full, untrimmed** view endpoint, pulling a 200KB–2.8MB response through the 3 Mbps link per code error.

## The change

```
aid_queue -> FetchVideoRecordJob x250   (HTTP only, ZERO DB)
              |
              +-- ok        -> fetched_record_queue -> BatchInsertVideoRecordJob -> downstream
              |
              +-- CodeError -> code_error_aid_queue -> UpdateVideoJob x10  (DB, bounded)
```

**DB connections held by the fetch tier: up to 250 → exactly zero.** `FetchVideoRecordJob` no longer even imports `Session`. The update pools cap DB concurrency at 5 (c0) + 10 (c30).

The update pool runs **concurrently** with fetching, so it doesn't extend the run, and carries the **same `duration_limit_s`** — the whole upstream stage stays hard-capped at 40 minutes.

Refreshing `tdd_video.code` is load-bearing, not just housekeeping: it's what drops a dead aid out of future `need_insert` lists (they filter `code == 0`). So it's kept — just moved off the fetch workers.

## UpdateVideoJob modernised, not replaced

- **Takes aids instead of bvids** (it used to `b2a()` internally; callers now convert, and `15_` passes `b2a(bvid)`).
- **Sentinel-terminated**, so an empty queue means "wait" — it can run alongside a live producer. This retires `while not queue.empty(): queue.get()`, which **races**: two workers both see a non-empty queue, both call `get()`, and the loser blocks forever on the last item. That was a **latent hang in `15_`**.
- **Rolls back on exception**, so a failed statement can't poison the session and cascade to every subsequent aid on that worker (the #18 bug pattern).
- **Optional `duration_limit_s`** hard stop.

`15_update-video-info.py` is updated for the new contract — worth watching its next run (06:00 daily).

## Verified

```
1. fetcher: records=5  code_error_queued=5  conditions={'success': 5, 'code_error': 5}
2. update pool: updated=20  workers_hung=0  peak_sessions=4  leaked=0   <- slow concurrent producer
3. duration limit: exited after 1.2s (cap 2s), 496 aids left, conditions={'duration_limit_reached': 1}
4. 15_ pattern: 1000/1000 updated, 0 workers hung, queue left=0
```

Test 2 is the one the old `empty()`/`get()` loop would have raced on — items arriving slowly while workers are already running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)