### PR TITLE
fix: accept global options before or after the runrecord subcommand

### DIFF
--- a/runrecord/query.py
+++ b/runrecord/query.py
@@ -490,14 +490,16 @@ def _print_detail(r, *, db_path, db_version):
 # --------------------------------------------------------------------------- #
 
 _EPILOG = (
+    '`list` is the default command and may be omitted. --db, --stale-after and\n'
+    '--json may appear before or after an explicit list / show.\n\n'
     'exit codes: 0 ok, 1 no match, 2 bad arguments, 3 incompatible schema, '
     '4 database error, 5 database file not found.\n\n'
     'examples:\n'
-    '  python -m runrecord list\n'
+    '  python -m runrecord\n'
     '  python -m runrecord list --script 51_hourly-video-record-add --since 7d\n'
-    '  python -m runrecord list --status stale --json\n'
+    '  python -m runrecord --json list --status stale\n'
     '  python -m runrecord show --latest --script 51_hourly-video-record-add\n'
-    '  python -m runrecord show a1b2c3d4\n')
+    '  python -m runrecord --db ./run-records.sqlite3 show a1b2c3d4\n')
 
 
 def _add_common(parser):
@@ -518,7 +520,8 @@ def _top_parser():
     parser = argparse.ArgumentParser(
         prog='python -m runrecord',
         description='Read-only query CLI over the run-record store. The default '
-                    'command is "list".',
+                    'command is "list"; --db, --stale-after and --json may '
+                    'appear before or after an explicit list / show.',
         epilog=_EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
     sub = parser.add_subparsers(dest='command', metavar='{list,show}')
     sub.add_parser('list', help='list recent runs (default)', add_help=False)
@@ -575,16 +578,48 @@ def _dispatch(args):
         conn.close()
 
 
+# options (on any command) that consume the following token as their value;
+# used only to skip over `--opt value` while locating the command token
+_VALUE_OPTS = frozenset((
+    '--db', '--stale-after', '--script', '--status', '--since', '--until', '--limit',
+))
+
+
+def _split_command(argv):
+    """
+    Find an explicit ``list`` / ``show`` token anywhere before the first bare
+    positional, and return ``(command, argv_without_that_token)``.
+
+    This lets the common options (--db, --stale-after, --json) sit on either
+    side of the command: everything is then handed to one flat per-command
+    parser that accepts those options regardless of position.
+    """
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok == '--':
+            break
+        if tok in ('list', 'show'):
+            return tok, argv[:i] + argv[i + 1:]
+        if tok in _VALUE_OPTS:
+            i += 2                     # skip the option and its value
+            continue
+        if tok.startswith('-'):        # a flag / --opt=value / -h -- keep scanning
+            i += 1
+            continue
+        break                          # a bare positional that isn't a command
+    return None, argv
+
+
 def _parse_args(argv):
     """Route to a flat per-command parser; `list` is the default command."""
     if argv and argv[0] in ('-h', '--help'):
         _top_parser().parse_args(argv)  # prints help, raises SystemExit(0)
-    if argv and argv[0] == 'show':
-        parser, rest, command = _show_parser(), argv[1:], 'show'
-    elif argv and argv[0] == 'list':
-        parser, rest, command = _list_parser(), argv[1:], 'list'
-    else:
-        parser, rest, command = _list_parser(), argv, 'list'
+
+    command, rest = _split_command(argv)
+    if command is None:
+        command = 'list'
+    parser = _show_parser() if command == 'show' else _list_parser()
 
     args = parser.parse_args(rest)
     args.command = command

--- a/tests/test_run_record_query.py
+++ b/tests/test_run_record_query.py
@@ -410,6 +410,107 @@ class ExitCodeTest(_DbCase):
             conn.close()
 
 
+class GlobalOptionOrderingTest(_DbCase):
+    """--db / --stale-after / --json work before or after an explicit list/show."""
+
+    def _json(self, argv):
+        code, out, err = run_cli(argv)
+        self.assertEqual(code, 0, (argv, err))
+        return json.loads(out)
+
+    def test_formerly_failing_global_before_list(self):
+        # `--json list --limit 1` used to be misrouted -> "unrecognized
+        # arguments: list", exit 2
+        self.seed_basic()
+        payload = self._json(['--json', 'list', '--limit', '1', '--db', self.path])
+        self.assertEqual(payload['count'], 1)
+
+    def test_json_before_and_after_list_match(self):
+        self.seed_basic()
+        before = self._json(['--json', 'list', '--db', self.path])
+        after = self._json(['list', '--json', '--db', self.path])
+        for d in (before, after):
+            d.pop('generated_at')
+        self.assertEqual(before, after)
+        self.assertGreater(before['count'], 0)
+
+    def test_json_before_and_after_show(self):
+        self.seed_basic()
+        rid = 'aaaa1111' + '0' * 24
+        before = self._json(['--json', 'show', rid, '--db', self.path])
+        after = self._json(['show', rid, '--json', '--db', self.path])
+        self.assertEqual(before['runs'][0]['run_id'], rid)
+        self.assertEqual(after['runs'][0]['run_id'], rid)
+
+    def test_db_before_and_after_command(self):
+        self.seed_basic()
+        # a wrong position would fail to resolve the non-default path
+        self._json(['--db', self.path, '--json', 'list'])
+        self._json(['list', '--json', '--db', self.path])
+        self._json(['--db', self.path, '--json', 'show', '--latest'])
+        self._json(['show', '--latest', '--json', '--db', self.path])
+
+    def test_db_in_wrong_position_is_not_silently_ignored(self):
+        # if --db were dropped, this absent path would still error out
+        absent = os.path.join(self.dir, 'nope.sqlite3')
+        code_before, _, _ = run_cli(['--db', absent, 'list'])
+        code_after, _, _ = run_cli(['list', '--db', absent])
+        self.assertEqual(code_before, query.EXIT_NO_DB)
+        self.assertEqual(code_after, query.EXIT_NO_DB)
+
+    def test_stale_after_before_and_after_list_match(self):
+        _make_db(self.path)
+        _insert_run(self.path, 'a' * 32, 's',
+                    datetime.now(timezone.utc) - timedelta(minutes=40))
+        before = self._json(['--stale-after', '1800', '--json', 'list', '--db', self.path])
+        after = self._json(['list', '--json', '--stale-after', '1800', '--db', self.path])
+        self.assertEqual(before['runs'][0]['display_status'], 'stale')
+        self.assertEqual(after['runs'][0]['display_status'], 'stale')
+        self.assertEqual(before['query']['stale_after_s'], 1800)
+        self.assertEqual(after['query']['stale_after_s'], 1800)
+
+    def test_stale_after_before_and_after_show(self):
+        _make_db(self.path)
+        _insert_run(self.path, 'a' * 32, 's',
+                    datetime.now(timezone.utc) - timedelta(minutes=40))
+        before = self._json(['--stale-after', '1800', '--json', 'show', 'a' * 32,
+                             '--db', self.path])
+        after = self._json(['show', 'a' * 32, '--json', '--stale-after', '1800',
+                            '--db', self.path])
+        self.assertEqual(before['runs'][0]['display_status'], 'stale')
+        self.assertEqual(after['runs'][0]['display_status'], 'stale')
+
+    def test_all_three_globals_before_command(self):
+        self.seed_basic()
+        payload = self._json(['--db', self.path, '--stale-after', '99999',
+                              '--json', 'list'])
+        self.assertEqual(payload['query']['stale_after_s'], 99999)
+        self.assertGreater(payload['count'], 0)
+
+    def test_default_command_with_leading_global(self):
+        self.seed_basic()
+        # no explicit `list`, global option first
+        payload = self._json(['--json', '--db', self.path])
+        self.assertEqual(payload['query']['command'], 'list')
+        self.assertGreater(payload['count'], 0)
+
+    def test_bare_invocation_is_list(self):
+        _make_db(self.path)
+        _insert_run(self.path, 'a' * 32, 's', self.now, self.now, status='succeeded')
+        code, out, _ = run_cli(['--db', self.path])
+        self.assertEqual(code, 0)
+        self.assertIn('run(s)', out)
+
+    def test_help_variants(self):
+        for argv in (['-h'], ['--help'], ['list', '-h'], ['show', '-h']):
+            code, out, _ = run_cli(argv)
+            self.assertEqual(code, 0, argv)
+            self.assertIn('usage: python -m runrecord', out)
+        # top-level help documents the flexible ordering
+        _, top, _ = run_cli(['-h'])
+        self.assertIn('before or after', top)
+
+
 class ReadOnlyTest(_DbCase):
     def test_queries_do_not_touch_the_database(self):
         self.seed_basic()


### PR DESCRIPTION
## Problem

The `runrecord` query CLI documents — in `--help`, the usage string, and the
examples — that its global options (`--db`, `--stale-after`, `--json`) come
before the subcommand. In practice the argument router only treated `list` /
`show` as a command when it was the *very first* token, so any global option in
front of an explicit subcommand broke:

```
$ python -m runrecord --json list --limit 1
usage: python -m runrecord list [-h] [--db PATH] ...
python -m runrecord list: error: unrecognized arguments: list
$ echo $?
2
```

`--json list ...` was misrouted into the `list` parser, which then saw `list`
as a stray positional.

## Fix

Replace the first-token check with a small scanner that finds an explicit
`list` / `show` anywhere before the first bare positional (stepping over
`--opt value` pairs), removes it, and hands the remainder to a single flat
per-command parser. Those parsers already accept the global options in any
position, so `--db` / `--stale-after` / `--json` now work identically before or
after `list` / `show`. `list` remains the default command when none is given.

`--help` text, the usage string and the examples are updated to match, and now
describe the flexible ordering explicitly.

## Tests

Adds regression coverage for `--json`, `--db` and `--stale-after` placed both
before and after an explicit `list` / `show` (including the exact command that
used to fail), plus the bare-invocation default and the `-h` / `--help`
variants. Full suite: 74 tests, all passing.

```
python -m unittest discover -s tests
```
