### PR TITLE
feat: video_tags non-fatal in update_video; JobPool + 50 workers in 15_

### DIFF
--- a/15_update-video-info.py
+++ b/15_update-video-info.py
@@ -67,7 +67,6 @@ def update_video_info():
         progress_total=len(bvids),
         progress_label='video-update',
         progress_interval_s=10.0,  # slow long job -- 10s keeps the log readable
-        ensure_conditions=['0_update', '1_update', 'update_exception'],
         logger_name=script_id)
     pool.start()
     logger.info(f'{job_num} job(s) started.')

--- a/15_update-video-info.py
+++ b/15_update-video-info.py
@@ -4,7 +4,7 @@ from serverchan import sc_send_summary
 from util import logging_init, get_week_day, fullname, b2a
 from timer import Timer
 from queue import Queue
-from job import UpdateVideoJob, JobStat
+from job import UpdateVideoJob, JobPool
 import logging
 
 script_id = '15'
@@ -49,32 +49,29 @@ def update_video_info():
     # 51_). This also retires the old `while not queue.empty(): queue.get()`
     # loop, which races -- two workers both see a non-empty queue, both call
     # get(), and the loser blocks forever on the last item.
-    job_num = 20
+    # 50 workers (was 20): this is worker-bound with inbound headroom (the
+    # full-view responses are large but the downlink is fat), so more workers
+    # cut the multi-hour runtime roughly proportionally. It hits the full-view
+    # Lambda -- a different endpoint than 51_'s trimmed one -- and sends little
+    # outbound per request, so it does not meaningfully slow 51_'s hourly runs
+    # even when it overruns. No duration cap: 15_ runs to completion.
+    job_num = 50
     for _ in range(job_num):
-        aid_queue.put(None)
+        aid_queue.put(None)  # one sentinel per worker (sentinel-terminated)
     logger.info(f'{len(bvids)} aids put into queue.')
 
-    # create jobs
-    job_list = []
-    for i in range(job_num):
-        job_list.append(UpdateVideoJob(f'job_{i}', aid_queue, service))
-
-    # start jobs
-    for job in job_list:
-        job.start()
+    # JobPool gives a per-interval PROGRESS heartbeat over the multi-hour run
+    # (previously blind) and merges the workers' stats.
+    pool = JobPool(
+        [UpdateVideoJob(f'job_{i}', aid_queue, service) for i in range(job_num)],
+        progress_total=len(bvids),
+        progress_label='video-update',
+        progress_interval_s=10.0,  # slow long job -- 10s keeps the log readable
+        ensure_conditions=['0_update', '1_update', 'update_exception'],
+        logger_name=script_id)
+    pool.start()
     logger.info(f'{job_num} job(s) started.')
-
-    # wait for jobs
-    for job in job_list:
-        job.join()
-
-    # collect statistics
-    job_stat_list: list[JobStat] = []
-    for job in job_list:
-        job_stat_list.append(job.stat)
-
-    # merge statistics counters
-    job_stat_merged = sum(job_stat_list, JobStat())
+    job_stat_merged = pool.join()
 
     session.close()
 
@@ -83,7 +80,7 @@ def update_video_info():
     # summary
     logger.info(f'Finish {script_fullname}!')
     logger.info(timer.get_summary())
-    logger.info(job_stat_merged.get_summary())
+    logger.info(job_stat_merged.get_summary('video-update'))
     sc_send_summary(script_fullname, timer, job_stat_merged)
 
 

