### PR TITLE
fix: give the trimmed worker timeout headroom above its Lambda timeout

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -21,33 +21,17 @@ RequestMode = Literal['direct', 'worker']
 
 __all__ = ['Service', 'RequestMode']
 
-# Client-side bounds for the trimmed video_view worker specifically, rather than
-# the Service-wide defaults (5.0s / 10.0s), which the other endpoints keep.
+# Trimmed-worker-only bounds, looser than the Service defaults (5.0s / 10.0s)
+# the other endpoints keep. Invariant:
 #
-# These are coupled to the worker Lambda's own function timeout, currently 10s.
-# The invariant is:
+#     _TRIMMED_DEADLINE_S > _TRIMMED_TIMEOUT_S > worker Lambda timeout (10s)
 #
-#     _TRIMMED_DEADLINE_S > _TRIMMED_TIMEOUT_S > lambda function timeout
-#
-# and both halves matter:
-#
-#   - `timeout` is the requests read timeout: the maximum gap between received
-#     bytes. A Lambda sends nothing at all while it works, so the entire
-#     invocation is one read gap and this value bounds its time-to-first-byte.
-#     If it sits below the Lambda's own timeout, the client abandons a request
-#     the Lambda is still running -- and still being billed for -- instead of
-#     letting the Lambda return its own error. That is strictly worse than a
-#     shorter Lambda timeout: the fetch thread parks longer AND the invocation
-#     costs more.
-#   - `deadline` is the wall-clock budget for the whole trial, and _get() only
-#     checks it once response headers have arrived. Set below `timeout` it would
-#     discard a response that landed just inside `timeout`, on receipt.
-#
-# History: the Lambda ran a 3s timeout until 2026-08-08. Migrating it to arm64
-# shifted p99.9 latency 2549ms -> 2944ms against that 3s wall, which pinned
-# Duration Maximum at exactly 3000ms and took the error rate 0.003% -> 0.225%.
-# Raising the Lambda alone would not have helped, because the old 5.0s Service
-# default would then have become the binding limit.
+# timeout is the requests read timeout -- the max gap between received bytes --
+# and a Lambda sends nothing while it works, so the whole invocation is one gap.
+# Below the Lambda's own timeout the client abandons requests the Lambda is
+# still running and still billing for. deadline sits above timeout because
+# _get() checks it only after headers arrive, so a lower value would discard a
+# response that landed just inside timeout.
 _TRIMMED_TIMEOUT_S = 12.0
 _TRIMMED_DEADLINE_S = 15.0
 
@@ -476,10 +460,8 @@ class Service:
             exit(1)
 
         # get response
-        # timeout/deadline default to the trimmed-worker values rather than the
-        # Service-wide ones: they must clear the worker Lambda's own function
-        # timeout, see _TRIMMED_TIMEOUT_S above. An explicit caller override
-        # still wins.
+        # trimmed-worker bounds instead of the Service-wide ones, see
+        # _TRIMMED_TIMEOUT_S. An explicit caller override still wins.
         timeout = timeout if timeout is not None else _TRIMMED_TIMEOUT_S
         response = self._get(url, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor,

--- a/service/Service.py
+++ b/service/Service.py
@@ -21,6 +21,36 @@ RequestMode = Literal['direct', 'worker']
 
 __all__ = ['Service', 'RequestMode']
 
+# Client-side bounds for the trimmed video_view worker specifically, rather than
+# the Service-wide defaults (5.0s / 10.0s), which the other endpoints keep.
+#
+# These are coupled to the worker Lambda's own function timeout, currently 10s.
+# The invariant is:
+#
+#     _TRIMMED_DEADLINE_S > _TRIMMED_TIMEOUT_S > lambda function timeout
+#
+# and both halves matter:
+#
+#   - `timeout` is the requests read timeout: the maximum gap between received
+#     bytes. A Lambda sends nothing at all while it works, so the entire
+#     invocation is one read gap and this value bounds its time-to-first-byte.
+#     If it sits below the Lambda's own timeout, the client abandons a request
+#     the Lambda is still running -- and still being billed for -- instead of
+#     letting the Lambda return its own error. That is strictly worse than a
+#     shorter Lambda timeout: the fetch thread parks longer AND the invocation
+#     costs more.
+#   - `deadline` is the wall-clock budget for the whole trial, and _get() only
+#     checks it once response headers have arrived. Set below `timeout` it would
+#     discard a response that landed just inside `timeout`, on receipt.
+#
+# History: the Lambda ran a 3s timeout until 2026-08-08. Migrating it to arm64
+# shifted p99.9 latency 2549ms -> 2944ms against that 3s wall, which pinned
+# Duration Maximum at exactly 3000ms and took the error rate 0.003% -> 0.225%.
+# Raising the Lambda alone would not have helped, because the old 5.0s Service
+# default would then have become the binding limit.
+_TRIMMED_TIMEOUT_S = 12.0
+_TRIMMED_DEADLINE_S = 15.0
+
 
 class Service:
 
@@ -446,8 +476,14 @@ class Service:
             exit(1)
 
         # get response
+        # timeout/deadline default to the trimmed-worker values rather than the
+        # Service-wide ones: they must clear the worker Lambda's own function
+        # timeout, see _TRIMMED_TIMEOUT_S above. An explicit caller override
+        # still wins.
+        timeout = timeout if timeout is not None else _TRIMMED_TIMEOUT_S
         response = self._get(url, params=params, headers=headers,
-                             retry=retry, timeout=timeout, colddown_factor=colddown_factor)
+                             retry=retry, timeout=timeout, colddown_factor=colddown_factor,
+                             deadline=_TRIMMED_DEADLINE_S)
         if response is None:
             raise ResponseError('video_view_trimmed', params)
 


