### PR TITLE
feat: card-specific workers + a throttle probe to test -352 fixes

### DIFF
--- a/service/workers/card/README.md
+++ b/service/workers/card/README.md
@@ -1,0 +1,84 @@
+# card workers
+
+Purpose-built workers for `get_member_card`. **Do not deploy the generic `../template/` files to
+this endpoint** — these differ from the templates in two ways that matter.
+
+## Why this endpoint is special
+
+`member_card` is the only endpoint bilibili rate-limits. It is the only one that returns
+`code: -352`, and it is the only endpoint deployed to more than one platform:
+
+| Endpoint | Workers |
+|---|---|
+| `get_member_card` | **4** — AWS Function URL, AWS API Gateway, GCP Cloud Run, Azure Functions |
+| everything else | 1 — AWS only, which is sufficient |
+
+The multi-platform spread exists to spread requests across source IP pools. Note that the two AWS
+URLs are one Lambda behind two front doors, so AWS carries ~50% of the traffic, not 25%.
+
+## How these differ from `../template/`
+
+1. **`baseUrl` is pinned to `http://api.bilibili.com/x/web-interface/card`.** The templates ship a
+   placeholder meant to be edited per deployment; these are not templates and should not be edited.
+2. **The caller's `User-Agent` is forwarded upstream.** The generic templates call
+   `fetch(url.href)` with no headers, so bilibili sees a bare runtime UA.
+
+## Deploy targets
+
+| File | Deploys to |
+|---|---|
+| `aws_lambda.mjs` | Lambda `bilibili-member-card` (serves **both** the Function URL and the `tdd-worker-API` HTTP API) |
+| `gcp_cloud_run.js` | Cloud Run `bilibili-member-card` |
+| `azure_function_app.js` | Azure Functions `bilibili-member-card` |
+
+There is no Cloudflare deployment.
+
+## Verify after deploying
+
+A worker pointed at the wrong upstream still returns HTTP 200 with `code: 0` — it just returns the
+wrong payload, and **cloud monitoring cannot see this**. Lambda's `Errors` metric counts crashes and
+timeouts, not wrong answers. Check the payload, not the dashboard:
+
+```bash
+curl -s 'https://<worker-url>?mid=1635775' \
+  -H 'User-Agent: Mozilla/5.0' | python3 -m json.tool | head -20
+```
+
+Expect `code: 0` and `data.card.name == "牛奶源"`. If you see `data: {archives, page}`, the
+`baseUrl` is pointing at the newlist endpoint.
+
+## Known limitation: `-352` is not solved
+
+Forwarding the User-Agent does **not** solve it. Measured 2026-08-09 — sequential requests succeed
+regardless of UA (18 requests across modern, legacy, and mobile UAs, all `code: 0`), while
+`16_update-member-info.py` at 50 concurrent workers hits `-352` on essentially every request.
+**The throttle is rate-based, not fingerprint-based.**
+
+## Testing a proposed fix — `probe_throttle.py`
+
+Use it before touching the production job. It reproduces the real failure in 45 seconds.
+
+```bash
+python service/workers/card/probe_throttle.py --sweep 1,5,10,20,50   # find the ceiling
+python service/workers/card/probe_throttle.py --per-worker --sweep 20 # per-platform or global?
+python service/workers/card/probe_throttle.py --sweep 50 --pace 0.5   # does pacing help?
+```
+
+The number that matters is **`settled/s`** — sustained successful requests/sec in the final third
+of the window, once the burst allowance is spent. The throttle lets a burst through before
+clamping, so short or sequential probes look perfect and prove nothing. That is precisely how the
+2026-08-09 deploy was verified as "all four workers correct" minutes before the job collapsed.
+
+Baseline, all four workers:
+
+| conc | reqs | ok | −352 | burst | 1st −352 | settled/s | verdict |
+|---:|---:|---:|---:|---:|---:|---:|---|
+| 1 | 74 | 67 | 0 | 67 | never | 2.50 | 2.8 h for 24,931 members |
+| 10 | 881 | 772 | 43 | 723 | 27.1 s | 25.40 | 0.3 h |
+| 50 | 6192 | 63 | 6115 | 0 | 0.5 s | **0.00** | **never finishes** |
+
+conc=50 is what the job uses, and 0.00/s is exactly what it did: stalled at 288 members.
+
+**Leave 2–5 minutes between runs.** The throttle persists after a run ends. The conc=50 row above
+shows `burst=0` because it followed conc=10 immediately — treat a burst of 0 as leftover throttling,
+not a reading.

