### PR TITLE
chore: schema-version guard + narrow test gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,13 @@ __pycache__/
 log/
 data/
 *.csv
-test*
+
+# scratch scripts/notebooks in the repo root (throwaway experiments, never
+# committed). Narrow, root-anchored patterns -- NOT a bare `test*`, which also
+# swallowed the tracked `tests/` suite.
+/test-*.py
+/test-*.ipynb
+/test.py
 
 # run-record SQLite db + its derived files (the default path lives under data/
 # and is already ignored; this also covers a db pointed elsewhere)
@@ -30,8 +36,3 @@ test*
 # config
 conf/conf.ini
 service/endpoints.json
-
-# the committed run-record test suite -- its dir name matches `test*` above
-!/tests/
-!/tests/**
-/tests/**/__pycache__/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,11 @@ the user where to write it.
 - `service/endpoints.json` (worker URLs) and `conf/conf.ini` (DB credentials)
   hold environment secrets and are git-ignored (see `.gitignore`) — never commit
   them. Their `.example` siblings are the tracked templates.
+
+## Tests
+
+- Committed tests live in `tests/`. Run them from the repo root:
+  `venv-3.11/bin/python -m unittest discover -s tests` (stdlib `unittest`, no
+  extra deps; a plain `python` works too where `venv-3.11` isn't set up).
+- Root-level `test-*.py` / `test-*.ipynb` / `test.py` are throwaway scratch and
+  are git-ignored — don't put committed tests there, and don't rely on them.

--- a/runrecord/schema.py
+++ b/runrecord/schema.py
@@ -10,11 +10,17 @@ Deliberately NOT stored: ``exit_code`` (a script cannot reliably read its own),
 free-text ``summary`` (it duplicates the structured fields + metrics), and
 ``duration_ms`` (derivable from ``finished_at - started_at``).
 
-``init`` is idempotent and doubles as the migration entry point: it bumps
-``PRAGMA user_version`` and applies any future migration steps in order.
+``init`` is idempotent and doubles as the migration entry point: it applies any
+missing migration steps in order and moves ``PRAGMA user_version`` *forward* only.
+A database written by newer code (``user_version`` > ``SCHEMA_VERSION``) is left
+untouched and ``init`` raises -- it never rewrites the version backwards.
 """
 
-__all__ = ['SCHEMA_VERSION', 'init']
+__all__ = ['SCHEMA_VERSION', 'SchemaTooNewError', 'init']
+
+
+class SchemaTooNewError(RuntimeError):
+    """The database is at a schema version this code does not understand."""
 
 SCHEMA_VERSION = 1
 
@@ -51,15 +57,27 @@ CREATE TABLE IF NOT EXISTS run_log (
 
 
 def init(conn):
-    """Create/upgrade the schema on ``conn``. Idempotent."""
+    """
+    Create/upgrade the schema on ``conn``. Idempotent.
+
+    Raises ``SchemaTooNewError`` if the database is at a higher ``user_version``
+    than this code knows about -- downgrading the version (or writing against an
+    unknown schema) would be silent corruption. ``RunRecorder.start`` turns this
+    into a disabled no-op recorder, so a version skew never breaks a run.
+    """
     current = conn.execute('PRAGMA user_version').fetchone()[0]
+
+    if current > SCHEMA_VERSION:
+        raise SchemaTooNewError(
+            f'run-records database is at schema v{current}, but this code only '
+            f'understands v{SCHEMA_VERSION}')
 
     if current < 1:
         conn.executescript(_DDL_V1)
 
     # future: `if current < 2: conn.executescript(_DDL_V2)` ...
 
-    if current != SCHEMA_VERSION:
-        # PRAGMA does not accept bound parameters
+    if current < SCHEMA_VERSION:
+        # forward only; PRAGMA does not accept bound parameters
         conn.execute(f'PRAGMA user_version = {SCHEMA_VERSION}')
     conn.commit()

--- a/tests/test_run_record.py
+++ b/tests/test_run_record.py
@@ -73,6 +73,35 @@ class SchemaTest(unittest.TestCase):
             self.assertNotIn(forbidden, cols)
         conn.close()
 
+    def test_newer_database_is_not_downgraded(self):
+        conn = _connect(self.path)
+        schema.init(conn)
+        # simulate a future schema version written by newer code
+        future = schema.SCHEMA_VERSION + 5
+        conn.execute(f'PRAGMA user_version = {future}')
+        conn.commit()
+
+        with self.assertRaises(schema.SchemaTooNewError):
+            schema.init(conn)
+        # version must be left exactly as it was, never rewritten backwards
+        self.assertEqual(conn.execute('PRAGMA user_version').fetchone()[0], future)
+        conn.close()
+
+    def test_start_on_a_newer_database_yields_disabled_recorder(self):
+        conn = _connect(self.path)
+        schema.init(conn)
+        future = schema.SCHEMA_VERSION + 5
+        conn.execute(f'PRAGMA user_version = {future}')
+        conn.commit()
+        conn.close()
+
+        rec = RunRecorder.start('s', db_path=self.path)
+        self.assertFalse(rec.enabled)
+        # the database on disk is untouched
+        self.assertEqual(
+            _rows(self.path, 'PRAGMA user_version')[0][0], future)
+        self.assertEqual(_rows(self.path, 'SELECT count(*) FROM run')[0][0], 0)
+
     def test_metric_and_log_semantics(self):
         conn = _connect(self.path)
         schema.init(conn)


### PR DESCRIPTION
Follow-up cleanup after #49 (BL-0001).

## `fix(runrecord)`: never downgrade a newer database's schema version

`schema.init()` used `current != SCHEMA_VERSION` and rewrote `user_version` whenever they differed — opening a DB written by newer code would silently stamp it **back down**. Now it moves the version forward only and raises `SchemaTooNewError` when `current > SCHEMA_VERSION`. `RunRecorder.start` already turns that into a disabled no-op recorder, so version skew degrades cleanly instead of corrupting the store.

+2 regression tests: `init()` raises and leaves `user_version` untouched on a future-versioned DB; `RunRecorder.start` returns a disabled recorder that writes nothing.

## `chore`: narrow root scratch-file gitignore so `tests/` is tracked naturally

`test*` also matched the `tests/` directory, which is why #49 needed `!/tests/` re-include hacks. Replaced with root-anchored patterns for the real scratch files (`/test-*.py`, `/test-*.ipynb`, `/test.py`); negations dropped. Test location + command now documented in `AGENTS.md`.

Verified: `git check-ignore` still ignores every root `test-*` scratch script; `tests/` tracked, `tests/__pycache__/` ignored; `python -m unittest discover -s tests` → **23 passing** (framework Python + `venv-3.11`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PG4dkgXKaWKTHwxEtdfKcn
