### PR TITLE
perf: C30 fetch workers 250 -> 300 (merged pipeline)

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -188,11 +188,13 @@ class VideoRecordAcquisitionJob(Job):
     (see git history for process_comprehensive et al., removed here). One aid
     set, one worker pool.
 
-    job_num=250: throughput is capped by the box's ~3Mbps OUTBOUND (request
-    headers + ACKs, ~500B/fetch), which saturates around 500-600/s regardless
-    of worker count -- more workers do not help. A single batch writer keeps up
-    comfortably (measured ~1000+ rec/s capacity vs the ~560/s network-capped
-    arrival), so no writer parallelism is needed.
+    job_num=300: matches the total concurrency the old split ran (250 c30 + 50
+    c0), which cleared the ~1.09M full scan in ~32 min. The first merged runs at
+    250 were a consistent ~35 min (~558/s) -- outbound (~3Mbps, request headers
+    + ACKs) is near saturation but not fully capped, so the extra 50 workers buy
+    back those ~3 min and, more usefully, headroom under the 40-min cap. A single
+    batch writer still keeps up comfortably (measured ~1000+ rec/s capacity vs
+    the ~560/s network-capped arrival), so no writer parallelism is needed.
     """
 
     def __init__(self, time_task: str, record_queue: Queue[RecordNew]):
@@ -210,7 +212,7 @@ class VideoRecordAcquisitionJob(Job):
 
         fetch_and_batch_insert_records(
             need_insert_aid_list, self.record_queue,
-            job_num=250,
+            job_num=300,
             fetch_label='record-fetch',
             writer_label='record-db-writer',
             logger_name='VideoRecordAcquisitionJob',


### PR DESCRIPTION
Two consistent merged full scans settle the 250-vs-300 question we parked after the C0/C30 merge (#37).

| | 07-19 04:00 | 07-20 04:00 |
|---|---|---|
| aids | 1,085,892 | 1,085,732 |
| http/aid | 448 ms | 446 ms |
| rate | ~557/s | ~558/s |
| total run | 35m 27s | 35m 18s |

250 workers is **consistently ~35 min** — a steady ~3 min slower than the old split's ~32 min, which effectively ran **300** concurrent workers (250 C30 + 50 C0). So outbound (~3 Mbps) is *near* saturation but not a hard cap at 250; the extra 50 workers:

1. **buy back the ~3 min** (→ ~32 min), and
2. **more usefully, widen headroom** under the 40-min cap. 35 min is only ~12% margin; a slow-upstream night (http 446 → ~550ms) could push it toward truncation. ~32 min gives real buffer.

**300 is not speculative** — it's the concurrency the split ran daily for weeks against this same endpoint, so worst case it performs like the split did. `pool_maxsize` derives from `job_num` (→ 332), so keep-alive stays intact.

Verify on the next 04:00 full scan: `duration_limit_reached: 0`, run ≈ 32 min, no new `record_dropped_queue_full`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)