### PR TITLE
fix: stop escaping CJK to \uXXXX in logs

### DIFF
--- a/util/logging_init.py
+++ b/util/logging_init.py
@@ -12,13 +12,25 @@ if not os.path.exists(LOG_DIR):
 
 class UnescapeFormatter(logging.Formatter):
     """
-    Unescape escaped character for logging. For example, print '\n' as '\\n'.
+    Collapse a log record onto a single line by escaping line-breaking control
+    characters (newline, carriage return, tab) -- video descriptions contain
+    newlines, and an un-collapsed record would break across many lines and
+    wreck line-based grep.
+
+    Only those control chars are escaped. The previous implementation used
+    str.encode('unicode_escape'), which ALSO escaped every non-ASCII character
+    to \\uXXXX -- turning CJK text (titles, descriptions) into unreadable escape
+    sequences in the log. Printable Unicode is now left intact (the file
+    handlers are opened as utf-8).
     """
 
     def format(self, record):
         original = logging.Formatter.format(self, record)
-        escaped = original.encode('unicode_escape').decode()
-        return escaped
+        return (original
+                .replace('\\', '\\\\')
+                .replace('\r', '\\r')
+                .replace('\n', '\\n')
+                .replace('\t', '\\t'))
 
 
 def logging_init(format=DEFAULT_LOG_FORMAT,
@@ -42,7 +54,9 @@ def logging_init(format=DEFAULT_LOG_FORMAT,
 
     for level in file_handler_levels:
         level_name = logging.getLevelName(level)
-        file_handler = logging.FileHandler(filename=os.path.join(LOG_DIR, f'{file_prefix}_{level_name}.log'))
+        file_handler = logging.FileHandler(
+            filename=os.path.join(LOG_DIR, f'{file_prefix}_{level_name}.log'),
+            encoding='utf-8')  # CJK titles/descs are no longer escaped, write them as utf-8
         file_handler.setLevel(level)
         handlers.append(file_handler)
 


### PR DESCRIPTION
## Symptom

Chinese/Japanese text in logs came out as escape sequences:
```
Update video info. bvid: ..., attr: desc, 本家：黄金数...
```
instead of `本家：黄金数...`.

## Cause

`UnescapeFormatter` (in `util/logging_init.py`) is misnamed and did the opposite of its docstring:
```python
escaped = original.encode('unicode_escape').decode()   # escapes ALL non-ASCII to \uXXXX
```
`unicode_escape` escapes every non-ASCII character, so CJK titles and descriptions became `\uXXXX` runs.

## Fix

The formatter's actual purpose is legitimate — collapse each record onto **one line**, because a video `desc` contains literal newlines that would otherwise break the record across many lines and wreck line-based grep. But it should escape only the *line-breaking control characters*, not printable Unicode:

```python
return (original.replace('\\', '\\\\')
                .replace('\r', '\\r')
                .replace('\n', '\\n')
                .replace('\t', '\\t'))
```

File handlers are now opened with `encoding='utf-8'` so the preserved CJK writes correctly. (Previously every record was pure ASCII, so the handler encoding never mattered.)

Shared by every script via `logging_init`, so all logs get readable CJK from the next run — while keeping the single-line-per-record property that grep relies on.

## Verified

```
WRITTEN: [...][t][INFO]: Update video info. aid: 123, attr: desc, 本家：黄金数-いよわ\nust：肺叶\nhttps://x -> 错付真心
readable CJK?        True
single line?         True
newline shown as \n? True
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)