### PR TITLE
fix: retry the full-table-scan queries on transient DB timeout

### DIFF
--- a/db/operation.py
+++ b/db/operation.py
@@ -1,5 +1,6 @@
 from .models import TddVideo, TddMember, TddVideoStaff
 import logging
+import time
 logger_db = logging.getLogger('db')
 
 __all__ = ['DBOperation']
@@ -104,15 +105,40 @@ class DBOperation:
                             (e, {}), exc_info=True)
             return None
 
+    # full-table scans (all bvids / all mids) stream ~1M+ rows and occasionally
+    # trip the connection read_timeout when MySQL is busy (e.g. the 06:00 cron
+    # pile-up crashed 15_ this way). A transient timeout should not lose the
+    # whole daily run, so retry with backoff -- pool_pre_ping (see db/basic.py)
+    # hands back a live connection on the next attempt.
+    _FULL_SCAN_RETRIES = 3
+    _FULL_SCAN_BACKOFF_S = 5.0
+
+    @classmethod
+    def _query_first_col_with_retry(cls, session, sql):
+        # returns list of first-column values, or None if it ultimately fails
+        # (preserves the historical contract of the callers below)
+        for attempt in range(1, cls._FULL_SCAN_RETRIES + 1):
+            try:
+                result = session.execute(sql)
+                return list(r[0] for r in result)
+            except Exception as e:
+                # clear the failed/half-read transaction so the retry starts clean
+                try:
+                    session.rollback()
+                except Exception:
+                    pass
+                if attempt >= cls._FULL_SCAN_RETRIES:
+                    logger_db.error('Query failed after %d attempts: %s, error: %s'
+                                    % (cls._FULL_SCAN_RETRIES, sql, e), exc_info=True)
+                    return None
+                backoff = cls._FULL_SCAN_BACKOFF_S * attempt
+                logger_db.warning('Query attempt %d/%d failed, retrying in %.0fs: %s, error: %s'
+                                  % (attempt, cls._FULL_SCAN_RETRIES, backoff, sql, e))
+                time.sleep(backoff)
+
     @classmethod
     def query_all_video_bvids(cls, session):
-        try:
-            result = session.execute('select bvid from tdd_video')
-            return list(r[0] for r in result)
-        except Exception as e:
-            logger_db.error('Exception: %s, params: %s' %
-                            (e, {}), exc_info=True)
-            return None
+        return cls._query_first_col_with_retry(session, 'select bvid from tdd_video')
 
     @classmethod
     def query_member_mids(cls, offset, size, session):
@@ -127,13 +153,7 @@ class DBOperation:
 
     @classmethod
     def query_all_member_mids(cls, session):
-        try:
-            result = session.execute('select mid from tdd_member')
-            return list(r[0] for r in result)
-        except Exception as e:
-            logger_db.error('Exception: %s, params: %s' %
-                            (e, {}), exc_info=True)
-            return None
+        return cls._query_first_col_with_retry(session, 'select mid from tdd_member')
 
     @classmethod
     def _tid_filters(cls, is_tid_30):


### PR DESCRIPTION
## What happened

15_'s 06:00 run **crashed on its first query**. `query_all_video_bvids` runs `select bvid from tdd_video` — a **~1.33M-row full-table scan**. Under the 06:00 cron pile-up (the 51_ hourly run + 16_ still going + 13_ all hammering MySQL), a **>30s gap between result packets** tripped the connection's `read_timeout=30` (`db/basic.py`): `(2013, 'Lost connection to MySQL server during query (timed out)')`.

Then the fragility chain: `query_all_video_bvids` **caught it and returned `None`**, and 15_ crashed on `None[-5000:]`. 15_ was lost for the day (clean crash, no data loss — it's a read).

**Not caused by a recent PR** — this query runs before any of the changed code, and 15_ ran fine yesterday. But the 15_/16_ worker bumps (#38/#39) raise DB contention during the 06:00–08:00 overlap, so this failure mode gets *more* likely going forward — hardening the daily bootstrap query is well-timed.

## Fix

These full scans stream ~1M+ rows and will keep hitting occasional timeouts under load. Route `query_all_video_bvids` and its twin `query_all_member_mids` (used by 16_/17_/03_) through a shared retry helper:

- on failure, **roll back** (clear the half-read transaction) and **retry with backoff** — 3 attempts, 5s then 10s;
- `pool_pre_ping` (already set in `db/basic.py`) hands back a **live connection** on the retry;
- **contract preserved**: `None` only after all attempts fail, so the 4 callers are unchanged.

Scope kept tight per the plan — no change to `read_timeout` or the query shape (bigger shared-engine decisions).

## Verified
```
transient-then-ok : ['bvA','bvB']  attempts: 2  rollbacks: 1
persistent-fail   : None           attempts: 3
happy-path        : [1,2,3]        attempts: 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)