--- a/service/workers/card/aws_lambda.mjs
+++ b/service/workers/card/aws_lambda.mjs
@@ -1,0 +1,40 @@
+const baseUrl = new URL("http://api.bilibili.com/x/web-interface/card");
+
+export const handler = async (event) => {
+  const queryParams = event.queryStringParameters || {};
+  const headers = event.headers || {};
+
+  // Append query parameters to the base URL
+  const url = new URL(baseUrl.href); // Clone baseUrl to avoid modifying the original
+  Object.keys(queryParams).forEach((key) => {
+    url.searchParams.append(key, queryParams[key]);
+  });
+
+  try {
+    // Fetch data from the API
+    const response = await fetch(url.href, {
+      headers: {
+        "User-Agent": headers["user-agent"] || headers["User-Agent"],
+      },
+    });
+
+    // Get the response body as text (JSON or other formats)
+    const body = await response.text();
+
+    // Return the status code and body as-is
+    return {
+      statusCode: response.status,
+      body,
+    };
+  } catch (error) {
+    console.error("Error occurred while fetching data:", error);
+
+    // Return the error in case of a failure
+    return {
+      statusCode: 500,
+      body: JSON.stringify({
+        message: error.message || "Internal Server Error",
+      }),
+    };
+  }
+};

--- a/service/workers/card/azure_function_app.js
+++ b/service/workers/card/azure_function_app.js
@@ -1,0 +1,35 @@
+const baseUrl = new URL("http://api.bilibili.com/x/web-interface/card");
+
+module.exports = async function (context, req) {
+  // Append query parameters to the base URL
+  const url = new URL(baseUrl.href); // Clone baseUrl to avoid modifying the original
+  Object.keys(req.query).forEach((key) => {
+    url.searchParams.append(key, req.query[key]);
+  });
+
+  try {
+    // Fetch data from the API
+    const response = await fetch(url.href, {
+      headers: { "User-Agent": (req.headers || {})["user-agent"] },
+    });
+
+    // Get the response body as text (JSON or other formats)
+    const body = await response.text();
+
+    // Return the status code and body as-is
+    context.res = {
+      status: response.status,
+      body: body,
+    };
+  } catch (error) {
+    console.error("Error occurred while fetching data:", error);
+
+    // Return the error in case of a failure
+    context.res = {
+      status: 500,
+      body: JSON.stringify({
+        message: error.message || "Internal Server Error",
+      }),
+    };
+  }
+};

--- a/service/workers/card/gcp_cloud_run.js
+++ b/service/workers/card/gcp_cloud_run.js
@@ -1,0 +1,33 @@
+const functions = require("@google-cloud/functions-framework");
+
+const baseUrl = new URL("http://api.bilibili.com/x/web-interface/card");
+
+functions.http("proxyRequest", async (req, res) => {
+  const queryParams = req.query || {};
+
+  // Append query parameters to the base URL
+  const url = new URL(baseUrl.href); // Clone baseUrl to avoid modifying the original
+  Object.keys(queryParams).forEach((key) => {
+    url.searchParams.append(key, queryParams[key]);
+  });
+
+  try {
+    // Fetch data from the API
+    const response = await fetch(url.href, {
+      headers: { "User-Agent": req.get("user-agent") },
+    });
+
+    // Get the response body as text (JSON or other formats)
+    const body = await response.text();
+
+    // Return the status code and body as-is
+    res.status(response.status).send(body);
+  } catch (error) {
+    console.error("Error occurred while fetching data:", error);
+
+    // Return the error in case of a failure
+    res.status(500).json({
+      message: error.message || "Internal Server Error",
+    });
+  }
+});

