### PR TITLE
perf: fetch/write-split 17_ with a batch writer + 50 fetchers; drop pool metric

### DIFF
--- a/17_add-member-follower-record.py
+++ b/17_add-member-follower-record.py
@@ -4,7 +4,7 @@ from util import logging_init, fullname
 from serverchan import sc_send_summary
 from queue import Queue
 from timer import Timer
-from job import AddMemberFollowerRecordJob, JobPool
+from job import FetchMemberFollowerRecordJob, BatchInsertMemberFollowerRecordJob, JobPool
 import logging
 
 script_id = '17'
@@ -18,44 +18,64 @@ def add_member_follower_record():
     timer = Timer()
     timer.start()
 
+    # fetch/write split (mirrors 51_): many fetch-only workers (HTTP, no DB) ->
+    # bounded queue -> ONE batch writer. Replaces the old 20 per-worker-insert
+    # jobs, whose per-record commits contended on fsync and pinned the run at
+    # ~1h10m. 50 fetchers + batched inserts should finish it in well under the
+    # ~40 min before 51_'s 12:00 run -- it runs to completion (no duration cap).
+    job_num = 50
+
     session = Session()
-    service = Service(mode='worker')
+    service = Service(mode='worker', pool_maxsize=job_num + 32)
 
     # load all mids
     mids: list[int] = DBOperation.query_all_member_mids(session=session)
+    session.close()
     logger.info(f'Total {len(mids)} members got.')
 
-    # put mid into queue
+    # mid queue for the fetch pool
     mid_queue: Queue[int] = Queue()
     for mid in mids:
         mid_queue.put(mid)
-    # one sentinel per worker (AddMemberFollowerRecordJob is sentinel-terminated)
-    job_num = 20
-    for _ in range(job_num):
-        mid_queue.put(None)
-    logger.info(f'{len(mids)} mids put into queue.')
 
