### PR TITLE
feat: SQLite run-record store + 51_ integration (BL-0001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,18 @@ data/
 *.csv
 test*
 
+# run-record SQLite db + its derived files (the default path lives under data/
+# and is already ignored; this also covers a db pointed elsewhere)
+*.sqlite3
+*.sqlite3-journal
+*.sqlite3-wal
+*.sqlite3-shm
+
 # config
 conf/conf.ini
 service/endpoints.json
+
+# the committed run-record test suite -- its dir name matches `test*` above
+!/tests/
+!/tests/**
+/tests/**/__pycache__/

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -15,6 +15,7 @@ from typing import Optional
 from core import RecordNew
 from service import Service
 from job import FetchVideoRecordJob, BatchInsertVideoRecordJob, UpdateVideoJob, Job, JobPool
+from runrecord import RunRecorder
 from timer import Timer
 import logging
 
@@ -197,11 +198,20 @@ class VideoRecordAcquisitionJob(Job):
     the ~560/s network-capped arrival), so no writer parallelism is needed.
     """
 
+    # pool labels, reused as run-record metric scopes
+    FETCH_LABEL = 'record-fetch'
+    WRITER_LABEL = 'record-db-writer'
+    UPDATE_LABEL = 'record-video-update'
+
     def __init__(self, time_task: str, record_queue: Queue[RecordNew]):
         super().__init__('acquisition')
         self.time_task = time_task      # full stamp, ex: '2026-07-14 08:00'
         self.time_label = time_task[-5:]  # hour only, ex: '08:00'
         self.record_queue = record_queue
+        # merged JobStats, populated by process(); stay None if process() raised
+        self.fetch_stat = None
+        self.writer_stat = None
+        self.update_stat = None
 
     def process(self):
         session = Session()
@@ -210,17 +220,24 @@ class VideoRecordAcquisitionJob(Job):
         self.logger.info(
             f'{len(need_insert_aid_list)} aid(s) need insert for time label {self.time_label}.')
 
-        fetch_and_batch_insert_records(
+        self.fetch_stat, self.writer_stat, self.update_stat = fetch_and_batch_insert_records(
             need_insert_aid_list, self.record_queue,
             job_num=300,
-            fetch_label='record-fetch',
-            writer_label='record-db-writer',
+            fetch_label=self.FETCH_LABEL,
+            writer_label=self.WRITER_LABEL,
             logger_name='VideoRecordAcquisitionJob',
             duration_limit_s=60 * 40,  # 40 minutes, caps the 04:00 full scan
             recovery_path=f'data/record_recovery_{_stamp(self.time_task)}.csv',
-            update_job_num=10, update_label='record-video-update')
+            update_job_num=10, update_label=self.UPDATE_LABEL)
 
         self.logger.info('Finish add need insert aid list!')
+
+    def stats(self) -> dict:
+        """{scope_label: merged JobStat} for the stats that were produced."""
+        pairs = ((self.FETCH_LABEL, self.fetch_stat),
+                 (self.WRITER_LABEL, self.writer_stat),
+                 (self.UPDATE_LABEL, self.update_stat))
+        return {label: stat for label, stat in pairs if stat is not None}
 
 # TODO: change to record new
 class RecordsSaveToFileRunner(Thread):
@@ -703,7 +720,7 @@ class RecentActivityFreqUpdateRunner(Thread):
             'Finish update recent, activity, freq fields of video!')
 
 
-def run_hourly_video_record_add(time_task):
+def run_hourly_video_record_add(time_task, recorder: Optional[RunRecorder] = None):
     time_label = time_task[-5:]  # current time, ex: 19:00
     logger.info(
         'Now start hourly video record add, time label: %s..' % time_label)
@@ -716,6 +733,12 @@ def run_hourly_video_record_add(time_task):
     acquisition_runner = VideoRecordAcquisitionJob(time_task, records_queue)
     acquisition_runner.start()
     acquisition_runner.join()
+
+    # run-record metrics: the key counts of the fetch / db-writer / video-update
+    # JobStats (best-effort; a disabled recorder is a no-op)
+    if recorder is not None:
+        for scope, stat in acquisition_runner.stats().items():
+            recorder.add_job_stat_metrics(scope, stat)
 
     records = []
     while not records_queue.empty():
@@ -774,14 +797,22 @@ def hourly_video_record_add():
     time_task = f'{get_ts_s_str()[:13]}:00'
     logger.info(f'Time task: {time_task}')
 
+    # persisted run record: one row per script start, updated on the way out.
+    # Best-effort -- start() never raises and returns a no-op recorder on failure.
+    recorder = RunRecorder.start(script_fullname)
+    recorder.attach_log_locations()
+
     try:
-        run_hourly_video_record_add(time_task)
+        run_hourly_video_record_add(time_task, recorder)
     except Exception as e:
         message = f'Exception occurred when running hourly video record add! time task: {time_task}, error: {e}'
         logger.critical(message)
+        recorder.finish('failed')
         sc_send_critical(script_fullname, message,
                          __file__, get_current_line_no())
         exit(1)
+
+    recorder.finish('succeeded')
 
     timer.stop()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,8 @@ pymysql==0.9.3
 sqlalchemy==1.3.8
 configparser==4.0.2
 requests==2.32.3
+# bundled SQLite runtime for the run-record store: the prod venv-3.11 (Ubuntu
+# 16.04) was built without _sqlite3, so stdlib `import sqlite3` fails there.
+# linux-only -- there is no macOS/Windows wheel, and dev machines use stdlib
+# sqlite3 (the driver shim in runrecord/_sqlite.py prefers it).
+pysqlite3-binary==0.5.4.post2 ; sys_platform == "linux"

--- a/runrecord/__init__.py
+++ b/runrecord/__init__.py
@@ -1,0 +1,8 @@
+from . import schema
+from .recorder import (
+    RunRecorder, display_status,
+    RUNNING, SUCCEEDED, FAILED, DEFAULT_DB_PATH,
+)
+
+__all__ = ['RunRecorder', 'display_status', 'schema',
+           'RUNNING', 'SUCCEEDED', 'FAILED', 'DEFAULT_DB_PATH']

--- a/runrecord/_sqlite.py
+++ b/runrecord/_sqlite.py
@@ -1,0 +1,25 @@
+"""
+SQLite driver shim.
+
+The stdlib ``sqlite3`` module is used everywhere it is available (dev machines,
+CI). The production ``venv-3.11`` (Ubuntu 16.04, Python 3.11.3) was built without
+the ``_sqlite3`` extension, so ``import sqlite3`` raises there; on that host the
+``pysqlite3-binary`` wheel (declared in requirements.txt for linux) provides a
+drop-in DB-API module backed by its own statically-linked SQLite.
+
+Only a local reference is rebound -- ``sys.modules['sqlite3']`` is left untouched
+so nothing else in the process is affected.
+"""
+
+try:
+    import sqlite3
+except ImportError:  # pragma: no cover - exercised only on the prod venv
+    try:
+        import pysqlite3 as sqlite3  # type: ignore
+    except ImportError:
+        sqlite3 = None  # type: ignore
+        # RunRecorder.start() turns a missing driver into a disabled (no-op)
+        # recorder rather than a crash -- run recording must never break a
+        # production script.
+
+__all__ = ['sqlite3']

--- a/runrecord/recorder.py
+++ b/runrecord/recorder.py
@@ -1,0 +1,207 @@
+"""
+RunRecorder -- one structured, persisted row per script start.
+
+Usage (see 51_hourly-video-record-add.py):
+
+    recorder = RunRecorder.start('51_hourly-video-record-add')
+    recorder.attach_log_locations()
+    try:
+        ... do the work ...
+        recorder.add_job_stat_metrics('record-fetch', fetch_stat)
+        recorder.finish('succeeded')
+    except Exception:
+        recorder.finish('failed')
+        raise
+
+Every method is best-effort: any failure is logged at WARNING and swallowed, and
+`RunRecorder.start` returns a disabled (no-op) recorder if the database cannot be
+opened. Recording is an index over the logs, never a thing that can break a run.
+"""
+
+import logging
+import os
+import socket
+import subprocess
+import uuid
+from datetime import datetime, timezone
+from typing import Optional
+
+from ._sqlite import sqlite3
+from . import schema
+
+__all__ = ['RunRecorder', 'display_status', 'RUNNING', 'SUCCEEDED', 'FAILED']
+
+logger = logging.getLogger('runrecord')
+
+_BASE_DIR = os.path.dirname(os.path.dirname(__file__))
+DEFAULT_DB_PATH = os.path.join(_BASE_DIR, 'data', 'run-records.sqlite3')
+
+RUNNING = 'running'
+SUCCEEDED = 'succeeded'
+FAILED = 'failed'
+_TERMINAL = (SUCCEEDED, FAILED)
+
+# a run still 'running' this long after it started is shown as 'stale' by the
+# query side (process killed / power loss / interpreter could not finish).
+DEFAULT_STALE_AFTER_S = 3 * 60 * 60
+
+
+def _utc_now_iso() -> str:
+    # e.g. '2026-08-29T22:45:00.123456+00:00' -- ISO 8601 UTC with a +00:00 offset
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _parse_iso(value: str) -> Optional[datetime]:
+    try:
+        return datetime.fromisoformat(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _code_version() -> Optional[str]:
+    try:
+        out = subprocess.run(
+            ['git', 'rev-parse', '--short', 'HEAD'],
+            cwd=_BASE_DIR, capture_output=True, text=True, timeout=5)
+        return out.stdout.strip() or None
+    except Exception:
+        return None
+
+
+def _resolve_db_path(db_path: Optional[str]) -> str:
+    return db_path or os.environ.get('TDD_RUN_RECORD_DB') or DEFAULT_DB_PATH
+
+
+class RunRecorder:
+    def __init__(self, conn=None, run_id: Optional[str] = None):
+        self._conn = conn
+        self.run_id = run_id
+        self.enabled = conn is not None
+
+    @classmethod
+    def start(cls, script_name: str, db_path: Optional[str] = None) -> 'RunRecorder':
+        try:
+            if sqlite3 is None:
+                raise RuntimeError('no SQLite driver available '
+                                   '(stdlib sqlite3 missing, pysqlite3 not installed)')
+            path = _resolve_db_path(db_path)
+            parent = os.path.dirname(path)
+            if parent:
+                os.makedirs(parent, exist_ok=True)
+            conn = sqlite3.connect(path, timeout=30)
+            schema.init(conn)
+            run_id = uuid.uuid4().hex
+            conn.execute(
+                'INSERT INTO run (run_id, script_name, host, code_version, '
+                'started_at, finished_at, status) '
+                'VALUES (?, ?, ?, ?, ?, NULL, ?)',
+                (run_id, script_name, socket.gethostname(), _code_version(),
+                 _utc_now_iso(), RUNNING))
+            conn.commit()
+            logger.info(f'run record started: run_id={run_id}, db={path}')
+            return cls(conn, run_id)
+        except Exception as e:
+            logger.warning(f'run record disabled: could not start ({e!r})')
+            return cls(None, None)
+
+    def attach_log_locations(self, source_logger: Optional[logging.Logger] = None) -> None:
+        """Record the baseFilename of every active FileHandler, keyed by level."""
+        if not self.enabled:
+            return
+        try:
+            root = source_logger if source_logger is not None else logging.getLogger()
+            rows = [
+                (self.run_id, logging.getLevelName(h.level), h.baseFilename)
+                for h in root.handlers
+                if isinstance(h, logging.FileHandler)
+            ]
+            if rows:
+                self._conn.executemany(
+                    'INSERT OR IGNORE INTO run_log (run_id, level, path) VALUES (?, ?, ?)',
+                    rows)
+                self._conn.commit()
+        except Exception as e:
+            logger.warning(f'run record: failed to attach log locations ({e!r})')
+
+    def add_metric(self, scope: str, name: str, value: float,
+                   unit: Optional[str] = None) -> None:
+        if not self.enabled:
+            return
+        try:
+            self._conn.execute(
+                'INSERT OR REPLACE INTO run_metric (run_id, scope, name, value, unit) '
+                'VALUES (?, ?, ?, ?, ?)',
+                (self.run_id, scope, name, float(value), unit))
+            self._conn.commit()
+        except Exception as e:
+            logger.warning(f'run record: failed to add metric {scope}/{name} ({e!r})')
+
+    def add_job_stat_metrics(self, scope: str, stat) -> None:
+        """
+        Persist the key counts of one JobStat under `scope`: total_count plus
+        every condition counter (the `*_ms` stage-timing accumulators are left
+        out -- they are durations, not counts, and not part of this contract).
+        """
+        if not self.enabled or stat is None:
+            return
+        try:
+            rows = [(self.run_id, scope, 'total_count', float(stat.total_count), 'count')]
+            for name, value in stat.condition.items():
+                if name.endswith('_ms'):
+                    continue
+                rows.append((self.run_id, scope, name, float(value), 'count'))
+            self._conn.executemany(
+                'INSERT OR REPLACE INTO run_metric (run_id, scope, name, value, unit) '
+                'VALUES (?, ?, ?, ?, ?)', rows)
+            self._conn.commit()
+        except Exception as e:
+            logger.warning(f'run record: failed to add metrics for scope {scope!r} ({e!r})')
+
+    def finish(self, status: str) -> None:
+        if not self.enabled:
+            return
+        if status not in _TERMINAL:
+            logger.warning(f'run record: ignoring non-terminal finish status {status!r}')
+            return
+        try:
+            self._conn.execute(
+                'UPDATE run SET finished_at = ?, status = ? WHERE run_id = ?',
+                (_utc_now_iso(), status, self.run_id))
+            self._conn.commit()
+            logger.info(f'run record finished: run_id={self.run_id}, status={status}')
+        except Exception as e:
+            logger.warning(f'run record: failed to finish ({e!r})')
+        finally:
+            self._close()
+
+    def _close(self) -> None:
+        try:
+            if self._conn is not None:
+                self._conn.close()
+        except Exception:
+            pass
+        self._conn = None
+        self.enabled = False
+
+
+def display_status(status: str, started_at: str, finished_at: Optional[str] = None,
+                   now: Optional[datetime] = None,
+                   stale_after_s: int = DEFAULT_STALE_AFTER_S) -> str:
+    """
+    Query-side display status. Persisted status is only ever running / succeeded
+    / failed; a run stuck in 'running' past `stale_after_s` is surfaced as
+    'stale'. Read-time only -- nothing writes 'stale'.
+    """
+    if status != RUNNING:
+        return status
+    started = _parse_iso(started_at)
+    if started is None:
+        return RUNNING
+    now_dt = now if now is not None else datetime.now(timezone.utc)
+    if started.tzinfo is None:
+        started = started.replace(tzinfo=timezone.utc)
+    if now_dt.tzinfo is None:
+        now_dt = now_dt.replace(tzinfo=timezone.utc)
+    if (now_dt - started).total_seconds() > stale_after_s:
+        return 'stale'
+    return RUNNING

--- a/runrecord/schema.py
+++ b/runrecord/schema.py
@@ -1,0 +1,65 @@
+"""
+Schema for the run-records SQLite database.
+
+One row in ``run`` per independent script start. Script-specific counters live in
+the associated ``run_metric`` table (so the fixed ``run`` columns never grow),
+and the active log-file paths live in ``run_log`` (a run may write INFO, WARNING
+and optionally DEBUG files at once, so this is a set, not a column).
+
+Deliberately NOT stored: ``exit_code`` (a script cannot reliably read its own),
+free-text ``summary`` (it duplicates the structured fields + metrics), and
+``duration_ms`` (derivable from ``finished_at - started_at``).
+
+``init`` is idempotent and doubles as the migration entry point: it bumps
+``PRAGMA user_version`` and applies any future migration steps in order.
+"""
+
+__all__ = ['SCHEMA_VERSION', 'init']
+
+SCHEMA_VERSION = 1
+
+_DDL_V1 = """
+CREATE TABLE IF NOT EXISTS run (
+    run_id       TEXT PRIMARY KEY,
+    script_name  TEXT NOT NULL,
+    host         TEXT NOT NULL,
+    code_version TEXT,
+    started_at   TEXT NOT NULL,
+    finished_at  TEXT,
+    status       TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_run_script_started ON run (script_name, started_at);
+CREATE INDEX IF NOT EXISTS idx_run_status ON run (status);
+
+CREATE TABLE IF NOT EXISTS run_metric (
+    run_id TEXT NOT NULL REFERENCES run (run_id),
+    scope  TEXT NOT NULL,
+    name   TEXT NOT NULL,
+    value  REAL NOT NULL,
+    unit   TEXT,
+    PRIMARY KEY (run_id, scope, name)
+);
+
+CREATE TABLE IF NOT EXISTS run_log (
+    run_id TEXT NOT NULL REFERENCES run (run_id),
+    level  TEXT NOT NULL,
+    path   TEXT NOT NULL,
+    PRIMARY KEY (run_id, level, path)
+);
+"""
+
+
+def init(conn):
+    """Create/upgrade the schema on ``conn``. Idempotent."""
+    current = conn.execute('PRAGMA user_version').fetchone()[0]
+
+    if current < 1:
+        conn.executescript(_DDL_V1)
+
+    # future: `if current < 2: conn.executescript(_DDL_V2)` ...
+
+    if current != SCHEMA_VERSION:
+        # PRAGMA does not accept bound parameters
+        conn.execute(f'PRAGMA user_version = {SCHEMA_VERSION}')
+    conn.commit()

--- a/tests/test_run_record.py
+++ b/tests/test_run_record.py
@@ -1,0 +1,363 @@
+"""
+Tests / reproducible verification for the run-record store (BL-0001).
+
+Run from the repo root:
+
+    python tests/test_run_record.py
+    # or
+    python -m unittest discover -s tests
+
+Uses only the stdlib (unittest + stdlib sqlite3). On a dev machine the driver
+shim in runrecord/_sqlite.py resolves to the stdlib sqlite3; the production
+venv-3.11 uses the pysqlite3-binary wheel instead (verified separately on the
+Ubuntu 16.04 host).
+"""
+
+import logging
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runrecord import RunRecorder, display_status, schema  # noqa: E402
+from runrecord._sqlite import sqlite3  # noqa: E402
+
+
+class FakeStat:
+    """Duck-types job.JobStat for add_job_stat_metrics (total_count + condition)."""
+
+    def __init__(self, total_count, condition):
+        self.total_count = total_count
+        self.condition = condition
+
+
+def _connect(path):
+    return sqlite3.connect(path)
+
+
+def _rows(path, query, params=()):
+    conn = _connect(path)
+    try:
+        return conn.execute(query, params).fetchall()
+    finally:
+        conn.close()
+
+
+class SchemaTest(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.path = os.path.join(self.dir, 'db.sqlite3')
+
+    def test_init_is_idempotent_and_versioned(self):
+        conn = _connect(self.path)
+        schema.init(conn)
+        schema.init(conn)  # second call must be a no-op
+        version = conn.execute('PRAGMA user_version').fetchone()[0]
+        self.assertEqual(version, schema.SCHEMA_VERSION)
+        tables = {r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'")}
+        self.assertLessEqual({'run', 'run_metric', 'run_log'}, tables)
+        conn.close()
+
+    def test_run_table_omits_forbidden_columns(self):
+        conn = _connect(self.path)
+        schema.init(conn)
+        cols = {r[1] for r in conn.execute('PRAGMA table_info(run)')}
+        self.assertEqual(cols, {
+            'run_id', 'script_name', 'host', 'code_version',
+            'started_at', 'finished_at', 'status'})
+        for forbidden in ('exit_code', 'summary', 'duration_ms'):
+            self.assertNotIn(forbidden, cols)
+        conn.close()
+
+    def test_metric_and_log_semantics(self):
+        conn = _connect(self.path)
+        schema.init(conn)
+        metric_cols = [r[1] for r in conn.execute('PRAGMA table_info(run_metric)')]
+        self.assertEqual(metric_cols, ['run_id', 'scope', 'name', 'value', 'unit'])
+        log_cols = [r[1] for r in conn.execute('PRAGMA table_info(run_log)')]
+        self.assertEqual(log_cols, ['run_id', 'level', 'path'])
+        conn.close()
+
+
+class FreshEnvTest(unittest.TestCase):
+    def test_start_creates_nested_db_and_schema(self):
+        d = tempfile.mkdtemp()
+        path = os.path.join(d, 'data', 'nested', 'run-records.sqlite3')
+        self.assertFalse(os.path.exists(path))
+        rec = RunRecorder.start('51_hourly-video-record-add', db_path=path)
+        self.addCleanup(rec.finish, 'succeeded')
+        self.assertTrue(rec.enabled)
+        self.assertTrue(os.path.exists(path))
+        version = _rows(path, 'PRAGMA user_version')[0][0]
+        self.assertEqual(version, schema.SCHEMA_VERSION)
+
+
+class RunLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.path = os.path.join(tempfile.mkdtemp(), 'db.sqlite3')
+
+    def _core(self):
+        return _rows(
+            self.path,
+            'SELECT run_id, script_name, host, code_version, started_at, '
+            'finished_at, status FROM run')
+
+    def test_start_creates_unique_running_row_with_core_fields(self):
+        rec = RunRecorder.start('51_hourly-video-record-add', db_path=self.path)
+        rows = self._core()
+        self.assertEqual(len(rows), 1)
+        run_id, script_name, host, code_version, started_at, finished_at, status = rows[0]
+        self.assertEqual(run_id, rec.run_id)
+        self.assertTrue(run_id)
+        self.assertEqual(script_name, '51_hourly-video-record-add')
+        self.assertTrue(host)
+        # code_version is git-derived; may be None off a checkout but the column exists
+        self.assertIn(type(code_version), (str, type(None)))
+        self.assertTrue(started_at)
+        self.assertIsNone(finished_at)
+        self.assertEqual(status, 'running')
+
+        rec2 = RunRecorder.start('51_hourly-video-record-add', db_path=self.path)
+        self.assertNotEqual(rec.run_id, rec2.run_id)
+        self.assertEqual(len(self._core()), 2)
+        rec.finish('succeeded')
+        rec2.finish('succeeded')
+
+    def test_timestamps_are_iso8601_utc_with_offset(self):
+        rec = RunRecorder.start('s', db_path=self.path)
+        rec.finish('succeeded')
+        started_at, finished_at = _rows(
+            self.path, 'SELECT started_at, finished_at FROM run')[0]
+        for value in (started_at, finished_at):
+            self.assertTrue(value.endswith('+00:00'), value)
+            parsed = datetime.fromisoformat(value)
+            self.assertEqual(parsed.utcoffset(), timedelta(0))
+        self.assertLessEqual(
+            datetime.fromisoformat(started_at), datetime.fromisoformat(finished_at))
+
+    def test_status_lifecycle_succeeded(self):
+        rec = RunRecorder.start('s', db_path=self.path)
+        self.assertEqual(self._core()[0][6], 'running')
+        rec.finish('succeeded')
+        self.assertEqual(self._core()[0][6], 'succeeded')
+
+    def test_status_lifecycle_failed(self):
+        rec = RunRecorder.start('s', db_path=self.path)
+        rec.finish('failed')
+        self.assertEqual(self._core()[0][6], 'failed')
+
+    def test_non_terminal_finish_status_ignored(self):
+        rec = RunRecorder.start('s', db_path=self.path)
+        rec.finish('running')  # not allowed
+        self.assertEqual(self._core()[0][6], 'running')
+        self.assertIsNone(self._core()[0][5])
+        rec.finish('succeeded')
+
+
+class DisplayStatusTest(unittest.TestCase):
+    def test_terminal_status_passes_through(self):
+        now = datetime(2026, 8, 29, 12, 0, tzinfo=timezone.utc)
+        old = (now - timedelta(hours=99)).isoformat()
+        self.assertEqual(display_status('succeeded', old, now=now), 'succeeded')
+        self.assertEqual(display_status('failed', old, now=now), 'failed')
+
+    def test_running_within_budget_stays_running(self):
+        now = datetime(2026, 8, 29, 12, 0, tzinfo=timezone.utc)
+        started = (now - timedelta(minutes=20)).isoformat()
+        self.assertEqual(display_status('running', started, now=now), 'running')
+
+    def test_running_past_budget_is_stale(self):
+        now = datetime(2026, 8, 29, 12, 0, tzinfo=timezone.utc)
+        started = (now - timedelta(hours=5)).isoformat()
+        self.assertEqual(display_status('running', started, now=now), 'stale')
+
+    def test_custom_budget(self):
+        now = datetime(2026, 8, 29, 12, 0, tzinfo=timezone.utc)
+        started = (now - timedelta(minutes=50)).isoformat()
+        self.assertEqual(
+            display_status('running', started, now=now, stale_after_s=2400), 'stale')
+
+
+class MetricsTest(unittest.TestCase):
+    def setUp(self):
+        self.path = os.path.join(tempfile.mkdtemp(), 'db.sqlite3')
+
+    def test_three_job_stat_scopes_recorded(self):
+        rec = RunRecorder.start('51_hourly-video-record-add', db_path=self.path)
+        stats = {
+            'record-fetch': FakeStat(997715, {
+                'success': 995500, 'code_error': 2215, 'other_exception': 0,
+                'record_dropped_queue_full': 0, 'duration_limit_reached': 0,
+                'http_ms': 431900}),  # *_ms must be excluded
+            'record-db-writer': FakeStat(995500, {
+                'batch_insert': 996, 'batch_insert_fail': 0}),
+            'record-video-update': FakeStat(2215, {
+                'update_exception': 0, 'duration_limit_reached': 0}),
+        }
+        for scope, stat in stats.items():
+            rec.add_job_stat_metrics(scope, stat)
+        rec.finish('succeeded')
+
+        rows = _rows(
+            self.path,
+            'SELECT run_id, scope, name, value, unit FROM run_metric ORDER BY scope, name')
+        by_scope = {}
+        for run_id, scope, name, value, unit in rows:
+            self.assertEqual(run_id, rec.run_id)
+            self.assertEqual(unit, 'count')
+            self.assertIsInstance(value, float)
+            by_scope.setdefault(scope, {})[name] = value
+
+        self.assertEqual(set(by_scope), set(stats))
+        self.assertEqual(by_scope['record-fetch']['total_count'], 997715.0)
+        self.assertEqual(by_scope['record-fetch']['success'], 995500.0)
+        self.assertEqual(by_scope['record-fetch']['code_error'], 2215.0)
+        self.assertNotIn('http_ms', by_scope['record-fetch'])
+        self.assertEqual(by_scope['record-db-writer']['batch_insert_fail'], 0.0)
+        self.assertEqual(by_scope['record-video-update']['total_count'], 2215.0)
+
+    def test_metric_values_are_numeric_only(self):
+        rec = RunRecorder.start('s', db_path=self.path)
+        rec.add_metric('scope', 'name', 5, unit='count')
+        rec.finish('succeeded')
+        (value,) = _rows(self.path, 'SELECT value FROM run_metric')[0]
+        self.assertIsInstance(value, float)
+
+
+class LogLocationTest(unittest.TestCase):
+    def test_paths_come_from_active_filehandler_basefilenames(self):
+        d = tempfile.mkdtemp()
+        db_path = os.path.join(d, 'db.sqlite3')
+        info_path = os.path.join(d, '51_202608291200_INFO.log')
+        warn_path = os.path.join(d, '51_202608291200_WARNING.log')
+
+        probe = logging.getLogger('runrecord_test_probe')
+        probe.handlers = []
+        for path, level in ((info_path, logging.INFO), (warn_path, logging.WARNING)):
+            h = logging.FileHandler(path, encoding='utf-8')
+            h.setLevel(level)
+            probe.addHandler(h)
+        # a non-file handler must be ignored
+        probe.addHandler(logging.StreamHandler())
+
+        rec = RunRecorder.start('s', db_path=db_path)
+        rec.attach_log_locations(source_logger=probe)
+        rec.finish('succeeded')
+
+        for h in probe.handlers:
+            h.close()
+
+        rows = _rows(db_path, 'SELECT run_id, level, path FROM run_log ORDER BY level')
+        self.assertEqual(len(rows), 2)
+        got = {(level, path) for _, level, path in rows}
+        self.assertEqual(got, {
+            ('INFO', info_path),
+            ('WARNING', warn_path),
+        })
+        for run_id, _, _ in rows:
+            self.assertEqual(run_id, rec.run_id)
+
+
+class DebugLogLocationTest(unittest.TestCase):
+    def test_debug_filehandler_is_captured_when_present(self):
+        d = tempfile.mkdtemp()
+        db_path = os.path.join(d, 'db.sqlite3')
+        debug_path = os.path.join(d, '51_202608291200_DEBUG.log')
+        info_path = os.path.join(d, '51_202608291200_INFO.log')
+
+        probe = logging.getLogger('runrecord_test_debug_probe')
+        probe.handlers = []
+        for path, level in ((debug_path, logging.DEBUG), (info_path, logging.INFO)):
+            h = logging.FileHandler(path, encoding='utf-8')
+            h.setLevel(level)
+            probe.addHandler(h)
+
+        rec = RunRecorder.start('s', db_path=db_path)
+        rec.attach_log_locations(source_logger=probe)
+        rec.finish('succeeded')
+        for h in probe.handlers:
+            h.close()
+
+        got = {(lvl, p) for _, lvl, p in
+               _rows(db_path, 'SELECT run_id, level, path FROM run_log')}
+        self.assertEqual(got, {('DEBUG', debug_path), ('INFO', info_path)})
+
+
+class SecretHygieneTest(unittest.TestCase):
+    def test_nothing_but_the_fixed_structured_fields_is_stored(self):
+        d = tempfile.mkdtemp()
+        db_path = os.path.join(d, 'db.sqlite3')
+        rec = RunRecorder.start('51_hourly-video-record-add', db_path=db_path)
+        rec.attach_log_locations()
+        rec.add_job_stat_metrics('record-fetch', FakeStat(10, {'success': 10}))
+        # a failed finish must persist only status/finished_at -- no message
+        rec.finish('failed')
+
+        conn = _connect(db_path)
+        # no column anywhere is a free-text message / error / summary sink
+        all_cols = set()
+        for (table,) in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"):
+            all_cols |= {r[1] for r in conn.execute(f'PRAGMA table_info({table})')}
+        for banned in ('message', 'error', 'summary', 'traceback', 'stacktrace',
+                       'desp', 'sckey', 'exit_code', 'duration_ms'):
+            self.assertNotIn(banned, all_cols)
+
+        # dump every stored string value; assert it is only the values we passed
+        strings = []
+        for table in ('run', 'run_metric', 'run_log'):
+            for row in conn.execute(f'SELECT * FROM {table}'):
+                strings += [c for c in row if isinstance(c, str)]
+        conn.close()
+        for s in strings:
+            self.assertNotRegex(s, r'(?i)sckey|token|password|secret|ftqq')
+
+
+class PersistFailureTest(unittest.TestCase):
+    def test_unopenable_db_yields_disabled_noop_recorder(self):
+        # parent path is a regular file, so makedirs / connect underneath fails
+        f = tempfile.NamedTemporaryFile(delete=False)
+        f.close()
+        bad_path = os.path.join(f.name, 'sub', 'db.sqlite3')
+
+        rec = RunRecorder.start('51_hourly-video-record-add', db_path=bad_path)
+        self.assertFalse(rec.enabled)
+        self.assertIsNone(rec.run_id)
+        # every method must be a silent no-op
+        rec.attach_log_locations()
+        rec.add_metric('s', 'n', 1)
+        rec.add_job_stat_metrics('s', FakeStat(1, {'x': 1}))
+        rec.finish('failed')
+
+    def test_start_never_raises_even_with_absurd_path(self):
+        rec = RunRecorder.start('s', db_path='/proc/nonexistent/definitely/nope.sqlite3')
+        self.assertFalse(rec.enabled)
+
+
+class RealJobStatTest(unittest.TestCase):
+    """If job.JobStat is importable standalone, exercise the real type once."""
+
+    def test_with_real_jobstat(self):
+        try:
+            from job import JobStat
+        except Exception as e:  # import chain pulls service/db on some setups
+            self.skipTest(f'job.JobStat not importable standalone: {e!r}')
+        path = os.path.join(tempfile.mkdtemp(), 'db.sqlite3')
+        stat = JobStat()
+        stat.total_count = 10
+        stat.condition['success'] = 9
+        stat.condition['code_error'] = 1
+        stat.condition['http_ms'] = 1234
+        rec = RunRecorder.start('s', db_path=path)
+        rec.add_job_stat_metrics('record-fetch', stat)
+        rec.finish('succeeded')
+        names = {r[0] for r in _rows(path, 'SELECT name FROM run_metric')}
+        self.assertEqual(names, {'total_count', 'success', 'code_error'})
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Delivers the first vertical slice of the run-record system (private backlog `BL-0001`): persist one structured, queryable row per script start, so a run can be checked without reading the full log. Scope is the SQLite core **plus wiring into `51_hourly-video-record-add.py` only** — no CLI/Web, ServerChan untouched.

## Changes

**New `runrecord/` package**
- `_sqlite.py` — driver shim: stdlib `sqlite3` → `pysqlite3` → `None`. The prod `venv-3.11` (Ubuntu 16.04) was built without `_sqlite3`, so `import sqlite3` fails there; `pysqlite3-binary` (linux-only) supplies a drop-in module with its own statically-linked SQLite. A missing driver degrades to a no-op recorder, never a crash.
- `schema.py` — idempotent `init(conn)`; `PRAGMA user_version` for versioning / future migrations. Tables:
  - `run(run_id, script_name, host, code_version, started_at, finished_at, status)` — **no** `exit_code` / `summary` / `duration_ms`
  - `run_metric(run_id, scope, name, value, unit)`
  - `run_log(run_id, level, path)`
- `recorder.py` — `RunRecorder` (`start` / `attach_log_locations` / `add_metric` / `add_job_stat_metrics` / `finish`), every method best-effort; `start()` returns a disabled no-op recorder on any failure. Plus `display_status()`, which derives `stale` from an overdue `running` at read time (never persisted). Timestamps are ISO 8601 UTC with a `+00:00` offset.

**`51_hourly-video-record-add.py`**
- `hourly_video_record_add()`: start recorder + attach log locations, then `finish('succeeded')` on the way out, or `finish('failed')` before the existing `sc_send_critical` + `exit(1)`. The ServerChan critical call is unchanged.
- `VideoRecordAcquisitionJob` keeps the three `JobStat`s returned by `fetch_and_batch_insert_records` and exposes them via `stats()`; the key counts of each scope (`record-fetch` / `record-db-writer` / `record-video-update`) are written as `run_metric` rows.
- Log locations come straight from the active `FileHandler.baseFilename`s set up by `logging_init` (INFO / WARNING, plus DEBUG under `--debug`).

**Dependencies / ignore**
- `requirements.txt` += `pysqlite3-binary==0.5.4.post2 ; sys_platform == "linux"` (no macOS/Windows wheel; dev uses stdlib sqlite3).
- `.gitignore`: ignore `*.sqlite3` + `-journal`/`-wal`/`-shm`; un-ignore `/tests/` (the existing `test*` rule also hid the tests dir).

## Testing

- `tests/test_run_record.py` — 21 stdlib-`unittest` cases: schema idempotency, UTC offset, `running`→`succeeded`/`failed` lifecycle, stale derivation, three-scope metrics semantics, log association (incl. DEBUG, excl. `StreamHandler`), persistence-failure degradation, secret hygiene. Run: `python -m unittest discover -s tests`.
- **21/21** on `venv-3.11`; 20 + 1 skip on framework Python (skipped case needs `sqlalchemy` for the real `JobStat`).
- Stubbed `51_` end-to-end run: both success and failure paths persist correctly.
- Prod **read-only** checks: `import sqlite3` fails as expected on `venv-3.11`; chosen wheel is `cp311-manylinux_2_17_x86_64` with a bundled static SQLite; `pip install --dry-run` resolves on the prod mirror.

## Not done — needs a prod deploy

Production verification of the wheel (`pip install pysqlite3-binary` into `venv-3.11` + one real `51_` run) is still pending. This is the repo's first binary dependency, and deploy is manual scp + `sync N` + blob-hash. `BL-0001` AC #1 stays unchecked until then; the ticket is in Review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG4dkgXKaWKTHwxEtdfKcn
