### PR TITLE
feat: add read-only run-record query CLI

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,15 @@ that shouldn't sit in a public repository.
 Don't create `docs/reports/`. If a milestone or incident is worth recording, ask
 the user where to write it.
 
+## Public metadata hygiene
+
+Treat this repository and its GitHub activity as public. Branch names, commit
+messages, pull-request titles and bodies, review comments, and issue text must
+stand on repository-visible evidence alone. Do not mention private planning
+systems, local absolute paths, private session links, server aliases, or
+internal deployment records. Refer to private context only in the private
+system where it lives.
+
 ## Repository notes
 
 - Scripts are numbered by role (`12_`, `51_`, …) and run from cron on the prod

--- a/runrecord/__main__.py
+++ b/runrecord/__main__.py
@@ -1,0 +1,8 @@
+"""``python -m runrecord`` -> the read-only run-record query CLI (BL-0005)."""
+
+import sys
+
+from .query import main
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/runrecord/query.py
+++ b/runrecord/query.py
@@ -1,0 +1,621 @@
+"""
+Read-only query CLI over the run-record store (BL-0005).
+
+The write side (RunRecorder, schema, the driver shim, the UTC contract) is
+BL-0001; this module never writes. It opens the SQLite database in read-only
+mode and only issues ``SELECT`` / ``PRAGMA`` statements.
+
+Run it as a module::
+
+    python -m runrecord list
+    python -m runrecord list --script 51_hourly-video-record-add --status failed --since 7d
+    python -m runrecord show --latest --script 51_hourly-video-record-add
+    python -m runrecord show a1b2c3d4          # full id or a unique prefix
+    python -m runrecord list --json            # stable machine-readable output
+
+Everything reused from the rest of the package rather than reimplemented:
+
+* ``runrecord._sqlite.sqlite3``  -- the driver shim (stdlib sqlite3 / pysqlite3).
+* ``recorder._resolve_db_path``  -- ``TDD_RUN_RECORD_DB`` / default ``data/`` path.
+* ``recorder.display_status``    -- the ``running`` -> ``stale`` derivation.
+* ``recorder._parse_iso`` / the ISO-8601-UTC timestamp contract.
+* ``schema.SCHEMA_VERSION``      -- the schema-compatibility check.
+
+Exit codes:
+
+===  ==================================================================
+  0  success -- the query ran and matched at least one run
+  1  no match -- the query is valid but nothing matched
+  2  invalid arguments (argparse)
+  3  incompatible schema -- the database is newer than this code understands
+  4  database error -- missing/corrupt database, no SQLite driver, bad table
+  5  database file not found
+===  ==================================================================
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+from datetime import datetime, timedelta, timezone
+
+from ._sqlite import sqlite3
+from .recorder import (
+    _parse_iso,
+    _resolve_db_path,
+    display_status,
+    DEFAULT_STALE_AFTER_S,
+    RUNNING,
+    SUCCEEDED,
+    FAILED,
+)
+from .schema import SCHEMA_VERSION
+
+__all__ = ['main']
+
+EXIT_OK = 0
+EXIT_NO_MATCH = 1
+EXIT_USAGE = 2
+EXIT_SCHEMA = 3
+EXIT_DB_ERROR = 4
+EXIT_NO_DB = 5
+
+# persisted statuses plus the read-time derivation
+_STATUS_CHOICES = (RUNNING, SUCCEEDED, FAILED, 'stale')
+
+# safety bound on the pre-derivation fetch; the store is a single-machine,
+# low-volume personal workload (hourly-ish runs) so this is never reached in
+# practice, it just stops a pathological query from reading an unbounded set.
+_FETCH_CAP = 100_000
+
+_CORE_COLUMNS = (
+    'run_id', 'script_name', 'host', 'code_version',
+    'started_at', 'finished_at', 'status',
+)
+_METRIC_COLUMNS = ('run_id', 'scope', 'name', 'value', 'unit')
+_LOG_COLUMNS = ('run_id', 'level', 'path')
+
+# every table + column set a v1 query may touch; all are probed up front so a
+# partially-created database fails with a concise EXIT_DB_ERROR instead of
+# leaking a sqlite3 error out of a detail query
+_REQUIRED_V1_SURFACE = (
+    ('run', _CORE_COLUMNS),
+    ('run_metric', _METRIC_COLUMNS),
+    ('run_log', _LOG_COLUMNS),
+)
+
+
+class QueryError(Exception):
+    """A query could not be answered; carries the process exit code to use."""
+
+    def __init__(self, message, exit_code=EXIT_DB_ERROR):
+        super().__init__(message)
+        self.exit_code = exit_code
+
+
+# --------------------------------------------------------------------------- #
+# time handling
+# --------------------------------------------------------------------------- #
+
+_REL_RE = re.compile(r'^(\d+)\s*([smhdw])$')
+_REL_UNIT_SECONDS = {'s': 1, 'm': 60, 'h': 3600, 'd': 86400, 'w': 604800}
+
+
+def _parse_time(value, now=None):
+    """
+    Parse a ``--since`` / ``--until`` bound into an aware UTC datetime.
+
+    Accepts a relative span (``30m``, ``24h``, ``7d``, ``2w``) measured back from
+    now, or an ISO-8601 date / datetime. A bare (offset-naive) ISO value is read
+    as UTC, matching how the store persists timestamps.
+    """
+    now = now or datetime.now(timezone.utc)
+    text = value.strip()
+
+    m = _REL_RE.match(text)
+    if m:
+        seconds = int(m.group(1)) * _REL_UNIT_SECONDS[m.group(2)]
+        return now - timedelta(seconds=seconds)
+
+    try:
+        dt = datetime.fromisoformat(text)
+    except ValueError:
+        raise QueryError(
+            f'invalid time value {value!r}: use a span like 24h/7d or an '
+            f'ISO-8601 date/datetime', EXIT_USAGE)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _duration_seconds(started_at, finished_at):
+    start = _parse_iso(started_at) if started_at else None
+    end = _parse_iso(finished_at) if finished_at else None
+    if start is None or end is None:
+        return None
+    if start.tzinfo is None:
+        start = start.replace(tzinfo=timezone.utc)
+    if end.tzinfo is None:
+        end = end.replace(tzinfo=timezone.utc)
+    return (end - start).total_seconds()
+
+
+def _human_duration(seconds):
+    if seconds is None:
+        return '-'
+    total = int(round(seconds))
+    sign = '-' if total < 0 else ''
+    total = abs(total)
+    hours, rem = divmod(total, 3600)
+    minutes, secs = divmod(rem, 60)
+    if hours:
+        return f'{sign}{hours}h{minutes}m'
+    if minutes:
+        return f'{sign}{minutes}m{secs}s'
+    return f'{sign}{secs}s'
+
+
+def _local(iso_value):
+    """ISO-8601 UTC string -> local wall-clock string, or '-' if unparseable."""
+    dt = _parse_iso(iso_value) if iso_value else None
+    if dt is None:
+        return '-'
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone().strftime('%Y-%m-%d %H:%M:%S')
+
+
+def _local_tz_label():
+    tz = datetime.now().astimezone().tzinfo
+    offset = datetime.now(timezone.utc).astimezone().strftime('%z')
+    name = tz.tzname(datetime.now()) if tz else 'local'
+    pretty = f'{offset[:3]}:{offset[3:]}' if len(offset) == 5 else offset
+    return f'{name} (UTC{pretty})'
+
+
+# --------------------------------------------------------------------------- #
+# database access (read-only)
+# --------------------------------------------------------------------------- #
+
+def _connect_ro(path):
+    """Open ``path`` read-only. Never creates or migrates the database."""
+    if sqlite3 is None:
+        raise QueryError(
+            'no SQLite driver available (stdlib sqlite3 missing, pysqlite3 not '
+            'installed)', EXIT_DB_ERROR)
+    if not os.path.exists(path):
+        raise QueryError(f'run-records database not found: {path}', EXIT_NO_DB)
+    uri = pathlib.Path(os.path.abspath(path)).as_uri() + '?mode=ro'
+    try:
+        return sqlite3.connect(uri, uri=True, timeout=5)
+    except sqlite3.Error as e:
+        raise QueryError(f'could not open database {path}: {e}', EXIT_DB_ERROR)
+
+
+def _check_schema(conn):
+    """Return the database's ``user_version``; refuse a newer schema."""
+    try:
+        version = conn.execute('PRAGMA user_version').fetchone()[0]
+    except sqlite3.DatabaseError as e:
+        raise QueryError(f'not a readable SQLite database: {e}', EXIT_DB_ERROR)
+
+    if version > SCHEMA_VERSION:
+        raise QueryError(
+            f'run-records database is at schema v{version}, but this CLI only '
+            f'understands v{SCHEMA_VERSION}; upgrade the tooling', EXIT_SCHEMA)
+
+    for table, columns in _REQUIRED_V1_SURFACE:
+        try:
+            conn.execute(f'SELECT {", ".join(columns)} FROM {table} LIMIT 0')
+        except sqlite3.DatabaseError as e:
+            raise QueryError(
+                f'database is missing the v1 "{table}" query surface ({e}); '
+                f'has it been initialised?', EXIT_DB_ERROR)
+    return version
+
+
+def _fetch_runs(conn, *, script=None, since=None, until=None, persisted_status=None,
+                order='DESC', limit=_FETCH_CAP):
+    where, params = [], []
+    if script:
+        where.append('script_name = ?')
+        params.append(script)
+    if since is not None:
+        where.append('started_at >= ?')
+        params.append(since.isoformat())
+    if until is not None:
+        where.append('started_at <= ?')
+        params.append(until.isoformat())
+    if persisted_status is not None:
+        where.append('status = ?')
+        params.append(persisted_status)
+
+    sql = f'SELECT {", ".join(_CORE_COLUMNS)} FROM run'
+    if where:
+        sql += ' WHERE ' + ' AND '.join(where)
+    sql += f' ORDER BY started_at {order}, run_id {order} LIMIT ?'
+    params.append(limit)
+    return _run_query(conn, sql, params)
+
+
+def _run_query(conn, sql, params=()):
+    """Execute a read query, translating any SQLite error into a QueryError."""
+    try:
+        return conn.execute(sql, params).fetchall()
+    except sqlite3.DatabaseError as e:
+        raise QueryError(f'query failed: {e}', EXIT_DB_ERROR)
+
+
+def _grouped_metrics(conn, run_id):
+    out = {}
+    rows = _run_query(
+        conn,
+        'SELECT scope, name, value, unit FROM run_metric WHERE run_id = ? '
+        'ORDER BY scope, name', (run_id,))
+    for scope, name, value, unit in rows:
+        out.setdefault(scope, []).append(
+            {'name': name, 'value': value, 'unit': unit})
+    return out
+
+
+def _log_paths(conn, run_id):
+    rows = _run_query(
+        conn,
+        'SELECT level, path FROM run_log WHERE run_id = ? ORDER BY level, path',
+        (run_id,))
+    return [{'level': level, 'path': path} for level, path in rows]
+
+
+# --------------------------------------------------------------------------- #
+# row -> structured record
+# --------------------------------------------------------------------------- #
+
+def _record(row, *, now, stale_after, conn=None, detail=False):
+    run_id, script_name, host, code_version, started_at, finished_at, status = row
+    shown = display_status(status, started_at, finished_at,
+                           now=now, stale_after_s=stale_after)
+    rec = {
+        'run_id': run_id,
+        'script_name': script_name,
+        'host': host,
+        'code_version': code_version,
+        'started_at': started_at,
+        'finished_at': finished_at,
+        'status': status,
+        'display_status': shown,
+        'stale': shown == 'stale',
+        'duration_s': _duration_seconds(started_at, finished_at),
+    }
+    if detail and conn is not None:
+        rec['metrics'] = _grouped_metrics(conn, run_id)
+        rec['logs'] = _log_paths(conn, run_id)
+    return rec
+
+
+def _select_by_status(records, status):
+    """Filter derived records by a requested display status.
+
+    ``running`` means genuinely running (not yet stale); ``stale`` means a
+    ``running`` row past its budget. ``succeeded`` / ``failed`` were already
+    filtered in SQL but re-checking is harmless.
+    """
+    if status is None:
+        return records
+    return [r for r in records if r['display_status'] == status]
+
+
+# --------------------------------------------------------------------------- #
+# commands
+# --------------------------------------------------------------------------- #
+
+def _persisted_prefilter(status):
+    """Map a requested display status to the persisted status to filter in SQL."""
+    if status in (RUNNING, 'stale'):
+        return RUNNING
+    return status  # succeeded / failed / None
+
+
+def _query_dict(args, command):
+    q = {'command': command, 'script': getattr(args, 'script', None),
+         'status': getattr(args, 'status', None)}
+    if command == 'list':
+        q['since'] = args.since.isoformat() if args.since else None
+        q['until'] = args.until.isoformat() if args.until else None
+        q['limit'] = args.limit
+    if command == 'show':
+        q['run_id'] = args.run_id
+        q['latest'] = args.latest
+    q['stale_after_s'] = args.stale_after
+    return q
+
+
+def _emit(records, *, args, command, db_path, db_version, detail):
+    payload = {
+        'schema_version': db_version,
+        'db_path': db_path,
+        'generated_at': datetime.now(timezone.utc).isoformat(),
+        'query': _query_dict(args, command),
+        'count': len(records),
+        'runs': records,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True))
+    elif command == 'show':
+        _print_detail(records[0], db_path=db_path, db_version=db_version)
+    else:
+        _print_table(records, db_path=db_path, db_version=db_version)
+    return EXIT_OK if records else EXIT_NO_MATCH
+
+
+def _cmd_list(args, conn, db_path, db_version):
+    now = datetime.now(timezone.utc)
+    rows = _fetch_runs(
+        conn, script=args.script, since=args.since, until=args.until,
+        persisted_status=_persisted_prefilter(args.status), order='DESC')
+    records = [_record(r, now=now, stale_after=args.stale_after) for r in rows]
+    records = _select_by_status(records, args.status)[:args.limit]
+    return _emit(records, args=args, command='list', db_path=db_path,
+                 db_version=db_version, detail=False)
+
+
+def _cmd_show(args, conn, db_path, db_version):
+    now = datetime.now(timezone.utc)
+    if args.run_id and args.latest:
+        raise QueryError('give a RUN_ID or --latest, not both', EXIT_USAGE)
+    if not args.run_id and not args.latest:
+        raise QueryError('give a RUN_ID or --latest', EXIT_USAGE)
+
+    if args.run_id:
+        row = _resolve_one(conn, args.run_id)
+        records = [_record(row, now=now, stale_after=args.stale_after,
+                           conn=conn, detail=True)]
+        return _emit(records, args=args, command='show', db_path=db_path,
+                     db_version=db_version, detail=True)
+
+    rows = _fetch_runs(
+        conn, script=args.script,
+        persisted_status=_persisted_prefilter(args.status), order='DESC')
+    records = [_record(r, now=now, stale_after=args.stale_after) for r in rows]
+    records = _select_by_status(records, args.status)
+    if not records:
+        return EXIT_NO_MATCH
+    chosen = records[0]
+    full = _record(
+        next(r for r in rows if r[0] == chosen['run_id']),
+        now=now, stale_after=args.stale_after, conn=conn, detail=True)
+    return _emit([full], args=args, command='show', db_path=db_path,
+                 db_version=db_version, detail=True)
+
+
+def _resolve_one(conn, run_id):
+    exact = _run_query(
+        conn, f'SELECT {", ".join(_CORE_COLUMNS)} FROM run WHERE run_id = ?',
+        (run_id,))
+    if len(exact) == 1:
+        return exact[0]
+
+    like = _run_query(
+        conn,
+        f'SELECT {", ".join(_CORE_COLUMNS)} FROM run WHERE run_id LIKE ? '
+        f'ESCAPE \'\\\' ORDER BY run_id LIMIT 2',
+        (run_id.replace('\\', '\\\\').replace('%', '\\%').replace('_', '\\_') + '%',))
+    if len(like) == 1:
+        return like[0]
+    if len(like) > 1:
+        raise QueryError(f'run id prefix {run_id!r} is ambiguous', EXIT_USAGE)
+    raise QueryError(f'no run with id {run_id!r}', EXIT_NO_MATCH)
+
+
+# --------------------------------------------------------------------------- #
+# human-readable rendering
+# --------------------------------------------------------------------------- #
+
+def _meta_line(db_path, db_version, count):
+    return (f'{count} run(s)   db: {db_path}   schema: v{db_version}   '
+            f'times: {_local_tz_label()}')
+
+
+def _print_table(records, *, db_path, db_version):
+    print(_meta_line(db_path, db_version, len(records)))
+    if not records:
+        print('(no matching runs)')
+        return
+    print()
+    print(f'{"STARTED (local)":<19}  {"SCRIPT":<32}  {"STATUS":<9}  '
+          f'{"DURATION":>8}  RUN ID')
+    for r in records:
+        script = r['script_name']
+        if len(script) > 32:
+            script = script[:31] + '…'
+        print(f'{_local(r["started_at"]):<19}  {script:<32}  '
+              f'{r["display_status"]:<9}  '
+              f'{_human_duration(r["duration_s"]):>8}  {r["run_id"][:12]}')
+
+
+def _print_detail(r, *, db_path, db_version):
+    print(_meta_line(db_path, db_version, 1))
+    print()
+    rows = [
+        ('run_id', r['run_id']),
+        ('script', r['script_name']),
+        ('host', r['host']),
+        ('code_version', r['code_version'] or '-'),
+        ('started', f'{_local(r["started_at"])}   ({r["started_at"]})'),
+        ('finished', (f'{_local(r["finished_at"])}   ({r["finished_at"]})'
+                      if r['finished_at'] else '-')),
+        ('duration', _human_duration(r['duration_s'])),
+        ('status', f'{r["status"]} (persisted)'),
+        ('display', r['display_status']),
+    ]
+    width = max(len(k) for k, _ in rows)
+    for key, value in rows:
+        print(f'{key:<{width}}  {value}')
+
+    metrics = r.get('metrics') or {}
+    print()
+    if metrics:
+        print('metrics:')
+        for scope in sorted(metrics):
+            print(f'  {scope}')
+            entries = metrics[scope]
+            name_w = max((len(e['name']) for e in entries), default=0)
+            rendered = []
+            for e in entries:
+                value = e['value']
+                if isinstance(value, float) and value.is_integer():
+                    value = int(value)
+                rendered.append((e['name'], str(value), e['unit']))
+            value_w = max((len(v) for _, v, _ in rendered), default=0)
+            for name, value, unit in rendered:
+                unit = f'  {unit}' if unit else ''
+                print(f'    {name:<{name_w}}  {value:>{value_w}}{unit}')
+    else:
+        print('metrics: (none)')
+
+    logs = r.get('logs') or []
+    print()
+    if logs:
+        print('logs:')
+        level_w = max(len(l['level']) for l in logs)
+        for l in logs:
+            print(f'  {l["level"]:<{level_w}}  {l["path"]}')
+    else:
+        print('logs: (none)')
+
+
+# --------------------------------------------------------------------------- #
+# argument parsing / entry point
+# --------------------------------------------------------------------------- #
+
+_EPILOG = (
+    'exit codes: 0 ok, 1 no match, 2 bad arguments, 3 incompatible schema, '
+    '4 database error, 5 database file not found.\n\n'
+    'examples:\n'
+    '  python -m runrecord list\n'
+    '  python -m runrecord list --script 51_hourly-video-record-add --since 7d\n'
+    '  python -m runrecord list --status stale --json\n'
+    '  python -m runrecord show --latest --script 51_hourly-video-record-add\n'
+    '  python -m runrecord show a1b2c3d4\n')
+
+
+def _add_common(parser):
+    parser.add_argument(
+        '--db', metavar='PATH', default=None,
+        help='path to the run-records SQLite file (default: $TDD_RUN_RECORD_DB '
+             'or <repo>/data/run-records.sqlite3)')
+    parser.add_argument(
+        '--stale-after', type=int, default=DEFAULT_STALE_AFTER_S, metavar='SECONDS',
+        help='a "running" run older than this is shown as "stale" '
+             f'(default: {DEFAULT_STALE_AFTER_S})')
+    parser.add_argument(
+        '--json', action='store_true',
+        help='emit a stable machine-readable JSON document instead of a table')
+
+
+def _top_parser():
+    parser = argparse.ArgumentParser(
+        prog='python -m runrecord',
+        description='Read-only query CLI over the run-record store. The default '
+                    'command is "list".',
+        epilog=_EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
+    sub = parser.add_subparsers(dest='command', metavar='{list,show}')
+    sub.add_parser('list', help='list recent runs (default)', add_help=False)
+    sub.add_parser('show', help='show one run in full', add_help=False)
+    _add_common(parser)
+    return parser
+
+
+def _list_parser():
+    parser = argparse.ArgumentParser(
+        prog='python -m runrecord list',
+        description='List recent runs, most recent first.',
+        epilog=_EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
+    _add_common(parser)
+    parser.add_argument('--script', metavar='NAME', help='exact script_name')
+    parser.add_argument('--status', choices=_STATUS_CHOICES,
+                        help='filter by persisted or derived status')
+    parser.add_argument('--since', metavar='WHEN',
+                        help='only runs started at/after this (span 24h/7d or ISO)')
+    parser.add_argument('--until', metavar='WHEN',
+                        help='only runs started at/before this (span or ISO)')
+    parser.add_argument('--limit', type=int, default=20, metavar='N',
+                        help='max rows to show (default: 20)')
+    return parser
+
+
+def _show_parser():
+    parser = argparse.ArgumentParser(
+        prog='python -m runrecord show',
+        description='Show one run: core fields, derived duration/stale status, '
+                    'grouped metrics and associated log paths.',
+        epilog=_EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
+    _add_common(parser)
+    parser.add_argument('run_id', nargs='?', metavar='RUN_ID',
+                        help='full run id or a unique prefix')
+    parser.add_argument('--latest', action='store_true',
+                        help='pick the most recent run (optionally filtered)')
+    parser.add_argument('--script', metavar='NAME',
+                        help='with --latest: restrict to this script_name')
+    parser.add_argument('--status', choices=_STATUS_CHOICES,
+                        help='with --latest: restrict to this status')
+    return parser
+
+
+def _dispatch(args):
+    db_path = _resolve_db_path(args.db)
+    conn = _connect_ro(db_path)
+    try:
+        db_version = _check_schema(conn)
+        if args.command == 'show':
+            return _cmd_show(args, conn, db_path, db_version)
+        return _cmd_list(args, conn, db_path, db_version)
+    finally:
+        conn.close()
+
+
+def _parse_args(argv):
+    """Route to a flat per-command parser; `list` is the default command."""
+    if argv and argv[0] in ('-h', '--help'):
+        _top_parser().parse_args(argv)  # prints help, raises SystemExit(0)
+    if argv and argv[0] == 'show':
+        parser, rest, command = _show_parser(), argv[1:], 'show'
+    elif argv and argv[0] == 'list':
+        parser, rest, command = _list_parser(), argv[1:], 'list'
+    else:
+        parser, rest, command = _list_parser(), argv, 'list'
+
+    args = parser.parse_args(rest)
+    args.command = command
+    if getattr(args, 'limit', 0) < 0:
+        parser.error('--limit must be non-negative')
+    if args.stale_after < 0:
+        parser.error('--stale-after must be non-negative')
+
+    # resolve time bounds here so a bad value is a clean usage error (exit 2)
+    # rather than surfacing after the database is opened
+    now = datetime.now(timezone.utc)
+    for attr in ('since', 'until'):
+        raw = getattr(args, attr, None)
+        if raw is not None:
+            try:
+                setattr(args, attr, _parse_time(raw, now))
+            except QueryError as e:
+                parser.error(str(e))
+    return args
+
+
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
+    args = _parse_args(list(argv))
+    try:
+        return _dispatch(args)
+    except QueryError as e:
+        print(f'error: {e}', file=sys.stderr)
+        return e.exit_code
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/tests/test_run_record_query.py
+++ b/tests/test_run_record_query.py
@@ -1,0 +1,494 @@
+"""
+Tests for the read-only run-record query CLI (BL-0005).
+
+Run from the repo root:
+
+    python tests/test_run_record_query.py
+    # or
+    python -m unittest discover -s tests
+
+Stdlib only (unittest + the driver shim, which resolves to stdlib sqlite3 on a
+dev machine). The CLI is exercised through ``query.main(argv)`` so exit codes and
+rendered output are both asserted.
+"""
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import time
+import unittest
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runrecord import RunRecorder, schema  # noqa: E402
+from runrecord import query  # noqa: E402
+from runrecord._sqlite import sqlite3  # noqa: E402
+
+
+def _iso(dt):
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def _make_db(path):
+    conn = sqlite3.connect(path)
+    schema.init(conn)
+    conn.close()
+
+
+def _insert_run(path, run_id, script, started_at, finished_at=None,
+                status='running', host='H', code_version='abcdef0'):
+    conn = sqlite3.connect(path)
+    schema.init(conn)
+    conn.execute(
+        'INSERT INTO run (run_id, script_name, host, code_version, started_at, '
+        'finished_at, status) VALUES (?, ?, ?, ?, ?, ?, ?)',
+        (run_id, script, host, code_version,
+         _iso(started_at) if isinstance(started_at, datetime) else started_at,
+         _iso(finished_at) if isinstance(finished_at, datetime) else finished_at,
+         status))
+    conn.commit()
+    conn.close()
+
+
+def _insert_metric(path, run_id, scope, name, value, unit='count'):
+    conn = sqlite3.connect(path)
+    conn.execute(
+        'INSERT INTO run_metric (run_id, scope, name, value, unit) '
+        'VALUES (?, ?, ?, ?, ?)', (run_id, scope, name, float(value), unit))
+    conn.commit()
+    conn.close()
+
+
+def _insert_log(path, run_id, level, log_path):
+    conn = sqlite3.connect(path)
+    conn.execute('INSERT INTO run_log (run_id, level, path) VALUES (?, ?, ?)',
+                 (run_id, level, log_path))
+    conn.commit()
+    conn.close()
+
+
+def run_cli(argv):
+    """Invoke the CLI; return (exit_code, stdout, stderr)."""
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = query.main(argv)
+    except SystemExit as e:  # argparse
+        code = e.code if isinstance(e.code, int) else (0 if e.code is None else 1)
+    return code, out.getvalue(), err.getvalue()
+
+
+class _DbCase(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.path = os.path.join(self.dir, 'run-records.sqlite3')
+        # seed relative to the real clock so --since/--until (which use the real
+        # clock) and the stale derivation line up
+        self.now = datetime.now(timezone.utc)
+
+    def seed_basic(self):
+        _make_db(self.path)
+        # three runs, staggered in time
+        _insert_run(self.path, 'aaaa1111' + '0' * 24, '51_hourly-video-record-add',
+                    self.now - timedelta(hours=3), self.now - timedelta(hours=2, minutes=52),
+                    status='succeeded')
+        _insert_run(self.path, 'bbbb2222' + '0' * 24, '12_add-latest-video-with-tid-30',
+                    self.now - timedelta(hours=2), self.now - timedelta(hours=2),
+                    status='failed')
+        _insert_run(self.path, 'cccc3333' + '0' * 24, '15_update-video-info',
+                    self.now - timedelta(minutes=30), None, status='running')
+
+
+class ListTest(_DbCase):
+    def test_lists_recent_first(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['list', '--db', self.path])
+        self.assertEqual(code, 0)
+        order = [out.index(s) for s in ('15_update-video-info',
+                                       '12_add-latest-video-with-tid-30',
+                                       '51_hourly-video-record-add')]
+        self.assertEqual(order, sorted(order))
+
+    def test_default_command_is_list(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['--db', self.path])
+        self.assertEqual(code, 0)
+        self.assertIn('51_hourly-video-record-add', out)
+
+    def test_filter_by_script(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['list', '--db', self.path,
+                                '--script', '51_hourly-video-record-add'])
+        self.assertEqual(code, 0)
+        self.assertIn('51_hourly-video-record-add', out)
+        self.assertNotIn('12_add-latest-video-with-tid-30', out)
+
+    def test_filter_by_persisted_status(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['list', '--db', self.path, '--status', 'failed'])
+        self.assertEqual(code, 0)
+        self.assertIn('12_add-latest-video-with-tid-30', out)
+        self.assertNotIn('51_hourly-video-record-add', out)
+
+    def test_limit(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['list', '--db', self.path, '--limit', '1', '--json'])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out)['count'], 1)
+
+    def test_time_range(self):
+        self.seed_basic()
+        # only the run started 30 min ago falls in the last hour
+        code, out, _ = run_cli(['list', '--db', self.path, '--since', '1h', '--json'])
+        self.assertEqual(code, 0)
+        runs = json.loads(out)['runs']
+        self.assertEqual([r['script_name'] for r in runs], ['15_update-video-info'])
+
+    def test_time_range_iso_until(self):
+        self.seed_basic()
+        cutoff = _iso(self.now - timedelta(hours=1))
+        code, out, _ = run_cli(['list', '--db', self.path, '--until', cutoff, '--json'])
+        self.assertEqual(code, 0)
+        names = {r['script_name'] for r in json.loads(out)['runs']}
+        self.assertEqual(names, {'51_hourly-video-record-add',
+                                 '12_add-latest-video-with-tid-30'})
+
+    def test_no_match_exit_code(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['list', '--db', self.path, '--script', 'nope'])
+        self.assertEqual(code, query.EXIT_NO_MATCH)
+
+
+class StaleDerivationTest(_DbCase):
+    def test_running_past_budget_shows_stale(self):
+        _make_db(self.path)
+        _insert_run(self.path, 'd' * 32, '17_add-member-follower-record',
+                    datetime.now(timezone.utc) - timedelta(hours=6), None,
+                    status='running')
+        code, out, _ = run_cli(['list', '--db', self.path, '--json'])
+        self.assertEqual(code, 0)
+        run = json.loads(out)['runs'][0]
+        self.assertEqual(run['status'], 'running')       # persisted, untouched
+        self.assertEqual(run['display_status'], 'stale')  # derived
+        self.assertTrue(run['stale'])
+
+    def test_filter_by_stale(self):
+        _make_db(self.path)
+        _insert_run(self.path, 'a' * 32, 's', datetime.now(timezone.utc) - timedelta(hours=6))
+        _insert_run(self.path, 'b' * 32, 's', datetime.now(timezone.utc) - timedelta(minutes=5))
+        code, out, _ = run_cli(['list', '--db', self.path, '--status', 'stale', '--json'])
+        self.assertEqual(code, 0)
+        runs = json.loads(out)['runs']
+        self.assertEqual([r['run_id'] for r in runs], ['a' * 32])
+
+    def test_running_filter_excludes_stale(self):
+        _make_db(self.path)
+        _insert_run(self.path, 'a' * 32, 's', datetime.now(timezone.utc) - timedelta(hours=6))
+        _insert_run(self.path, 'b' * 32, 's', datetime.now(timezone.utc) - timedelta(minutes=5))
+        code, out, _ = run_cli(['list', '--db', self.path, '--status', 'running', '--json'])
+        self.assertEqual(code, 0)
+        self.assertEqual([r['run_id'] for r in json.loads(out)['runs']], ['b' * 32])
+
+    def test_custom_stale_after(self):
+        _make_db(self.path)
+        _insert_run(self.path, 'a' * 32, 's', datetime.now(timezone.utc) - timedelta(minutes=40))
+        code, out, _ = run_cli(['list', '--db', self.path, '--stale-after', '1800', '--json'])
+        self.assertEqual(code, 0)
+        self.assertEqual(json.loads(out)['runs'][0]['display_status'], 'stale')
+
+
+class ShowTest(_DbCase):
+    def test_show_by_full_id(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['show', '--db', self.path, 'aaaa1111' + '0' * 24])
+        self.assertEqual(code, 0)
+        self.assertIn('51_hourly-video-record-add', out)
+
+    def test_show_by_unique_prefix(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['show', '--db', self.path, 'aaaa'])
+        self.assertEqual(code, 0)
+        self.assertIn('51_hourly-video-record-add', out)
+
+    def test_ambiguous_prefix_is_usage_error(self):
+        _make_db(self.path)
+        _insert_run(self.path, 'ab' + '0' * 30, 's', self.now)
+        _insert_run(self.path, 'ac' + '1' * 30, 's', self.now)
+        code, _, err = run_cli(['show', '--db', self.path, 'a'])
+        self.assertEqual(code, query.EXIT_USAGE)
+        self.assertIn('ambiguous', err)
+
+    def test_unknown_id_is_no_match(self):
+        self.seed_basic()
+        code, _, err = run_cli(['show', '--db', self.path, 'ffff'])
+        self.assertEqual(code, query.EXIT_NO_MATCH)
+
+    def test_latest_selects_most_recent(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['show', '--db', self.path, '--latest'])
+        self.assertEqual(code, 0)
+        self.assertIn('15_update-video-info', out)
+
+    def test_latest_with_script_filter(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['show', '--db', self.path, '--latest',
+                                '--script', '51_hourly-video-record-add'])
+        self.assertEqual(code, 0)
+        self.assertIn('51_hourly-video-record-add', out)
+
+    def test_latest_no_match(self):
+        self.seed_basic()
+        code, _, _ = run_cli(['show', '--db', self.path, '--latest', '--script', 'nope'])
+        self.assertEqual(code, query.EXIT_NO_MATCH)
+
+    def test_id_and_latest_together_is_usage_error(self):
+        self.seed_basic()
+        code, _, err = run_cli(['show', '--db', self.path, 'aaaa', '--latest'])
+        self.assertEqual(code, query.EXIT_USAGE)
+
+    def test_neither_id_nor_latest_is_usage_error(self):
+        self.seed_basic()
+        code, _, err = run_cli(['show', '--db', self.path])
+        self.assertEqual(code, query.EXIT_USAGE)
+
+    def test_show_renders_grouped_metrics_and_logs(self):
+        _make_db(self.path)
+        rid = 'e' * 32
+        _insert_run(self.path, rid, '51_hourly-video-record-add',
+                    self.now - timedelta(minutes=10), self.now, status='succeeded')
+        _insert_metric(self.path, rid, 'record-fetch', 'total_count', 170287)
+        _insert_metric(self.path, rid, 'record-fetch', 'other_exception', 877)
+        _insert_metric(self.path, rid, 'record-db-writer', 'batch_insert', 170)
+        _insert_log(self.path, rid, 'INFO', '/home/ubuntu/tdd-spider/log/51_x_INFO.log')
+        _insert_log(self.path, rid, 'WARNING', '/home/ubuntu/tdd-spider/log/51_x_WARNING.log')
+
+        code, out, _ = run_cli(['show', '--db', self.path, rid])
+        self.assertEqual(code, 0)
+        self.assertIn('record-fetch', out)
+        self.assertIn('record-db-writer', out)
+        self.assertIn('total_count', out)
+        self.assertIn('/home/ubuntu/tdd-spider/log/51_x_INFO.log', out)
+
+        code, out, _ = run_cli(['show', '--db', self.path, rid, '--json'])
+        payload = json.loads(out)
+        run = payload['runs'][0]
+        self.assertEqual(set(run['metrics']), {'record-fetch', 'record-db-writer'})
+        self.assertEqual(run['metrics']['record-fetch'][0],
+                         {'name': 'other_exception', 'value': 877.0, 'unit': 'count'})
+        self.assertEqual(
+            [l['level'] for l in run['logs']], ['INFO', 'WARNING'])
+        self.assertAlmostEqual(run['duration_s'], 600.0)
+
+
+class JsonShapeTest(_DbCase):
+    def test_list_json_shape(self):
+        self.seed_basic()
+        code, out, _ = run_cli(['list', '--db', self.path, '--json',
+                                '--script', '51_hourly-video-record-add'])
+        self.assertEqual(code, 0)
+        payload = json.loads(out)
+        self.assertEqual(set(payload), {
+            'schema_version', 'db_path', 'generated_at', 'query', 'count', 'runs'})
+        self.assertEqual(payload['schema_version'], schema.SCHEMA_VERSION)
+        self.assertEqual(payload['query']['command'], 'list')
+        self.assertEqual(payload['query']['script'], '51_hourly-video-record-add')
+        run = payload['runs'][0]
+        self.assertEqual(set(run), {
+            'run_id', 'script_name', 'host', 'code_version', 'started_at',
+            'finished_at', 'status', 'display_status', 'stale', 'duration_s'})
+        # timestamps stay ISO-8601 UTC, never reformatted for a terminal
+        self.assertTrue(run['started_at'].endswith('+00:00'))
+        self.assertNotIn('  ', json.dumps(run))  # no padded table cells leaked in
+
+    def test_json_is_stable_sorted(self):
+        self.seed_basic()
+        _, out1, _ = run_cli(['list', '--db', self.path, '--json'])
+        _, out2, _ = run_cli(['list', '--db', self.path, '--json'])
+        d1, d2 = json.loads(out1), json.loads(out2)
+        d1.pop('generated_at'), d2.pop('generated_at')
+        self.assertEqual(d1, d2)
+        # output is the canonical sorted-key rendering of its own content
+        canonical = json.dumps(json.loads(out1), indent=2,
+                               ensure_ascii=False, sort_keys=True)
+        self.assertEqual(out1.strip(), canonical)
+
+
+class ExitCodeTest(_DbCase):
+    def test_success(self):
+        self.seed_basic()
+        self.assertEqual(run_cli(['list', '--db', self.path])[0], query.EXIT_OK)
+
+    def test_no_match(self):
+        self.seed_basic()
+        self.assertEqual(
+            run_cli(['list', '--db', self.path, '--script', 'x'])[0],
+            query.EXIT_NO_MATCH)
+
+    def test_invalid_arguments(self):
+        self.assertEqual(
+            run_cli(['list', '--db', self.path, '--status', 'bogus'])[0],
+            query.EXIT_USAGE)
+        self.assertEqual(
+            run_cli(['list', '--db', self.path, '--since', 'yesterday'])[0],
+            query.EXIT_USAGE)
+        self.assertEqual(
+            run_cli(['list', '--db', self.path, '--limit', '-2'])[0],
+            query.EXIT_USAGE)
+
+    def test_incompatible_schema(self):
+        self.seed_basic()
+        conn = sqlite3.connect(self.path)
+        conn.execute(f'PRAGMA user_version = {schema.SCHEMA_VERSION + 7}')
+        conn.commit()
+        conn.close()
+        code, _, err = run_cli(['list', '--db', self.path])
+        self.assertEqual(code, query.EXIT_SCHEMA)
+        self.assertIn('schema', err)
+
+    def test_database_error_on_garbage_file(self):
+        with open(self.path, 'wb') as f:
+            f.write(b'this is definitely not a sqlite database' * 4)
+        code, _, err = run_cli(['list', '--db', self.path])
+        self.assertEqual(code, query.EXIT_DB_ERROR)
+
+    def test_database_error_on_uninitialised_file(self):
+        open(self.path, 'wb').close()  # 0-byte file == empty db, no tables
+        code, _, err = run_cli(['list', '--db', self.path])
+        self.assertEqual(code, query.EXIT_DB_ERROR)
+
+    def test_missing_database_file(self):
+        code, _, err = run_cli(['list', '--db', os.path.join(self.dir, 'absent.sqlite3')])
+        self.assertEqual(code, query.EXIT_NO_DB)
+        self.assertIn('not found', err)
+
+    def _partial_v1_db(self, drop_table):
+        """A v1 database with a valid run + row but one associated table gone."""
+        _make_db(self.path)
+        _insert_run(self.path, 'a' * 32, '51_hourly-video-record-add',
+                    self.now - timedelta(minutes=5), self.now, status='succeeded')
+        conn = sqlite3.connect(self.path)
+        conn.execute(f'DROP TABLE {drop_table}')
+        conn.commit()
+        conn.close()
+
+    def test_missing_run_metric_table_is_db_error(self):
+        self._partial_v1_db('run_metric')
+        for argv in (['show', '--db', self.path, 'a' * 32],
+                     ['show', '--db', self.path, 'a' * 32, '--json'],
+                     ['show', '--db', self.path, '--latest'],
+                     ['list', '--db', self.path],
+                     ['list', '--db', self.path, '--json']):
+            code, out, err = run_cli(argv)
+            self.assertEqual(code, query.EXIT_DB_ERROR, argv)
+            self.assertIn('run_metric', err)
+            self.assertNotIn('Traceback', err + out)
+            self.assertFalse(out.strip(), argv)  # nothing half-rendered on stdout
+
+    def test_missing_run_log_table_is_db_error(self):
+        self._partial_v1_db('run_log')
+        for argv in (['show', '--db', self.path, 'a' * 32],
+                     ['show', '--db', self.path, 'a' * 32, '--json'],
+                     ['list', '--db', self.path, '--json']):
+            code, out, err = run_cli(argv)
+            self.assertEqual(code, query.EXIT_DB_ERROR, argv)
+            self.assertIn('run_log', err)
+            self.assertNotIn('Traceback', err + out)
+
+    def test_detail_query_error_is_translated_even_if_probe_skipped(self):
+        # exercise the defensive wrapper on the detail helpers directly
+        self._partial_v1_db('run_metric')
+        conn = sqlite3.connect(f'file:{self.path}?mode=ro', uri=True)
+        try:
+            with self.assertRaises(query.QueryError) as cm:
+                query._grouped_metrics(conn, 'a' * 32)
+            self.assertEqual(cm.exception.exit_code, query.EXIT_DB_ERROR)
+        finally:
+            conn.close()
+
+
+class ReadOnlyTest(_DbCase):
+    def test_queries_do_not_touch_the_database(self):
+        self.seed_basic()
+        before = os.stat(self.path)
+        before_rows = _count_rows(self.path)
+        time.sleep(0.01)
+        for argv in (['list', '--db', self.path],
+                     ['list', '--db', self.path, '--json'],
+                     ['show', '--db', self.path, '--latest'],
+                     ['show', '--db', self.path, 'aaaa']):
+            run_cli(argv)
+        after = os.stat(self.path)
+        self.assertEqual(before.st_mtime, after.st_mtime)
+        self.assertEqual(before.st_size, after.st_size)
+        self.assertEqual(before_rows, _count_rows(self.path))
+        # no side-car files created by a write attempt
+        self.assertFalse(os.path.exists(self.path + '-wal'))
+        self.assertFalse(os.path.exists(self.path + '-journal'))
+
+    def test_missing_db_is_not_created(self):
+        absent = os.path.join(self.dir, 'absent.sqlite3')
+        run_cli(['list', '--db', absent])
+        self.assertFalse(os.path.exists(absent))
+
+
+class RecorderIntegrationTest(_DbCase):
+    """End-to-end against data written by the real RunRecorder."""
+
+    class _Stat:
+        def __init__(self, total_count, condition):
+            self.total_count = total_count
+            self.condition = condition
+
+    def test_query_reads_real_recorder_output(self):
+        rec = RunRecorder.start('51_hourly-video-record-add', db_path=self.path)
+        rec.add_job_stat_metrics('record-fetch', self._Stat(
+            170287, {'success': 169410, 'other_exception': 877, 'http_ms': 999}))
+        rec.finish('succeeded')
+
+        code, out, _ = run_cli(['show', '--db', self.path, '--latest', '--json'])
+        self.assertEqual(code, 0)
+        run = json.loads(out)['runs'][0]
+        self.assertEqual(run['run_id'], rec.run_id)
+        self.assertEqual(run['display_status'], 'succeeded')
+        self.assertEqual(run['status'], 'succeeded')
+        self.assertIn('record-fetch', run['metrics'])
+        names = {m['name'] for m in run['metrics']['record-fetch']}
+        self.assertEqual(names, {'total_count', 'success', 'other_exception'})
+        self.assertNotIn('http_ms', names)  # *_ms excluded upstream
+
+
+class TimeParseTest(unittest.TestCase):
+    def test_relative_spans(self):
+        now = datetime(2026, 8, 30, 12, 0, tzinfo=timezone.utc)
+        self.assertEqual(query._parse_time('90m', now), now - timedelta(minutes=90))
+        self.assertEqual(query._parse_time('2h', now), now - timedelta(hours=2))
+        self.assertEqual(query._parse_time('7d', now), now - timedelta(days=7))
+        self.assertEqual(query._parse_time('1w', now), now - timedelta(weeks=1))
+
+    def test_iso_values_are_utc(self):
+        got = query._parse_time('2026-08-30')
+        self.assertEqual(got, datetime(2026, 8, 30, tzinfo=timezone.utc))
+        got = query._parse_time('2026-08-30T06:30:00+08:00')
+        self.assertEqual(got.utcoffset(), timedelta(0))
+
+    def test_bad_value_raises_usage_error(self):
+        with self.assertRaises(query.QueryError) as cm:
+            query._parse_time('later')
+        self.assertEqual(cm.exception.exit_code, query.EXIT_USAGE)
+
+
+def _count_rows(path):
+    conn = sqlite3.connect(path)
+    try:
+        return {t: conn.execute(f'SELECT count(*) FROM {t}').fetchone()[0]
+                for t in ('run', 'run_metric', 'run_log')}
+    finally:
+        conn.close()
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Adds `python -m runrecord`, a read-only query CLI over the run-record SQLite store, so people and automation can inspect runs without writing SQL. This PR adds no dependencies and does not modify existing runtime behavior.

- `runrecord/query.py`: query core and argument parsing
- `runrecord/__main__.py`: `python -m runrecord` entry point
- `tests/test_run_record_query.py`: query CLI tests
- `AGENTS.md`: public metadata privacy guidance

## Commands

- `list` (the default): list recent runs, with optional script, status, time-range, and limit filters.
- `show`: inspect one run by ID, unique prefix, or the latest matching run.
- Global options include `--db`, `--stale-after`, and `--json`.

## Contracts

- Opens SQLite using `mode=ro`; a missing database is not created.
- Reuses the existing SQLite driver shim, database-path resolution, status derivation, time parsing, and schema version.
- Provides stable structured JSON output and compact human-readable output.
- Uses documented exit codes for no match, invalid arguments, incompatible schemas, database errors, and missing files.
- Validates all required query surfaces before reading details and converts SQLite failures into concise CLI errors without tracebacks.

## Verification

- 63 tests pass under both supported Python environments:
  `venv-3.11/bin/python -m unittest discover -s tests`
- Coverage includes filters, time ranges, lookup by ID and prefix, latest-run selection, JSON output, exit codes, stale-status derivation, missing and incompatible databases, partial schemas, read-only behavior, and end-to-end recorder output.
- A regression test covers databases missing a required query table and verifies exit code 4 with no traceback or partial output.

## Not in this PR

Deployment is intentionally separate from this change.