### PR DESCRIPTION
## Why

Migrating `bilibili-video-view-trimmed` to arm64 on 2026-08-07 (a cost change, ~\$8.50/mo) shifted its latency tail into the worker Lambda's 3s function timeout:

| Duration | p50 | p90 | p99 | p99.9 | **Max** |
|---|---:|---:|---:|---:|---:|
| Pre (x86_64) | 254.6 | 361.5 | 921.3 | 2549.5 | **2987.8** |
| Post (arm64) | 263.5 | 385.0 | 1205.9 | 2944.0 | **3000.0** |

`Maximum` pinned at exactly 3000.0ms is the signature of hitting the configured timeout. Error rate went **0.0026% → 0.2250%** (~7,600 failed invocations/day). p50 barely moved (+3.5%) while p99 moved +31% — a tail regression, not a uniform slowdown.

Corroborating: error *count* is ~constant at ~300/hour regardless of volume. The 20:00Z hour runs 1.13M invocations and produces only 440 errors (0.039%), while a 70k-invocation hour produces ~310 (0.44%). A per-invocation incompatibility would scale with volume; a tail crossing a fixed wall does not.

The five other bilibili functions received an identical CloudWatch logging change the same day but stayed arm64, and show no error change — so this is the architecture switch, not the logging.

Retries (`retry=3`) are covering the data, so the cost is billed duration and error noise rather than loss. Timeouts are the expensive failure mode: each burns the full 3s instead of ~293ms, about **\$1.21/mo**.

## ⚠️ This PR does not fix anything on its own

**The 3s timeout is AWS-side configuration on the Lambda, not in this repo.** This PR changes only client-side bounds, and today they are never the binding constraint — the Lambda self-kills at 3s and returns its error well before the client's 5.0s read timeout fires. Merging this alone is **inert**: no behaviour change, no error-rate change.

The actual fix is the AWS-side change:

```
aws lambda update-function-configuration --region us-west-1 \
  --function-name bilibili-video-view-trimmed --timeout 10
```

This PR exists so that change is fully effective.

## What this changes, and why it's needed

`Service.__init__` sets `timeout=5.0`, which `requests` applies as the *read* timeout — the max gap between received bytes. A Lambda sends nothing while it works, so the entire invocation is one read gap, and that 5s bounds its time-to-first-byte.

Raising the Lambda to 10s **without** this PR would still help: requests needing 3–5s would start succeeding, and given p99.9 sat at 2944ms those are probably most of the current failures. But anything needing more than 5s would trip the client's 5.0s read timeout and abort — while the Lambda kept running and billing to 10s. So the AWS change alone is a partial fix that leaves a wasteful tail; this PR removes the client ceiling so the full 10s is usable.

Bounds for the trimmed endpoint only:

```
_TRIMMED_TIMEOUT_S  = 12.0   (was 5.0,  Service default)
_TRIMMED_DEADLINE_S = 15.0   (was 10.0, Service default)
```

preserving **`deadline > timeout > lambda timeout`**. `deadline` must also clear `timeout` because `_get()` checks it only *after* response headers arrive — set lower, it would discard a response that landed just inside `timeout`.

Scoped to `get_video_view_trimmed` rather than the `Service` defaults, which the other five endpoints keep. `_get()` already documents why loose global timeouts are dangerous here: *"observed in production as 100+ second single-trial requests against the worker Lambda, each one parking a fetch thread the whole time."* An explicit caller override still wins.

Throughput cost is negligible: 0.227% of requests taking up to 7s longer, against 250 workers, is ~1,100 extra worker-seconds/hour out of ~900,000 available — **~0.12% of capacity**.

## Deploy order

1. **Merge this first** — inert on its own, so it is safe to land at any time.
2. Then raise the Lambda timeout to 10s (command above).
3. Confirm error rate returns to ~0.003% and `Maximum` duration is no longer pinned at 3000.

Doing step 2 before step 1 leaves the 5s client ceiling in place and wastes billed Lambda time on the >5s tail.

## Caveats

**This treats a symptom.** Why the arm64 tail moved is unknown — duration here is supposedly dominated by waiting on bilibili, which shouldn't care about CPU architecture. Unverified hypotheses: TLS/JSON-parse cost differing on Graviton in the slow path, or new execution environments drawing different IPs and hitting bilibili's anti-crawler differently.

The logs that would settle it were deleted the same day as part of the cost work. Root-causing means temporarily re-enabling logging on this one function (~1 GB, ~\$0.55/hour) — worth doing *before* step 2, since the fix masks the signal.

**Note for the batching work:** if the tail already sits near 3s for a *single* fetch, batching 10 concurrent fetches per invocation will need substantially more headroom. Don't carry 3s forward.

## Testing

Verified on Python 3.11 (the 3.8 venv can't import this package at all — `list[...]` in `response.py`):

- module imports; `deadline > timeout > 10.0` invariant asserted
- `get_video_view_trimmed` wired to both constants
- `Service.__init__` defaults confirmed unchanged at 5.0 / 10.0

Not exercised against the live worker — the behaviour change only manifests once the Lambda timeout is raised in step 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)