--- a/service/workers/card/probe_throttle.py
+++ b/service/workers/card/probe_throttle.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""Measure where bilibili's -352 throttle starts on the member_card workers.
+
+The point of this tool is to answer one question quickly: **will a proposed
+anti-352 change let 16_update-member-info.py actually finish?** -- without
+running the job for hours to find out.
+
+Why a naive check is not enough
+-------------------------------
+On 2026-08-09 the card workers were verified by sending a handful of sequential
+requests. All returned code 0. The job was started and collapsed within three
+minutes: 288 members done, then every one of its 50 workers stuck in a loop of
+-352 -> sleep 60s -> retry -> -352.
+
+The throttle has a **burst allowance**. Low-rate and short-burst probes sail
+straight through it and prove nothing. Any useful test has to run concurrently,
+for long enough to exhaust the allowance, and then measure what is left.
+
+So this reports two numbers per concurrency level, and only the second one
+predicts whether a job finishes:
+
+  burst    how many requests succeed before the first -352
+  settled  successful requests/sec in the FINAL THIRD of the window, i.e.
+           the sustained rate once the throttle has clamped down
+
+A settled rate near zero means the job will never finish, no matter how good
+the burst looks.
+
+Usage
+-----
+    # find the ceiling: sweep concurrency against all four workers
+    python service/workers/card/probe_throttle.py --sweep 1,5,10,20,50
+
+    # is the limit per-platform or global? test each worker alone
+    python service/workers/card/probe_throttle.py --per-worker --sweep 5,20
+
+    # evaluate a change: does pacing help at the concurrency the job uses?
+    python service/workers/card/probe_throttle.py --sweep 50 --duration 120
+
+Run from the repo root with venv-3.11 active. Requests hit the real bilibili
+API through the real workers, so keep durations modest.
+
+Leave a cooldown between runs
+-----------------------------
+The throttle persists after a run ends, so back-to-back levels contaminate each
+other. Measured 2026-08-09: a conc=10 level finished with the throttle active,
+and the conc=50 level that followed immediately reported burst=0 -- its very
+first request was already throttled. Wait 2-5 minutes between levels, or treat a
+burst of 0 as "still throttled from last time" rather than a real reading.
+
+Validated against production
+----------------------------
+2026-08-09, sweeping all four workers:
+
+    conc   reqs    ok    -352    burst   1st352   settled/s
+       1     74    67       0       67    never       2.50
+      10    881   772      43      723    27.1s      25.40
+      50   6192    63    6115        0     0.5s       0.00
+
+16_update-member-info.py runs at conc=50 and stalled at 288 members with 0/s --
+which is exactly what the conc=50 row predicts. The tool reproduces the real
+failure in 45 seconds instead of three minutes of a doomed production job.
+"""
+
+import argparse
+import json
+import random
+import statistics
+import sys
+import threading
+import time
+from collections import Counter
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+import requests
+
+# Real, long-lived accounts. Throttling can behave differently for mids that do
+# not exist, so probing must not use synthetic ones.
+DEFAULT_MIDS = [
+    2, 208259, 546195, 1635775, 8047632, 11783021, 17706376, 37974, 703007996,
+    174485983, 486906330, 3494380402, 434401755, 8964182, 22884204,
+]
+
+UA_LIST = [
+    'Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/72.0.3626.121 Safari/537.36',
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_1) AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/72.0.3626.121 Safari/537.36',
+    'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) '
+    'Chrome/71.0.3578.98 Safari/537.36',
+]
+
+
+def load_workers(repo_root: Path) -> list:
+    path = repo_root / 'service' / 'endpoints.json'
+    if not path.exists():
+        sys.exit(f'endpoints.json not found at {path} -- run from the repo root.')
+    return json.load(path.open())['get_member_card']['workers']
+
+
+def worker_label(url: str) -> str:
+    for needle, name in (
+        ('lambda-url', 'AWS fn-url'),
+        ('execute-api', 'AWS API GW'),
+        ('azurewebsites', 'Azure'),
+        ('run.app', 'GCP Run'),
+    ):
+        if needle in url:
+            return name
+    return url[:24]
+
+
+class Probe:
+    """Fires requests at a fixed concurrency for a fixed wall-clock window."""
+
+    def __init__(self, urls, mids, timeout, pace):
+        self.urls = urls
+        self.mids = mids
+        self.timeout = timeout
+        self.pace = pace           # seconds to sleep after each request, per thread
+        self.session = requests.Session()
+        self.lock = threading.Lock()
+        self.events = []           # (elapsed_seconds, outcome)
+        self.first_352_at = None
+        self.before_first_352 = 0
+
+    def _record(self, elapsed, outcome):
+        with self.lock:
+            self.events.append((elapsed, outcome))
+            if outcome == 'ok' and self.first_352_at is None:
+                self.before_first_352 += 1
+            elif outcome == 'throttled' and self.first_352_at is None:
+                self.first_352_at = elapsed
+
+    def _one(self, start):
+        url = random.choice(self.urls)
+        mid = random.choice(self.mids)
+        try:
+            r = self.session.get(
+                url,
+                params={'mid': mid},
+                headers={'User-Agent': random.choice(UA_LIST)},
+                timeout=self.timeout,
+            )
+            code = r.json().get('code')
+            if code == 0:
+                outcome = 'ok'
+            elif code == -352:
+                outcome = 'throttled'
+            else:
+                outcome = f'code{code}'
+        except Exception as exc:                       # noqa: BLE001 - report, never abort
+            outcome = type(exc).__name__
+        self._record(time.perf_counter() - start, outcome)
+
+    def _thread(self, start, deadline):
+        while time.perf_counter() < deadline:
+            self._one(start)
+            if self.pace:
+                time.sleep(self.pace)
+
+    def run(self, concurrency, duration):
+        start = time.perf_counter()
+        deadline = start + duration
+        with ThreadPoolExecutor(max_workers=concurrency) as pool:
+            for _ in range(concurrency):
+                pool.submit(self._thread, start, deadline)
+        return self.summary(duration)
+
+    def summary(self, duration):
+        tally = Counter(o for _, o in self.events)
+        total = len(self.events)
+        # settled rate: successes in the final third of the window
+        cutoff = duration * 2 / 3
+        tail = [o for t, o in self.events if t >= cutoff]
+        tail_ok = sum(1 for o in tail if o == 'ok')
+        tail_secs = duration - cutoff
+        return {
+            'total': total,
+            'ok': tally.get('ok', 0),
+            'throttled': tally.get('throttled', 0),
+            'other': total - tally.get('ok', 0) - tally.get('throttled', 0),
+            'burst': self.before_first_352,
+            'first_352_at': self.first_352_at,
+            'settled_rps': tail_ok / tail_secs if tail_secs > 0 else 0.0,
+            'overall_rps': tally.get('ok', 0) / duration,
+            'tally': tally,
+        }
+
+
+def run_level(urls, mids, concurrency, duration, timeout, pace, label):
+    probe = Probe(urls, mids, timeout, pace)
+    s = probe.run(concurrency, duration)
+    first = f"{s['first_352_at']:.1f}s" if s['first_352_at'] is not None else 'never'
+    pct = (s['throttled'] / s['total'] * 100) if s['total'] else 0.0
+    print(
+        f"  {label:<12}{concurrency:>5}{s['total']:>8}{s['ok']:>8}{s['throttled']:>9}"
+        f"{pct:>7.1f}%{s['burst']:>8}{first:>9}{s['settled_rps']:>11.2f}"
+    )
+    if s['other']:
+        odd = {k: v for k, v in s['tally'].items() if k not in ('ok', 'throttled')}
+        print(f"  {'':<12}{'':>5}  other outcomes: {odd}")
+    return s
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument('--sweep', default='1,5,10,20,50',
+                    help='comma-separated concurrency levels (default: 1,5,10,20,50)')
+    ap.add_argument('--duration', type=float, default=45.0,
+                    help='seconds per level; needs to exceed the burst allowance (default: 45)')
+    ap.add_argument('--per-worker', action='store_true',
+                    help='test each worker URL alone, to see if the limit is per-platform')
+    ap.add_argument('--pace', type=float, default=0.0,
+                    help='seconds each thread sleeps between requests -- use this to evaluate '
+                         'a pacing fix (default: 0)')
+    ap.add_argument('--timeout', type=float, default=15.0)
+    ap.add_argument('--mids', help='file with one mid per line; defaults to a built-in real set')
+    args = ap.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[3]
+    workers = load_workers(repo_root)
+    mids = ([int(x) for x in Path(args.mids).read_text().split()] if args.mids else DEFAULT_MIDS)
+    levels = [int(x) for x in args.sweep.split(',')]
+
+    print(f"member_card throttle probe -- {len(workers)} workers, {len(mids)} mids, "
+          f"{args.duration:.0f}s per level, pace={args.pace}s")
+    print("\n  settled_rps is the number that matters: sustained successful req/s in the final")
+    print("  third of the window, after the burst allowance is spent. Near zero => job stalls.\n")
+    header = (f"  {'target':<12}{'conc':>5}{'reqs':>8}{'ok':>8}{'-352':>9}{'352%':>8}"
+              f"{'burst':>8}{'1st352':>9}{'settled/s':>11}")
+    print(header)
+    print('  ' + '-' * (len(header) - 2))
+
+    targets = ([(worker_label(u), [u]) for u in workers] if args.per_worker
+               else [('all workers', workers)])
+    results = {}
+    for label, urls in targets:
+        for c in levels:
+            results[(label, c)] = run_level(urls, mids, c, args.duration,
+                                            args.timeout, args.pace, label)
+        if args.per_worker:
+            print()
+
+    print("\n  verdict:")
+    for (label, c), s in results.items():
+        need = 24931 / s['settled_rps'] / 3600 if s['settled_rps'] > 0.01 else None
+        eta = f"{need:.1f}h to do 24,931 members" if need else "job would NEVER finish"
+        print(f"    {label:<12} conc={c:<4} settled {s['settled_rps']:>6.2f}/s  ->  {eta}")
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Adds `service/workers/card/` and a tool for testing anti-`-352` changes without running the production job.

## Why `card/` exists

`get_member_card` is the only endpoint deployed to more than one platform, and the only one bilibili rate-limits:

| Endpoint | Workers |
|---|---|
| `get_member_card` | **4** — AWS fn-url, AWS API Gateway, GCP Cloud Run, Azure |
| everything else | 1 — AWS only, sufficient |

Four URLs but **three backends** — both AWS entries are one Lambda behind two front doors (confirmed via `apigatewayv2 get-integrations`; warm latency 393 ms vs 385 ms). So AWS carries ~50% of the traffic.

The card workers differ from `../template/` in two ways:

1. `baseUrl` pinned to `/x/web-interface/card` — templates ship a per-deploy placeholder
2. the caller's `User-Agent` is forwarded upstream — templates call `fetch(url.href)` bare

`../template/` is left exactly as it was. The differing placeholders there are intentional.

## The incident this came out of

The AWS template was deployed to member-card with `/newlist` still in place. The worker returned a tid=30 category listing — **HTTP 200, `code: 0`, well-formed JSON**, just the wrong endpoint.

**CloudWatch showed zero errors for the entire window.** Lambda's `Errors` metric counts crashes and timeouts, not wrong answers. It surfaced only as `FormatError` inside `Service.get_member_card`, at a measured 66.7% failure rate.

## Why `probe_throttle.py` exists

After fixing the workers I verified them by hand — a handful of sequential requests, all `code: 0`, all four correct. Then the job was started and **stalled at 288 of 24,931 members within three minutes**, every one of its 50 workers cycling `-352` → sleep 60 s → retry.

The verification was true and useless. **The throttle has a burst allowance**, so low-rate and short probes sail through it and prove nothing about production.

So the probe fires at a real concurrency for a sustained window and reports **`settled/s`** — successful req/s in the final third, after the allowance is spent:

| conc | reqs | ok | −352 | burst | 1st −352 | settled/s | verdict |
|---:|---:|---:|---:|---:|---:|---:|---|
| 1 | 74 | 67 | 0 | 67 | never | 2.50 | 2.8 h for 24,931 members |
| 10 | 881 | 772 | 43 | 723 | 27.1 s | 25.40 | 0.3 h |
| 50 | 6192 | 63 | 6115 | 0 | 0.5 s | **0.00** | **never finishes** |

conc=50 is what `16_` uses, and `0.00/s` is exactly what it did. **The tool reproduces the real failure in 45 seconds.**

```bash
python service/workers/card/probe_throttle.py --sweep 1,5,10,20,50   # find the ceiling
python service/workers/card/probe_throttle.py --per-worker --sweep 20 # per-platform or global?
python service/workers/card/probe_throttle.py --sweep 50 --pace 0.5   # does pacing help?
```

## What this does not fix

**`-352` is still unsolved, deliberately.** UA forwarding was necessary but not sufficient — sequential requests succeed on any UA (18 across modern, legacy and mobile, all `code: 0`); 50 concurrent fail on all of them. The throttle is **rate-based, not fingerprint-based**.

One thing the numbers suggest, untested: `16_`'s comment justifies 50 workers on the grounds that each member is mostly parked in the 60 s sleep, so more workers means more sleeping in parallel. If the throttle is rate-based, that reasoning inverts — the concurrency is *causing* the sleeps. conc=10 sustains 25.4/s while conc=50 sustains zero. Worth measuring with `--sweep` before changing `job_num`.

## Note

Leave 2–5 minutes between probe runs. The throttle persists after a run ends — the conc=50 row shows `burst=0` because it followed conc=10 immediately. Documented in the tool.

🤖 Generated with [Claude Code](https://claude.com/claude-code)