--- a/task/task.py
+++ b/task/task.py
@@ -503,15 +503,27 @@ def update_video(aid: int, service: Service, session: Session, out_context: dict
                 video_update_logs.append(
                     TddVideoLog(added, aid, bvid,
                                 'staff', f'mid: {curr_staff_item.mid}; title: {curr_staff_item.title}', None))
-        # update tags string
-        new_tags = get_video_tags_str(aid, service)
-        new_tags_sorted = ';'.join(sorted(new_tags.split(';')))
-        curr_tags_sorted = ';'.join(sorted(curr_video.tags.split(';')))
-        if new_tags_sorted != curr_tags_sorted:
-            video_update_logs.append(
-                TddVideoLog(added, aid, bvid,
-                            'tags', curr_video.tags, new_tags))
-            curr_video.tags = new_tags
+        # update tags string. The video_tags endpoint is separate from the
+        # view and unstable (frequent ResponseError). It must NOT be fatal: the
+        # view fetch already succeeded and its changes (title, tname, code,
+        # state, ...) are staged on curr_video, so letting a tags failure
+        # propagate here would roll ALL of them back at the commit below --
+        # dropping real metadata/reactivation updates over a flaky tags call.
+        # On failure, skip tags this pass (it gets another chance next cycle)
+        # and keep the view-based changes.
+        try:
+            new_tags = get_video_tags_str(aid, service)
+        except ServiceError as e:
+            logger.warning(
+                f'Skip tags update (view changes kept). aid: {aid}, error: {e}')
+        else:
+            new_tags_sorted = ';'.join(sorted(new_tags.split(';')))
+            curr_tags_sorted = ';'.join(sorted(curr_video.tags.split(';')))
+            if new_tags_sorted != curr_tags_sorted:
+                video_update_logs.append(
+                    TddVideoLog(added, aid, bvid,
+                                'tags', curr_video.tags, new_tags))
+                curr_video.tags = new_tags
 
     # commit changes
     try:


### PR DESCRIPTION
`15_update-video-info` is the **sole reconciler** of `tdd_video` metadata (`code`, `tid`, `title`, `tname`, …) since the C0/C30 merge (#37), and its recent runs took **2.5–2.8h with zero visibility**. Reviewed a 100k-line log slice; three changes.

## A — `video_tags` is now non-fatal in `update_video` (the real fix)

Every `update_exception` in 15_ (14–289/run) is a `ResponseError` on the **separate, unstable** `video_tags` endpoint. Tracing `update_video` (`task/task.py`): it stages all the **view-based** changes on the row (title, tname, **code**, state…), *then* fetches tags, *then* commits. So a tags failure propagated **before** the commit and the whole update rolled back — **silently discarding real metadata changes, including `code` dead↔alive reactivation, over a flaky tags call.**

Post-merge this matters more: 15_ is the only path that reactivates a returned video, and it was dropping those updates whenever tags happened to be flaky.

Now the tags fetch is caught: on `ServiceError`, log and **skip tags for this pass** (retried next cycle), and **keep + commit the view changes**. Same class of bug #21 fixed for 51_. Benefits every `update_video` caller (15_ and 51_'s delegated updater).

Verified both paths:
```
tags-FAIL -> attrs: ['title', 'pubdate', 'mid', 'hasstaff']   (committed, tags skipped)
tags-OK   -> attrs: ['title', 'pubdate', 'mid', 'hasstaff', 'tags']
```

## B — `JobPool` in 15_ (observability)

15_ ran a manual job-list/`join`/`sum` with **no progress signal** for 2.5h. Now it uses `JobPool` like 51_: a **per-10s `PROGRESS` heartbeat** (done/total/%/rate) and merged stats, replacing the boilerplate. **No duration cap** — 15_ runs to completion by design.

## C — workers 20 → 50 (throughput)

15_ is **worker-bound with inbound headroom** (large full-view responses, fat downlink; workers ~92% busy at 20). More workers cut the multi-hour runtime roughly proportionally. It hits the **full-view** Lambda — a different endpoint than 51_'s trimmed one — and sends little outbound per request, so it won't meaningfully slow 51_'s hourly runs even if it overruns.

## Not changed (per review)
- **serverchan** summary (fails 400 every run) — left as-is; a new notification path is planned.
- **1/7 positional rotation** — kept as-is; still fine.
- **`tname` churn** (dominant change type) — expected: Bilibili is deprecating `tname` toward empty; it settles once most rows are updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)