-    # JobPool gives a per-30s PROGRESS heartbeat over the ~1h run (previously
-    # blind) and merges the workers' stats.
-    pool = JobPool(
-        [AddMemberFollowerRecordJob(f'job_{i}', mid_queue, service) for i in range(job_num)],
+    # fetched records -> single batch writer. BOUNDED so fetchers apply
+    # backpressure at writer speed instead of growing RSS.
+    record_queue: Queue = Queue(maxsize=20000)
+
+    fetch_pool = JobPool(
+        [FetchMemberFollowerRecordJob(f'job_{i}', mid_queue, record_queue, service)
+         for i in range(job_num)],
         progress_total=len(mids),
-        progress_label='follower-record',
-        progress_interval_s=30.0,
+        progress_label='follower-fetch',
+        ensure_conditions=['success', 'exception', 'other_exception',
+                           'record_dropped_queue_full'],
         logger_name=script_id)
-    pool.start()
-    logger.info(f'{job_num} job(s) started.')
-    job_stat_merged = pool.join()
+    writer_pool = JobPool(
+        [BatchInsertMemberFollowerRecordJob('writer_0', record_queue)],
+        progress_total=len(mids),
+        progress_label='follower-db-writer',
+        progress_interval_s=5.0,
+        ensure_conditions=['batch_insert', 'batch_insert_split',
+                           'batch_insert_split_ok', 'batch_insert_fail'],
+        logger_name=script_id)
 
-    session.close()
+    fetch_pool.start()
+    writer_pool.start()
+
+    fetch_stat = fetch_pool.join()
+    # sentinel AFTER all fetchers finished (FIFO -> arrives behind every record)
+    record_queue.put(None)
+    writer_stat = writer_pool.join()
 
     timer.stop()
 
     # summary
     logger.info(f'Finish {script_fullname}!')
     logger.info(timer.get_summary())
-    logger.info(job_stat_merged.get_summary('follower-record'))
-    sc_send_summary(script_fullname, timer, job_stat_merged)
+    logger.info(fetch_stat.get_summary('follower-fetch'))
+    logger.info(writer_stat.get_summary('follower-db-writer'))
+    logger.info(f'{writer_stat.total_count} follower record(s) fetched and inserted.')
+    sc_send_summary(script_fullname, timer, fetch_stat)
 
 
 def main():

--- a/core/record.py
+++ b/core/record.py
@@ -1,6 +1,6 @@
 from typing import NamedTuple, Optional
 
-__all__ = ['RecordNew']
+__all__ = ['RecordNew', 'MemberFollowerRecordNew']
 
 
 # Lightweight, immutable, session-independent video record DTO. This is the type
@@ -25,3 +25,12 @@ class RecordNew(NamedTuple):
     his_rank: int
     vt: Optional[int]
     vv: Optional[int]
+
+
+# Lightweight, session-independent member-follower record DTO. Same role as
+# RecordNew for the follower-count time series (fetch -> queue -> batch INSERT
+# into tdd_member_follower_record); ORM objects never cross the thread boundary.
+class MemberFollowerRecordNew(NamedTuple):
+    added: int
+    mid: int
+    follower: int

--- a/job/BatchInsertMemberFollowerRecordJob.py
+++ b/job/BatchInsertMemberFollowerRecordJob.py
@@ -1,0 +1,100 @@
+import time
+from .Job import Job
+from queue import Queue, Empty
+from db import Session
+from core import MemberFollowerRecordNew
+from task import commit_member_follower_records_batch
+from typing import Optional
+
+__all__ = ['BatchInsertMemberFollowerRecordJob']
+
+
+class BatchInsertMemberFollowerRecordJob(Job):
+    """
+    Dedicated DB writer: drains MemberFollowerRecordNew from record_queue and
+    persists them with multi-row INSERTs, one commit per batch. A single writer
+    with batches removes the per-record commit/fsync contention of the old
+    per-worker-insert path (17_ at 20 workers each committing per member).
+
+    A failing batch is split and retried (1000 -> 500 -> ...) so a transient
+    blip loses at most one record, not a whole batch. Terminates on a None
+    sentinel: the producer puts one None after all fetch workers finish (FIFO
+    guarantees it arrives behind every record).
+
+    Follower records are an append-only time series and there is no downstream
+    consumer, so (unlike the video writer) records are not forwarded on and
+    there is no recovery file -- a dropped record is picked up next run.
+    """
+
+    def __init__(self, name: str, record_queue: 'Queue[Optional[MemberFollowerRecordNew]]',
+                 batch_size: int = 1000, poll_timeout_s: float = 1.0):
+        super().__init__(name)
+        self.record_queue = record_queue
+        self.batch_size = batch_size
+        self.poll_timeout_s = poll_timeout_s
+        self.session = Session()
+
+    def _rollback_quietly(self):
+        try:
+            self.session.rollback()
+        except Exception:
+            pass
+
+    def _insert_splitting(self, batch: list, depth: int = 0) -> int:
+        if not batch:
+            return 0
+        try:
+            commit_member_follower_records_batch(batch, self.session)
+        except Exception as e:
+            self._rollback_quietly()
+            if len(batch) == 1:
+                self.logger.error(
+                    f'Fail to insert follower record after splitting to one row. '
+                    f'mid: {batch[0].mid}, error: {e}')
+                self.stat.condition['batch_insert_fail'] += 1
+                return 0
+            self.logger.warning(
+                f'Batch insert failed, splitting and retrying. '
+                f'size: {len(batch)}, mids: {batch[0].mid}..{batch[-1].mid}, error: {e}')
+            self.stat.condition['batch_insert_split'] += 1
+            mid = len(batch) // 2
+            return (self._insert_splitting(batch[:mid], depth + 1)
+                    + self._insert_splitting(batch[mid:], depth + 1))
+        else:
+            self.stat.condition['batch_insert' if depth == 0 else 'batch_insert_split_ok'] += 1
+            return len(batch)
+
+    def _flush(self, batch: list):
+        if not batch:
+            return
+        flush_start = time.perf_counter()
+        persisted = self._insert_splitting(batch)
+        flush_ms = int((time.perf_counter() - flush_start) * 1000)
+        if persisted < len(batch):
+            self.logger.error(
+                f'{len(batch) - persisted} of {len(batch)} follower record(s) not persisted.')
+        self.stat.condition['db_ms'] += flush_ms
+        self.logger.debug(f'BATCH size={len(batch)} persisted={persisted} db={flush_ms}ms')
+        self.stat.total_count += len(batch)
+        self.stat.total_duration_ms += flush_ms
+
+    def process(self):
+        batch = []
+        while True:
+            try:
+                item = self.record_queue.get(timeout=self.poll_timeout_s)
+            except Empty:
+                self._flush(batch)
+                batch = []
+                continue
+            if item is None:  # sentinel: all producers finished
+                self._flush(batch)
+                batch = []
+                break
+            batch.append(item)
+            if len(batch) >= self.batch_size:
+                self._flush(batch)
+                batch = []
+
+    def cleanup(self):
+        self.session.close()

--- a/job/FetchMemberFollowerRecordJob.py
+++ b/job/FetchMemberFollowerRecordJob.py
@@ -1,0 +1,93 @@
+from .Job import Job
+from service import Service, ServiceError
+from timer import Timer
+from queue import Queue, Empty, Full
+from core import MemberFollowerRecordNew
+from util import get_ts_s, ts_s_to_str
+from task import fetch_member_follower_record
+from typing import Optional
+
+__all__ = ['FetchMemberFollowerRecordJob']
+
+
+class FetchMemberFollowerRecordJob(Job):
+    """
+    Fetch-only worker: HTTP fetch -> MemberFollowerRecordNew -> record_queue.
+    Holds NO DB connection (member-follower is append-only, so there is no
+    read/compare, just the relation fetch). A BatchInsertMemberFollowerRecordJob
+    drains the queue and batch-inserts, removing the per-record commit
+    contention that pinned 17_'s old per-worker-insert path.
+    """
+
+    def __init__(self, name: str, mid_queue: Queue[int],
+                 record_queue: 'Queue[Optional[MemberFollowerRecordNew]]',
+                 service: Service,
+                 duration_limit_s: Optional[int] = None, put_timeout_s: float = 30.0):
+        super().__init__(name)
+        self.mid_queue = mid_queue
+        self.record_queue = record_queue
+        self.service = service
+        self.duration_limit_s = duration_limit_s
+        self.duration_limit_due_ts_s = None
+        self.put_timeout_s = put_timeout_s
+
+    def _put_record(self, record) -> bool:
+        try:
+            self.record_queue.put(record, timeout=self.put_timeout_s)
+            return True
+        except Full:
+            return False
+
+    def process(self):
+        if self.duration_limit_s is not None:
+            self.duration_limit_due_ts_s = get_ts_s() + self.duration_limit_s
+            self.logger.info(f'Duration limit due at {ts_s_to_str(self.duration_limit_due_ts_s)}.')
+
+        while True:
+            if (self.duration_limit_due_ts_s is not None
+                    and get_ts_s() >= self.duration_limit_due_ts_s):
+                self.logger.info(f'Duration limit reached. Now exit. '
+                                 f'{self.mid_queue.qsize()} mid(s) left unfetched.')
+                self.stat.condition['duration_limit_reached'] += 1
+                break
+
+            # get_nowait, not empty()+get(): the latter races -- workers seeing
+            # the same last item all call get(), the losers block forever.
+            try:
+                mid = self.mid_queue.get_nowait()
+            except Empty:
+                break
+            self.logger.debug(f'Now start fetch member follower record. mid: {mid}')
+            timer = Timer()
+            timer.start()
+
+            stage_stat = {}
+            try:
+                record = fetch_member_follower_record(mid, self.service, out_stat=stage_stat)
+            except ServiceError as e:
+                self.logger.error(f'Fail to fetch member follower record. mid: {mid}, error: {e}')
+                self.stat.condition['exception'] += 1
+            except Exception as e:
+                self.logger.error(f'Fail to fetch member follower record. mid: {mid}, error: {e}')
+                self.stat.condition['other_exception'] += 1
+            else:
+                # bounded queue: block on a slow writer, but never forever --
+                # give up on the record if a dead writer stalls the pool
+                while not self._put_record(record):
+                    if (self.duration_limit_due_ts_s is not None
+                            and get_ts_s() >= self.duration_limit_due_ts_s):
+                        self.logger.error(
+                            f'Record queue full and duration limit reached -- writer stalled. '
+                            f'Dropping record and exiting. mid: {mid}')
+                        self.stat.condition['record_dropped_queue_full'] += 1
+                        return
+                    self.logger.warning(
+                        f'Record queue full for {self.put_timeout_s}s -- writer slow/dead. '
+                        f'Still waiting. mid: {mid}')
+                self.stat.condition['success'] += 1
+
+            timer.stop()
+            for stage_key, stage_ms in stage_stat.items():
+                self.stat.condition[stage_key] += stage_ms
+            self.stat.total_count += 1
+            self.stat.total_duration_ms += timer.get_duration_ms()

--- a/job/JobPool.py
+++ b/job/JobPool.py
@@ -3,7 +3,6 @@ import logging
 from collections import Counter
 from threading import Thread, Event
 from typing import Optional
-from db import engine
 from .Job import Job
 from .JobStat import JobStat
 
@@ -84,20 +83,6 @@ class JobPool:
     def _fmt_ms(ms: float) -> str:
         return f'{ms / 1000:.2f}s' if ms >= 1000 else f'{ms:.0f}ms'
 
-    @staticmethod
-    def _pool_status_str() -> str:
-        # live DB connection-pool usage: how many connections the process holds
-        # (checked out) right now, vs the base pool size. A worker that holds a
-        # session across a slow HTTP fetch / sleep keeps a connection checked
-        # out the whole time, so this reveals connection pressure directly.
-        # Cheap: attribute reads, no DB round-trip. Best-effort (pool type may
-        # vary), so never let it break the heartbeat.
-        try:
-            pool = engine.pool
-            return f'pool: {pool.checkedout()}/{pool.size()} checked out'
-        except Exception:
-            return ''
-
     def _report_progress(self):
         last_done = 0
         last_ts = time.time()
@@ -137,9 +122,6 @@ class JobPool:
                     cond_str = ', '.join(
                         f'{k}: {v}' for k, v in counts.most_common())
                     msg = f'{msg} | {cond_str}'
-            pool_str = self._pool_status_str()
-            if pool_str:
-                msg = f'{msg} | {pool_str}'
             self.logger.info(msg)
             last_done, last_ts = done, now
             if stopped:

--- a/job/__init__.py
+++ b/job/__init__.py
@@ -1,4 +1,6 @@
 from .AddMemberFollowerRecordJob import *
+from .FetchMemberFollowerRecordJob import *
+from .BatchInsertMemberFollowerRecordJob import *
 from .AddSprintVideoRecordJob import *
 from .AddVideoJob import *
 from .AddVideoRecordJob import *

--- a/task/task.py
+++ b/task/task.py
@@ -3,7 +3,7 @@ from sqlalchemy.orm.session import Session
 from db import DBOperation, TddVideo, TddVideoRecord, TddVideoLog, TddVideoStaff, TddMember, TddMemberFollowerRecord, \
     TddMemberLog, TddSprintVideoRecord
 from util import get_ts_s, a2b, same_pic_url, null_or_str
-from core import TddError, RecordNew
+from core import TddError, RecordNew, MemberFollowerRecordNew
 from .error import AlreadyExistError, NotExistError
 
 import logging
@@ -19,6 +19,7 @@ __all__ = ['add_video_record_via_video_view',
            'add_sprint_video_record_via_video_view',
            'add_video', 'update_video',
            'add_member', 'update_member', 'commit_staff', 'add_member_follower_record',
+           'fetch_member_follower_record', 'commit_member_follower_records_batch',
            'get_video_tags_str']
 
 
@@ -698,6 +699,44 @@ def add_member_follower_record(mid: int, service: Service, session: Session):
     DBOperation.add(new_follower_record, session)
 
     return new_follower_record
+
+
+def fetch_member_follower_record(mid: int, service: Service,
+                                 out_stat: dict = None) -> MemberFollowerRecordNew:
+    # Fetch-only: build a session-independent follower record WITHOUT touching
+    # the DB. Pair with commit_member_follower_records_batch (the bulk writer).
+    # out_stat (optional): filled with 'http_ms'.
+    stage_start = time.perf_counter()
+    try:
+        member_relation = service.get_member_relation({'vmid': mid})
+    except ServiceError as e:
+        raise e
+    if out_stat is not None:
+        out_stat['http_ms'] = int((time.perf_counter() - stage_start) * 1000)
+
+    return MemberFollowerRecordNew(
+        added=get_ts_s(),
+        mid=mid,
+        follower=member_relation.follower,
+    )
+
+
+def commit_member_follower_records_batch(records: list, session: Session, out_stat: dict = None) -> None:
+    # Persist many MemberFollowerRecordNew with ONE multi-row INSERT and ONE
+    # commit -- the bulk counterpart of add_member_follower_record, removing the
+    # per-record commit/fsync contention. Raises on failure; caller owns retry.
+    # out_stat (optional): filled with 'db_ms'.
+    if not records:
+        return
+
+    stage_start = time.perf_counter()
+    sql = 'insert into tdd_member_follower_record(added, mid, follower) values '
+    sql += ', '.join(
+        '(%d, %d, %d)' % (r.added, r.mid, r.follower) for r in records)
+    session.execute(sql)
+    session.commit()
+    if out_stat is not None:
+        out_stat['db_ms'] = int((time.perf_counter() - stage_start) * 1000)
 
 
 def get_video_tags_str(aid: int, service: Service) -> str:


### PR DESCRIPTION
Applies the 51_ #28 pattern to `17_add-member-follower-record` so it finishes fast enough not to overlap 51_'s 12:00 run, and removes the now-diagnostic-only pool metric.

## The problem
17_ was 20 `AddMemberFollowerRecordJob` workers, each committing **one** follower record per member. Per-record commit/fsync contention pinned the run at **~1h 10m** (and held ~20 connections in *active* commits — the reason its pool metric read 21/50). It's an append-only insert job, so it's the ideal candidate for the batched-writer pattern.

## The change: fetch/write split
```
mid_queue → FetchMemberFollowerRecordJob × 50 (HTTP only, ZERO DB)
          → bounded record_queue
          → BatchInsertMemberFollowerRecordJob × 1 (multi-row INSERT, one commit per batch)
```
- **core:** `MemberFollowerRecordNew` DTO `(added, mid, follower)` — session-independent, so no ORM crosses the thread boundary.
- **task:** `fetch_member_follower_record` (HTTP only) + `commit_member_follower_records_batch` (one multi-row INSERT + commit).
- **job:** `FetchMemberFollowerRecordJob` (fetch-only, bounded put, get_nowait) + `BatchInsertMemberFollowerRecordJob` (single writer, batches of 1000, split-retry on failure, sentinel termination). No downstream/recovery file — follower records are an append time series, so a dropped one is simply picked up next run.
- **17_:** 50 fetchers → bounded queue → 1 writer via two `JobPool`s. **No duration cap** — runs to completion; the speedup (removing commit contention + 2.5× fetchers) should put it well under the ~40 min before 51_'s 12:00 run.

Removing the per-record commits also drops 17_'s DB footprint to **one** connection (the writer) plus 50 DB-free fetchers.

## Also: drop the pool-checkout heartbeat field
It served its purpose (revealed the connection-holding pattern that led to the anti-crawler-vs-reorder decision), but it's near-static per run, so it was noise as a permanent field.

## Verified
```
end-to-end: fetched=2050 inserted=2050 all-once=True success=2050 batches=3
PASS: split pipeline, all fetched+inserted exactly once, no loss (bounded queue)
SQL: insert into tdd_member_follower_record(added, mid, follower) values (100, 0, 0), (101, 1, 7), (102, 2, 14)
PASS: batch INSERT SQL correct
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)