### PR TITLE
feat: show DB pool checkout count in the JobPool heartbeat

### DIFF
--- a/job/JobPool.py
+++ b/job/JobPool.py
@@ -3,6 +3,7 @@ import logging
 from collections import Counter
 from threading import Thread, Event
 from typing import Optional
+from db import engine
 from .Job import Job
 from .JobStat import JobStat
 
@@ -83,6 +84,20 @@ class JobPool:
     def _fmt_ms(ms: float) -> str:
         return f'{ms / 1000:.2f}s' if ms >= 1000 else f'{ms:.0f}ms'
 
+    @staticmethod
+    def _pool_status_str() -> str:
+        # live DB connection-pool usage: how many connections the process holds
+        # (checked out) right now, vs the base pool size. A worker that holds a
+        # session across a slow HTTP fetch / sleep keeps a connection checked
+        # out the whole time, so this reveals connection pressure directly.
+        # Cheap: attribute reads, no DB round-trip. Best-effort (pool type may
+        # vary), so never let it break the heartbeat.
+        try:
+            pool = engine.pool
+            return f'pool: {pool.checkedout()}/{pool.size()} checked out'
+        except Exception:
+            return ''
+
     def _report_progress(self):
         last_done = 0
         last_ts = time.time()
@@ -122,6 +137,9 @@ class JobPool:
                     cond_str = ', '.join(
                         f'{k}: {v}' for k, v in counts.most_common())
                     msg = f'{msg} | {cond_str}'
+            pool_str = self._pool_status_str()
+            if pool_str:
+                msg = f'{msg} | {pool_str}'
             self.logger.info(msg)
             last_done, last_ts = done, now
             if stopped:


### PR DESCRIPTION
**Day 1** of the short-lived-session measurement plan. Ships the instrumentation *first* so tomorrow's 15_/16_ runs capture the **before** baseline on the same metric the **after** runs will use.

## What

Adds a live field to every `PROGRESS` line:

```
PROGRESS video-update: 40000 done, 154376 left (20.6%), 35/s | 0_update: 40000 | pool: 47/50 checked out
```

`pool.checkedout()` = DB connections the process currently holds; `pool.size()` = base pool size (50). A worker that holds a session across a slow HTTP fetch or 60s sleep keeps a connection checked out the whole time — so this reveals connection pressure directly, per process.

## Why now, before the fix

The 50-worker `UpdateVideoJob`/`UpdateMemberJob` currently hold a session for the worker's life, so this should read **~50/50** the whole run. After the short-lived-session change (Day 2), it should drop to **single digits**. Same metric, same runs — a clean empirical before/after instead of an assumed "it's 50."

## Properties

- **Cheap:** attribute reads only, no DB round-trip.
- **Best-effort:** wrapped so it can never break the heartbeat.
- **Permanent:** stays in as an ongoing health signal — any future job that regresses to holding connections shows up immediately.

## Verified
```
import OK
idle pool status: 'pool: 0/50 checked out'
```
(renders from pool state with no DB connection). Applies to all JobPool users: 51_ (record-fetch/writer/update), 15_, 16_.

🤖 Generated with [Claude Code](https://claude.com/claude-code)