### PR TITLE
feat: JobPool + heartbeat in 17_; fix AddMemberFollowerRecordJob race

### DIFF
--- a/17_add-member-follower-record.py
+++ b/17_add-member-follower-record.py
@@ -4,7 +4,7 @@ from util import logging_init, fullname
 from serverchan import sc_send_summary
 from queue import Queue
 from timer import Timer
-from job import AddMemberFollowerRecordJob, JobStat
+from job import AddMemberFollowerRecordJob, JobPool
 import logging
 
 script_id = '17'
@@ -29,30 +29,23 @@ def add_member_follower_record():
     mid_queue: Queue[int] = Queue()
     for mid in mids:
         mid_queue.put(mid)
-    logger.info(f'{mid_queue.qsize()} mids put into queue.')
-
-    # create jobs
+    # one sentinel per worker (AddMemberFollowerRecordJob is sentinel-terminated)
     job_num = 20
-    job_list = []
-    for i in range(job_num):
-        job_list.append(AddMemberFollowerRecordJob(f'job_{i}', mid_queue, service))
+    for _ in range(job_num):
+        mid_queue.put(None)
+    logger.info(f'{len(mids)} mids put into queue.')
 
-    # start jobs
-    for job in job_list:
-        job.start()
+    # JobPool gives a per-30s PROGRESS heartbeat over the ~1h run (previously
+    # blind) and merges the workers' stats.
+    pool = JobPool(
+        [AddMemberFollowerRecordJob(f'job_{i}', mid_queue, service) for i in range(job_num)],
+        progress_total=len(mids),
+        progress_label='follower-record',
+        progress_interval_s=30.0,
+        logger_name=script_id)
+    pool.start()
     logger.info(f'{job_num} job(s) started.')
-
-    # wait for jobs
-    for job in job_list:
-        job.join()
-
-    # collect statistics
-    job_stat_list: list[JobStat] = []
-    for job in job_list:
-        job_stat_list.append(job.stat)
-
-    # merge statistics counters
-    job_stat_merged = sum(job_stat_list, JobStat())
+    job_stat_merged = pool.join()
 
     session.close()
 
@@ -61,7 +54,7 @@ def add_member_follower_record():
     # summary
     logger.info(f'Finish {script_fullname}!')
     logger.info(timer.get_summary())
-    logger.info(job_stat_merged.get_summary())
+    logger.info(job_stat_merged.get_summary('follower-record'))
     sc_send_summary(script_fullname, timer, job_stat_merged)
 
 

--- a/job/AddMemberFollowerRecordJob.py
+++ b/job/AddMemberFollowerRecordJob.py
@@ -1,24 +1,43 @@
 from .Job import Job
 from db import Session
 from service import Service
-from queue import Queue
+from queue import Queue, Empty
 from task import add_member_follower_record
 from timer import Timer
 from util import format_ts_ms
+from typing import Optional
 
 __all__ = ['AddMemberFollowerRecordJob']
 
 
 class AddMemberFollowerRecordJob(Job):
-    def __init__(self, name: str, mid_queue: Queue[int], service: Service):
+    """
+    Fetch a member's follower/following counts and append a follower record.
+    Terminates on a None sentinel: the producer must put one None per worker
+    after filling the queue.
+
+    Sentinel termination (not `while not queue.empty(): queue.get()`) fixes a
+    race -- two workers both see a non-empty queue, both call get(), and the
+    loser blocks forever on the last item.
+    """
+
+    def __init__(self, name: str, mid_queue: 'Queue[Optional[int]]', service: Service,
+                 poll_timeout_s: float = 1.0):
         super().__init__(name)
         self.mid_queue = mid_queue
         self.service = service
+        self.poll_timeout_s = poll_timeout_s
         self.session = Session()
 
     def process(self):
-        while not self.mid_queue.empty():
-            mid = self.mid_queue.get()
+        while True:
+            try:
+                mid = self.mid_queue.get(timeout=self.poll_timeout_s)
+            except Empty:
+                continue  # producer may still be filling; sentinel ends us
+            if mid is None:  # sentinel: producer finished
+                break
+
             self.logger.debug(f'Now start add member follower record. mid: {mid}')
             timer = Timer()
             timer.start()
@@ -26,7 +45,13 @@ class AddMemberFollowerRecordJob(Job):
             try:
                 new_follower_record = add_member_follower_record(mid, self.service, self.session)
             except Exception as e:
-                self.logger.error(f'Fail to update member info. mid: {mid}, error: {e}')
+                # roll back, else the failed transaction poisons this session
+                # and every subsequent mid on this worker fails too
+                try:
+                    self.session.rollback()
+                except Exception:
+                    pass
+                self.logger.error(f'Fail to add member follower record. mid: {mid}, error: {e}')
                 self.stat.condition['exception'] += 1
             else:
                 self.logger.debug(f'New member follower record {new_follower_record} added. mid: {mid}')


### PR DESCRIPTION
Foundation/hygiene pass for `17_add-member-follower-record`, matching the 15_/16_ treatment.

**17_ is the healthiest of the three** — 100% success (168,233/168,233), ~1h10m, and its `member_relation` endpoint is **not** anti-crawler'd (zero `-352`, zero sleeps). So this is consistency + latent-bug removal, not a fix.

## AddMemberFollowerRecordJob
- **Sentinel-terminated** (one `None` per worker) instead of `while not queue.empty(): queue.get()`, which **races**: two workers both see a non-empty queue, both `get()`, the loser blocks forever on the last item. Same latent hang fixed in the sibling jobs.
- **Rolls back on exception**, so a failed insert can't poison the session and cascade.
- Fixed a log typo (`"Fail to update member info"` → `"Fail to add member follower record"`).

## 17_
- Runs workers through **`JobPool`** → a **per-30s `PROGRESS` heartbeat** over the ~1h run (previously blind) + merged stats. Picks up the new `pool: N/20 checked out` field (#42) automatically.
- Worker count unchanged (20) — it's not throttled and runs fine.

## Verified
```
added 25/25, hung=0
PASS: sentinel-terminated, no hang, drains fully
```

## Not in this PR
- **Short-lived session** — folded into the unified Day 2 change across all fetch-then-write jobs, so the pool-checkout metric measures them together.
- **Full fetch/write-split with batched inserts** — 17_ is the ideal candidate (append-only, 168k inserts/run), but it's an optimization of an already-100%-healthy job, so it's a later item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)