### PR TITLE
feat: JobPool + heartbeat in 16_; fix UpdateMemberJob race (easy tier)

### DIFF
--- a/16_update-member-info.py
+++ b/16_update-member-info.py
@@ -4,7 +4,7 @@ from queue import Queue
 from service import Service
 from serverchan import sc_send_summary
 from timer import Timer
-from job import UpdateMemberJob, JobStat
+from job import UpdateMemberJob, JobPool
 import logging
 
 script_id = '16'
@@ -36,36 +36,33 @@ def update_member_info():
         if idx % 7 == week_day:
             mids.append(mid)
 
-    logger.info(f'Will update {len(mids)} videos info.')
+    logger.info(f'Will update {len(mids)} members info.')
 
     # put mid into queue
     mid_queue: Queue[int] = Queue()
     for mid in mids:
         mid_queue.put(mid)
-    logger.info(f'{mid_queue.qsize()} mids put into queue.')
+    # one sentinel per worker (UpdateMemberJob is sentinel-terminated)
+    # 50 workers (was 20): each member spends most of its ~25s parked in the
+    # member-card anti-crawler 60s sleep, so more workers just means more
+    # members sleeping in parallel -- worth trying to cut the multi-hour runtime.
+    # (The proper fix for the anti-crawler is a separate, thornier change.)
+    job_num = 50
+    for _ in range(job_num):
+        mid_queue.put(None)
+    logger.info(f'{len(mids)} mids put into queue.')
 
-    # create jobs
-    job_num = 20
-    job_list = []
-    for i in range(job_num):
-        job_list.append(UpdateMemberJob(f'job_{i}', mid_queue, service))
-
-    # start jobs
-    for job in job_list:
-        job.start()
+    # JobPool gives a per-30s PROGRESS heartbeat over the multi-hour run
+    # (previously blind) and merges the workers' stats.
+    pool = JobPool(
+        [UpdateMemberJob(f'job_{i}', mid_queue, service) for i in range(job_num)],
+        progress_total=len(mids),
+        progress_label='member-update',
+        progress_interval_s=30.0,  # very slow job (~25s/member) -- 30s is plenty
+        logger_name=script_id)
+    pool.start()
     logger.info(f'{job_num} job(s) started.')
-
-    # wait for jobs
-    for job in job_list:
-        job.join()
-
-    # collect statistics
-    job_stat_list: list[JobStat] = []
-    for job in job_list:
-        job_stat_list.append(job.stat)
-
-    # merge statistics counters
-    job_stat_merged = sum(job_stat_list, JobStat())
+    job_stat_merged = pool.join()
 
     session.close()
 
@@ -74,7 +71,7 @@ def update_member_info():
     # summary
     logger.info(f'Finish {script_fullname}!')
     logger.info(timer.get_summary())
-    logger.info(job_stat_merged.get_summary())
+    logger.info(job_stat_merged.get_summary('member-update'))
     sc_send_summary(script_fullname, timer, job_stat_merged)
 
 

--- a/job/UpdateMemberJob.py
+++ b/job/UpdateMemberJob.py
@@ -1,24 +1,43 @@
 from .Job import Job
 from db import Session
 from service import Service
-from queue import Queue
+from queue import Queue, Empty
 from task import update_member
 from timer import Timer
 from util import format_ts_ms
+from typing import Optional
 
 __all__ = ['UpdateMemberJob']
 
 
 class UpdateMemberJob(Job):
-    def __init__(self, name: str, mid_queue: Queue[int], service: Service):
+    """
+    Refresh tdd_member info for mids drained from mid_queue. Terminates on a None
+    sentinel: the producer must put one None per worker after filling the queue.
+
+    Sentinel termination (not `while not queue.empty(): queue.get()`) fixes a
+    race -- two workers both see a non-empty queue, both call get(), and the
+    loser blocks forever on the last item. A blocking get with timeout also lets
+    the worker exit cleanly.
+    """
+
+    def __init__(self, name: str, mid_queue: 'Queue[Optional[int]]', service: Service,
+                 poll_timeout_s: float = 1.0):
         super().__init__(name)
         self.mid_queue = mid_queue
         self.service = service
+        self.poll_timeout_s = poll_timeout_s
         self.session = Session()
 
     def process(self):
-        while not self.mid_queue.empty():
-            mid = self.mid_queue.get()
+        while True:
+            try:
+                mid = self.mid_queue.get(timeout=self.poll_timeout_s)
+            except Empty:
+                continue  # producer may still be filling; sentinel ends us
+            if mid is None:  # sentinel: producer finished
+                break
+
             self.logger.debug(f'Now start update member info. mid: {mid}')
             timer = Timer()
             timer.start()
@@ -26,11 +45,18 @@ class UpdateMemberJob(Job):
             try:
                 tdd_member_logs = update_member(mid, self.service, self.session)
             except Exception as e:
+                # roll back, else the failed transaction poisons this session
+                # and every subsequent mid on this worker fails too
+                try:
+                    self.session.rollback()
+                except Exception:
+                    pass
                 self.logger.error(f'Fail to update member info. mid: {mid}, error: {e}')
-                self.stat.condition['exception'] += 1
+                self.stat.condition['update_exception'] += 1
             else:
                 for log in tdd_member_logs:
-                    self.logger.info(f'Update member info. bvid: {mid}, attr: {log.attr}, {log.oldval} -> {log.newval}')
+                    self.logger.info(f'Update member info. mid: {mid}, '
+                                     f'attr: {log.attr}, {log.oldval} -> {log.newval}')
                 self.logger.debug(f'{len(tdd_member_logs)} log(s) found. mid: {mid}')
                 self.stat.condition[f'{len(tdd_member_logs)}_update'] += 1
 


### PR DESCRIPTION
The easy/hygiene tier for `16_update-member-info`, mirroring the 15_ modernization (#38). **`16_`'s deeper problem — 8.5h runtime from the member-card anti-crawler 60s-sleep × `retry=20` — is deliberately NOT fixed here**; that's a separate, more careful investigation.

## UpdateMemberJob
- **Sentinel-terminated** (one `None` per worker) instead of `while not queue.empty(): queue.get()`, which **races**: two workers both see a non-empty queue, both `get()`, and the loser blocks forever on the last item. Same latent hang fixed in `UpdateVideoJob`.
- **Rolls back on exception**, so a failed member can't poison the session and cascade to the rest of that worker's mids.
- Renamed `exception` → `update_exception` and fixed a log typo (`bvid:` → `mid:`), matching `UpdateVideoJob`.

## 16_
- Runs workers through **`JobPool`** → a **per-30s `PROGRESS` heartbeat** over the multi-hour run (previously **blind for 8.5 hours**) + merged stats, replacing the manual job-list/`join`/`sum`.
- **Workers 20 → 50**: each member spends most of its ~25s parked in the anti-crawler 60s sleep, so more workers just means more members sleeping in parallel — worth trying to cut the runtime while the real fix waits. (Easily reverted if it triggers *more* throttling.)
- Fixed the `"Will update N videos info"` copy-paste — it's members.

## Verified
```
updated 30/30, workers_hung=0   (slow concurrent producer)
PASS: sentinel-terminated, no hang, drains fully
```

## Not in this PR (the thorny tier)
The 8.5-hour runtime: `Service.get_member_card` handles `-352` anti-crawler with a `TMP sleep 60` + retry against the *same* endpoint (`retry=20`), logged **517,988** times. Fixing it (rotate endpoints on `-352` instead of sleeping; cut retries) touches the worker rate-limit strategy and deserves its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)