### PR TITLE
feat: run records for the five sc_send_summary scripts

### DIFF
--- a/12_add-latest-video-with-tid-30.py
+++ b/12_add-latest-video-with-tid-30.py
@@ -3,6 +3,7 @@ from serverchan import sc_send_summary
 from timer import Timer
 from queue import Queue
 from job import JobStat, GetNewlistArchiveJob, AddVideoFromArchiveJob
+from runrecord import track
 from util import logging_init, fullname
 import logging
 
@@ -17,83 +18,90 @@ def add_latest_video_with_tid_30():
     timer = Timer()
     timer.start()
 
-    tid = 30
-    latest_page_num = 3
-    service = Service(mode='worker')
+    with track(script_fullname) as recorder:
+        tid = 30
+        latest_page_num = 3
+        service = Service(mode='worker')
 
-    # prepare page num queue
-    page_num_queue = Queue[int]()
+        # prepare page num queue
+        page_num_queue = Queue[int]()
 
-    # put page num
-    for page_num in range(1, latest_page_num + 1):
-        page_num_queue.put(page_num)
-    logger.info(f'Page num queue from 1 to {latest_page_num} prepared.')
+        # put page num
+        for page_num in range(1, latest_page_num + 1):
+            page_num_queue.put(page_num)
+        logger.info(f'Page num queue from 1 to {latest_page_num} prepared.')
 
-    # prepare archive video queue
-    archive_video_queue = Queue[tuple[int, NewlistArchive]]()
+        # prepare archive video queue
+        archive_video_queue = Queue[tuple[int, NewlistArchive]]()
 
-    # create get newlist archive job
-    get_newlist_archive_job = GetNewlistArchiveJob(
-        'job_tid_30', tid, page_num_queue, archive_video_queue, service)
+        # create get newlist archive job
+        get_newlist_archive_job = GetNewlistArchiveJob(
+            'job_tid_30', tid, page_num_queue, archive_video_queue, service)
 
-    # start get newlist archive job
-    get_newlist_archive_job.start()
-    logger.info(f'1 get newlist archive job started.')
+        # start get newlist archive job
+        get_newlist_archive_job.start()
+        logger.info(f'1 get newlist archive job started.')
 
-    # wait for get newlist archive job
-    get_newlist_archive_job.join()
+        # wait for get newlist archive job
+        get_newlist_archive_job.join()
 
-    # collect statistic
-    get_newlist_archive_job_stat = get_newlist_archive_job.stat
+        # collect statistic
+        get_newlist_archive_job_stat = get_newlist_archive_job.stat
 
-    logger.info(
-        f'{archive_video_queue.qsize()} archive(s) from newlist archive pages fetched.')
+        logger.info(
+            f'{archive_video_queue.qsize()} archive(s) from newlist archive pages fetched.')
 
-    # create add video from archive jobs
-    add_video_from_archive_job_num = 10
-    add_video_from_archive_job_list = []
-    for i in range(add_video_from_archive_job_num):
-        add_video_from_archive_job_list.append(
-            AddVideoFromArchiveJob(f'job_{i}', archive_video_queue, service))
+        # create add video from archive jobs
+        add_video_from_archive_job_num = 10
+        add_video_from_archive_job_list = []
+        for i in range(add_video_from_archive_job_num):
+            add_video_from_archive_job_list.append(
+                AddVideoFromArchiveJob(f'job_{i}', archive_video_queue, service))
 
-    # start add video from archive jobs
-    for job in add_video_from_archive_job_list:
-        job.start()
-    logger.info(
-        f'{add_video_from_archive_job_num} add video from archive jobs started.')
+        # start add video from archive jobs
+        for job in add_video_from_archive_job_list:
+            job.start()
+        logger.info(
+            f'{add_video_from_archive_job_num} add video from archive jobs started.')
 
-    # wait for add video from archive jobs
-    for job in add_video_from_archive_job_list:
-        job.join()
+        # wait for add video from archive jobs
+        for job in add_video_from_archive_job_list:
+            job.join()
 
-    # collect statistic
-    add_video_from_archive_job_stat_list: list[JobStat] = []
-    for job in add_video_from_archive_job_list:
-        add_video_from_archive_job_stat_list.append(job.stat)
+        # collect statistic
+        add_video_from_archive_job_stat_list: list[JobStat] = []
+        for job in add_video_from_archive_job_list:
+            add_video_from_archive_job_stat_list.append(job.stat)
 
-    # merge statistic
-    add_video_from_archive_job_stat_merged = sum(
-        add_video_from_archive_job_stat_list, JobStat())
+        # merge statistic
+        add_video_from_archive_job_stat_merged = sum(
+            add_video_from_archive_job_stat_list, JobStat())
 
-    # generate concatenated job stat for summary
-    concatenated_stat = JobStat()
-    concatenated_stat.total_count = add_video_from_archive_job_stat_merged.total_count
-    concatenated_stat.total_duration_ms = add_video_from_archive_job_stat_merged.total_duration_ms
-    concatenated_stat.condition = get_newlist_archive_job_stat.condition + \
-        add_video_from_archive_job_stat_merged.condition
+        # run-record metrics: the two pipeline stages kept separate (the newlist
+        # fetch and the per-archive add), mirroring how the summary log splits
+        # their condition keys. Best-effort; a disabled recorder is a no-op.
+        recorder.add_job_stat_metrics('get-newlist-archive', get_newlist_archive_job_stat)
+        recorder.add_job_stat_metrics('add-video-from-archive', add_video_from_archive_job_stat_merged)
 
-    timer.stop()
-    concatenated_stat.start_ts_ms = timer.start_ts_ms
-    concatenated_stat.end_ts_ms = timer.end_ts_ms
+        # generate concatenated job stat for summary
+        concatenated_stat = JobStat()
+        concatenated_stat.total_count = add_video_from_archive_job_stat_merged.total_count
+        concatenated_stat.total_duration_ms = add_video_from_archive_job_stat_merged.total_duration_ms
+        concatenated_stat.condition = get_newlist_archive_job_stat.condition + \
+            add_video_from_archive_job_stat_merged.condition
 
-    # summary
-    logger.info(f'Finish {script_fullname}!')
-    logger.info(timer.get_summary())
-    logger.info(concatenated_stat.get_summary())
-    if concatenated_stat.condition['get_newlist_exception'] > 0 \
-            or concatenated_stat.condition['add_video_exception'] > 0 \
-            or concatenated_stat.condition['commit_video_record_exception'] > 0:
-        sc_send_summary(script_fullname, timer, concatenated_stat)
+        timer.stop()
+        concatenated_stat.start_ts_ms = timer.start_ts_ms
+        concatenated_stat.end_ts_ms = timer.end_ts_ms
+
+        # summary
+        logger.info(f'Finish {script_fullname}!')
+        logger.info(timer.get_summary())
+        logger.info(concatenated_stat.get_summary())
+        if concatenated_stat.condition['get_newlist_exception'] > 0 \
+                or concatenated_stat.condition['add_video_exception'] > 0 \
+                or concatenated_stat.condition['commit_video_record_exception'] > 0:
+            sc_send_summary(script_fullname, timer, concatenated_stat)
 
 
 def main():

--- a/15_update-video-info.py
+++ b/15_update-video-info.py
@@ -1,6 +1,7 @@
 from db import DBOperation, Session
 from service import Service
 from serverchan import sc_send_summary
+from runrecord import track
 from util import logging_init, get_week_day, fullname, b2a
 from timer import Timer
 from queue import Queue
@@ -18,69 +19,74 @@ def update_video_info():
     timer = Timer()
     timer.start()
 
-    session = Session()
-    service = Service(mode='worker')
+    with track(script_fullname) as recorder:
+        session = Session()
+        service = Service(mode='worker')
 
-    # get all bvids
-    all_bvids: list[str] = DBOperation.query_all_video_bvids(session)
-    logger.info(f'Total {len(all_bvids)} videos got.')
+        # get all bvids
+        all_bvids: list[str] = DBOperation.query_all_video_bvids(session)
+        logger.info(f'Total {len(all_bvids)} videos got.')
 
-    # add latest 5000 bvids first
-    bvids = all_bvids[-5000:]
+        # add latest 5000 bvids first
+        bvids = all_bvids[-5000:]
 
-    # TODO: add top 1000 view bvids
+        # TODO: add top 1000 view bvids
 
-    # for the rest, add 1 / 7 of them, according to the week day (0-6)
-    week_day = get_week_day()
-    for idx, bvid in enumerate(all_bvids[:-5000]):
-        if idx % 7 == week_day:
-            bvids.append(bvid)
+        # for the rest, add 1 / 7 of them, according to the week day (0-6)
+        week_day = get_week_day()
+        for idx, bvid in enumerate(all_bvids[:-5000]):
+            if idx % 7 == week_day:
+                bvids.append(bvid)
 
-    logger.info(f'Will update {len(bvids)} videos info.')
+        logger.info(f'Will update {len(bvids)} videos info.')
 
-    # put aid into queue. UpdateVideoJob takes aids (it used to take bvids and
-    # b2a them itself); converting here keeps the job free of that concern and
-    # lets 51_ feed it aids straight from the fetch pipeline.
-    aid_queue: Queue[int] = Queue()
-    for bvid in bvids:
-        aid_queue.put(b2a(bvid))
-    # one sentinel per worker: UpdateVideoJob is now sentinel-terminated (an
-    # empty queue means "wait", so it can also run alongside a live producer in
-    # 51_). This also retires the old `while not queue.empty(): queue.get()`
-    # loop, which races -- two workers both see a non-empty queue, both call
-    # get(), and the loser blocks forever on the last item.
-    # 50 workers (was 20): this is worker-bound with inbound headroom (the
-    # full-view responses are large but the downlink is fat), so more workers
-    # cut the multi-hour runtime roughly proportionally. It hits the full-view
-    # Lambda -- a different endpoint than 51_'s trimmed one -- and sends little
-    # outbound per request, so it does not meaningfully slow 51_'s hourly runs
-    # even when it overruns. No duration cap: 15_ runs to completion.
-    job_num = 50
-    for _ in range(job_num):
-        aid_queue.put(None)  # one sentinel per worker (sentinel-terminated)
-    logger.info(f'{len(bvids)} aids put into queue.')
+        # put aid into queue. UpdateVideoJob takes aids (it used to take bvids and
+        # b2a them itself); converting here keeps the job free of that concern and
+        # lets 51_ feed it aids straight from the fetch pipeline.
+        aid_queue: Queue[int] = Queue()
+        for bvid in bvids:
+            aid_queue.put(b2a(bvid))
+        # one sentinel per worker: UpdateVideoJob is now sentinel-terminated (an
+        # empty queue means "wait", so it can also run alongside a live producer in
+        # 51_). This also retires the old `while not queue.empty(): queue.get()`
+        # loop, which races -- two workers both see a non-empty queue, both call
+        # get(), and the loser blocks forever on the last item.
+        # 50 workers (was 20): this is worker-bound with inbound headroom (the
+        # full-view responses are large but the downlink is fat), so more workers
+        # cut the multi-hour runtime roughly proportionally. It hits the full-view
+        # Lambda -- a different endpoint than 51_'s trimmed one -- and sends little
+        # outbound per request, so it does not meaningfully slow 51_'s hourly runs
+        # even when it overruns. No duration cap: 15_ runs to completion.
+        job_num = 50
+        for _ in range(job_num):
+            aid_queue.put(None)  # one sentinel per worker (sentinel-terminated)
+        logger.info(f'{len(bvids)} aids put into queue.')
 
-    # JobPool gives a per-interval PROGRESS heartbeat over the multi-hour run
-    # (previously blind) and merges the workers' stats.
-    pool = JobPool(
-        [UpdateVideoJob(f'job_{i}', aid_queue, service) for i in range(job_num)],
-        progress_total=len(bvids),
-        progress_label='video-update',
-        progress_interval_s=10.0,  # slow long job -- 10s keeps the log readable
-        logger_name=script_id)
-    pool.start()
-    logger.info(f'{job_num} job(s) started.')
-    job_stat_merged = pool.join()
+        # JobPool gives a per-interval PROGRESS heartbeat over the multi-hour run
+        # (previously blind) and merges the workers' stats.
+        pool = JobPool(
+            [UpdateVideoJob(f'job_{i}', aid_queue, service) for i in range(job_num)],
+            progress_total=len(bvids),
+            progress_label='video-update',
+            progress_interval_s=10.0,  # slow long job -- 10s keeps the log readable
+            logger_name=script_id)
+        pool.start()
+        logger.info(f'{job_num} job(s) started.')
+        job_stat_merged = pool.join()
 
-    session.close()
+        session.close()
 
-    timer.stop()
+        timer.stop()
 
-    # summary
-    logger.info(f'Finish {script_fullname}!')
-    logger.info(timer.get_summary())
-    logger.info(job_stat_merged.get_summary('video-update'))
-    sc_send_summary(script_fullname, timer, job_stat_merged)
+        # run-record metrics, keyed by the same label the summary log uses
+        # (best-effort; a disabled recorder is a no-op)
+        recorder.add_job_stat_metrics('video-update', job_stat_merged)
+
+        # summary
+        logger.info(f'Finish {script_fullname}!')
+        logger.info(timer.get_summary())
+        logger.info(job_stat_merged.get_summary('video-update'))
+        sc_send_summary(script_fullname, timer, job_stat_merged)
 
 
 def main():

--- a/17_add-member-follower-record.py
+++ b/17_add-member-follower-record.py
@@ -2,6 +2,7 @@ from db import DBOperation, Session
 from service import Service
 from util import logging_init, fullname
 from serverchan import sc_send_summary
+from runrecord import track
 from queue import Queue
 from timer import Timer
 from job import FetchMemberFollowerRecordJob, BatchInsertMemberFollowerRecordJob, JobPool
@@ -18,64 +19,70 @@ def add_member_follower_record():
     timer = Timer()
     timer.start()
 
-    # fetch/write split (mirrors 51_): many fetch-only workers (HTTP, no DB) ->
-    # bounded queue -> ONE batch writer. Replaces the old 20 per-worker-insert
-    # jobs, whose per-record commits contended on fsync and pinned the run at
-    # ~1h10m. 50 fetchers + batched inserts should finish it in well under the
-    # ~40 min before 51_'s 12:00 run -- it runs to completion (no duration cap).
-    job_num = 50
+    with track(script_fullname) as recorder:
+        # fetch/write split (mirrors 51_): many fetch-only workers (HTTP, no DB) ->
+        # bounded queue -> ONE batch writer. Replaces the old 20 per-worker-insert
+        # jobs, whose per-record commits contended on fsync and pinned the run at
+        # ~1h10m. 50 fetchers + batched inserts should finish it in well under the
+        # ~40 min before 51_'s 12:00 run -- it runs to completion (no duration cap).
+        job_num = 50
 
-    session = Session()
-    service = Service(mode='worker', pool_maxsize=job_num + 32)
+        session = Session()
+        service = Service(mode='worker', pool_maxsize=job_num + 32)
 
-    # load all mids
-    mids: list[int] = DBOperation.query_all_member_mids(session=session)
-    session.close()
-    logger.info(f'Total {len(mids)} members got.')
+        # load all mids
+        mids: list[int] = DBOperation.query_all_member_mids(session=session)
+        session.close()
+        logger.info(f'Total {len(mids)} members got.')
 
-    # mid queue for the fetch pool
-    mid_queue: Queue[int] = Queue()
-    for mid in mids:
-        mid_queue.put(mid)
+        # mid queue for the fetch pool
+        mid_queue: Queue[int] = Queue()
+        for mid in mids:
+            mid_queue.put(mid)
 
-    # fetched records -> single batch writer. BOUNDED so fetchers apply
-    # backpressure at writer speed instead of growing RSS.
-    record_queue: Queue = Queue(maxsize=20000)
+        # fetched records -> single batch writer. BOUNDED so fetchers apply
+        # backpressure at writer speed instead of growing RSS.
+        record_queue: Queue = Queue(maxsize=20000)
 
-    fetch_pool = JobPool(
-        [FetchMemberFollowerRecordJob(f'job_{i}', mid_queue, record_queue, service)
-         for i in range(job_num)],
-        progress_total=len(mids),
-        progress_label='follower-fetch',
-        ensure_conditions=['success', 'exception', 'other_exception',
-                           'record_dropped_queue_full'],
-        logger_name=script_id)
-    writer_pool = JobPool(
-        [BatchInsertMemberFollowerRecordJob('writer_0', record_queue)],
-        progress_total=len(mids),
-        progress_label='follower-db-writer',
-        progress_interval_s=5.0,
-        ensure_conditions=['batch_insert', 'batch_insert_split',
-                           'batch_insert_split_ok', 'batch_insert_fail'],
-        logger_name=script_id)
+        fetch_pool = JobPool(
+            [FetchMemberFollowerRecordJob(f'job_{i}', mid_queue, record_queue, service)
+             for i in range(job_num)],
+            progress_total=len(mids),
+            progress_label='follower-fetch',
+            ensure_conditions=['success', 'exception', 'other_exception',
+                               'record_dropped_queue_full'],
+            logger_name=script_id)
+        writer_pool = JobPool(
+            [BatchInsertMemberFollowerRecordJob('writer_0', record_queue)],
+            progress_total=len(mids),
+            progress_label='follower-db-writer',
+            progress_interval_s=5.0,
+            ensure_conditions=['batch_insert', 'batch_insert_split',
+                               'batch_insert_split_ok', 'batch_insert_fail'],
+            logger_name=script_id)
 
-    fetch_pool.start()
-    writer_pool.start()
+        fetch_pool.start()
+        writer_pool.start()
 
-    fetch_stat = fetch_pool.join()
-    # sentinel AFTER all fetchers finished (FIFO -> arrives behind every record)
-    record_queue.put(None)
-    writer_stat = writer_pool.join()
+        fetch_stat = fetch_pool.join()
+        # sentinel AFTER all fetchers finished (FIFO -> arrives behind every record)
+        record_queue.put(None)
+        writer_stat = writer_pool.join()
 
-    timer.stop()
+        timer.stop()
 
-    # summary
-    logger.info(f'Finish {script_fullname}!')
-    logger.info(timer.get_summary())
-    logger.info(fetch_stat.get_summary('follower-fetch'))
-    logger.info(writer_stat.get_summary('follower-db-writer'))
-    logger.info(f'{writer_stat.total_count} follower record(s) fetched and inserted.')
-    sc_send_summary(script_fullname, timer, fetch_stat)
+        # run-record metrics: both pipeline stages, keyed by the same labels the
+        # summary log uses (best-effort; a disabled recorder is a no-op)
+        recorder.add_job_stat_metrics('follower-fetch', fetch_stat)
+        recorder.add_job_stat_metrics('follower-db-writer', writer_stat)
+
+        # summary
+        logger.info(f'Finish {script_fullname}!')
+        logger.info(timer.get_summary())
+        logger.info(fetch_stat.get_summary('follower-fetch'))
+        logger.info(writer_stat.get_summary('follower-db-writer'))
+        logger.info(f'{writer_stat.total_count} follower record(s) fetched and inserted.')
+        sc_send_summary(script_fullname, timer, fetch_stat)
 
 
 def main():

--- a/62_add-evocalrank-video.py
+++ b/62_add-evocalrank-video.py
@@ -10,6 +10,7 @@ from timer import Timer
 from queue import Queue
 from job import AddVideoJob, JobStat
 from serverchan import sc_send_summary
+from runrecord import track
 
 script_id = '62'
 script_name = 'add-evocalrank-video'
@@ -48,116 +49,124 @@ def add_evocalrank_video(ranknum: int):
     timer = Timer()
     timer.start()
 
-    service = Service(mode="worker", retry=20)
+    with track(script_fullname) as recorder:
+        service = Service(mode="worker", retry=20)
 
-    logger.info(f'Will add evocalrank video with ranknum: {ranknum}')
+        logger.info(f'Will add evocalrank video with ranknum: {ranknum}')
 
-    # load evocalrank json, min ranknum is 520
-    logger.info(f'Loading evocalrank data...')
-    url = f'https://www.evocalrank.com/data/rank_data/{ranknum}.json'
-    try:
-        response = requests.get(url)
-        response.raise_for_status()
-        evocalrank_data = response.json()
-    except Exception as e:
-        logger.critical(
-            f'Failed to get evocalrank data from {url}, error: {e}')
-        exit(1)
-    logger.info(f'Evocalrank data loaded successfully!')
+        # load evocalrank json, min ranknum is 520
+        logger.info(f'Loading evocalrank data...')
+        url = f'https://www.evocalrank.com/data/rank_data/{ranknum}.json'
+        try:
+            response = requests.get(url)
+            response.raise_for_status()
+            evocalrank_data = response.json()
+        except Exception as e:
+            logger.critical(
+                f'Failed to get evocalrank data from {url}, error: {e}')
+            # exit() raises SystemExit(1): `track` closes the run as 'failed'
+            # before it propagates, so this stays distinct from a killed run.
+            exit(1)
+        logger.info(f'Evocalrank data loaded successfully!')
 
-    # load avid from evocalrank_data
-    logger.info(f'Now extract avid from evocalrank data...')
-    aid_list: list[int] = []
-    rank_name_list = [
-        'main_rank',
-        'second_rank',
-        'super_hit',
-        'pick_up',
-        'oth_pickup', 'Vocaloid_pick_up',
-        'history-1-year',
-        'history-10-year',
-        'ed',
-        'op'
-    ]
-    for rank_name in rank_name_list:
-        logger.info(f'Now extract aid from {rank_name}...')
-        if rank_name not in evocalrank_data:
-            logger.warning(
-                f'Rank name {rank_name} not found in evocalrank data')
-            continue
-        rank_data = evocalrank_data[rank_name]
-        aid_count = 0
-        for item in rank_data:
-            if 'avid' not in item:
+        # load avid from evocalrank_data
+        logger.info(f'Now extract avid from evocalrank data...')
+        aid_list: list[int] = []
+        rank_name_list = [
+            'main_rank',
+            'second_rank',
+            'super_hit',
+            'pick_up',
+            'oth_pickup', 'Vocaloid_pick_up',
+            'history-1-year',
+            'history-10-year',
+            'ed',
+            'op'
+        ]
+        for rank_name in rank_name_list:
+            logger.info(f'Now extract aid from {rank_name}...')
+            if rank_name not in evocalrank_data:
                 logger.warning(
-                    f'Item missing "avid" property in {rank_name}: {item}')
+                    f'Rank name {rank_name} not found in evocalrank data')
                 continue
-            avid_str = item['avid']
-            # Validate format: av + digits (at least one)
-            match = re.match(r'^av(\d+)$', avid_str, re.IGNORECASE)
-            if match:
-                try:
-                    aid = int(match.group(1))
-                    # Validate aid > 0 and fits in signed bigint (64-bit: -2^63 to 2^63-1)
-                    MAX_SIGNED_BIGINT = 9223372036854775807  # 2^63 - 1
-                    if aid <= 0:
-                        logger.warning(
-                            f'Invalid aid: {aid} (must be > 0), from avid: {avid_str}')
-                    elif aid > MAX_SIGNED_BIGINT:
-                        logger.warning(
-                            f'Invalid aid: {aid} (exceeds signed bigint max: {MAX_SIGNED_BIGINT}), from avid: {avid_str}')
-                    else:
-                        aid_list.append(aid)
-                        aid_count += 1
-                except ValueError as e:
+            rank_data = evocalrank_data[rank_name]
+            aid_count = 0
+            for item in rank_data:
+                if 'avid' not in item:
                     logger.warning(
-                        f'Failed to convert avid digits to int: {avid_str}, error: {e}')
-            else:
-                logger.warning(
-                    f'Failed to extract aid from avid: {avid_str}, format invalid (expected: av+digits)')
-        logger.info(
-            f'Extract {aid_count} aids from {rank_name}, rank data length: {len(rank_data)}')
-    logger.info(f'Total {len(aid_list)} aids extracted from evocalrank data!')
-    aid_list = list(set(aid_list))
-    logger.info(f'Total {len(aid_list)} aids after deduplication: {aid_list}')
+                        f'Item missing "avid" property in {rank_name}: {item}')
+                    continue
+                avid_str = item['avid']
+                # Validate format: av + digits (at least one)
+                match = re.match(r'^av(\d+)$', avid_str, re.IGNORECASE)
+                if match:
+                    try:
+                        aid = int(match.group(1))
+                        # Validate aid > 0 and fits in signed bigint (64-bit: -2^63 to 2^63-1)
+                        MAX_SIGNED_BIGINT = 9223372036854775807  # 2^63 - 1
+                        if aid <= 0:
+                            logger.warning(
+                                f'Invalid aid: {aid} (must be > 0), from avid: {avid_str}')
+                        elif aid > MAX_SIGNED_BIGINT:
+                            logger.warning(
+                                f'Invalid aid: {aid} (exceeds signed bigint max: {MAX_SIGNED_BIGINT}), from avid: {avid_str}')
+                        else:
+                            aid_list.append(aid)
+                            aid_count += 1
+                    except ValueError as e:
+                        logger.warning(
+                            f'Failed to convert avid digits to int: {avid_str}, error: {e}')
+                else:
+                    logger.warning(
+                        f'Failed to extract aid from avid: {avid_str}, format invalid (expected: av+digits)')
+            logger.info(
+                f'Extract {aid_count} aids from {rank_name}, rank data length: {len(rank_data)}')
+        logger.info(f'Total {len(aid_list)} aids extracted from evocalrank data!')
+        aid_list = list(set(aid_list))
+        logger.info(f'Total {len(aid_list)} aids after deduplication: {aid_list}')
 
-    # put aid into queue
-    aid_queue: Queue[int] = Queue()
-    for aid in aid_list:
-        aid_queue.put(aid)
+        # put aid into queue
+        aid_queue: Queue[int] = Queue()
+        for aid in aid_list:
+            aid_queue.put(aid)
 
-    # create jobs
-    job_num = 50
-    job_list: list[AddVideoJob] = []
-    for i in range(job_num):
-        job_list.append(AddVideoJob(
-            f'job_{i}', aid_queue, service))
+        # create jobs
+        job_num = 50
+        job_list: list[AddVideoJob] = []
+        for i in range(job_num):
+            job_list.append(AddVideoJob(
+                f'job_{i}', aid_queue, service))
 
-    # start jobs
-    for job in job_list:
-        job.start()
-    logger.info(f'{job_num} job(s) started.')
+        # start jobs
+        for job in job_list:
+            job.start()
+        logger.info(f'{job_num} job(s) started.')
 
-    # wait for jobs
-    for job in job_list:
-        job.join()
+        # wait for jobs
+        for job in job_list:
+            job.join()
 
-    # collect statistics
-    job_stat_list: list[JobStat] = []
-    for job in job_list:
-        job_stat_list.append(job.stat)
+        # collect statistics
+        job_stat_list: list[JobStat] = []
+        for job in job_list:
+            job_stat_list.append(job.stat)
 
-    # merge statistics counters
-    job_stat_merged = sum(job_stat_list, JobStat())
+        # merge statistics counters
+        job_stat_merged = sum(job_stat_list, JobStat())
 
-    timer.stop()
+        timer.stop()
 
-    logger.info('Finish add evocalrank video!')
-    logger.info(job_stat_merged.get_summary())
+        # run-record metrics (best-effort; a disabled recorder is a no-op).
+        # The run record keys the canonical script_fullname; the ServerChan
+        # summary below keeps its historical '.add_evocalrank_video' suffix.
+        recorder.add_job_stat_metrics('add-evocalrank-video', job_stat_merged)
 
-    # send sc
-    sc_send_summary(
-        f'{script_fullname}.add_evocalrank_video', timer, job_stat_merged)
+        logger.info('Finish add evocalrank video!')
+        logger.info(job_stat_merged.get_summary())
+
+        # send sc
+        sc_send_summary(
+            f'{script_fullname}.add_evocalrank_video', timer, job_stat_merged)
 
 
 def main():

--- a/71_add-sprint-video-record.py
+++ b/71_add-sprint-video-record.py
@@ -3,6 +3,7 @@ from timer import Timer
 from job import AddSprintVideoRecordJob
 from service import Service
 from serverchan import sc_send_summary
+from runrecord import track
 from util import logging_init, fullname
 from queue import Queue
 import logging
@@ -18,44 +19,48 @@ def add_sprint_video_record():
     timer = Timer()
     timer.start()
 
-    session = Session()
-    service = Service(mode='worker')
+    with track(script_fullname) as recorder:
+        session = Session()
+        service = Service(mode='worker')
 
-    # load processing video aids from db
-    result = session.execute('select aid from tdd_sprint_video where status = "processing"')
-    aids = [r['aid'] for r in result]
-    logger.info(f'Total {len(aids)} videos got.')
+        # load processing video aids from db
+        result = session.execute('select aid from tdd_sprint_video where status = "processing"')
+        aids = [r['aid'] for r in result]
+        logger.info(f'Total {len(aids)} videos got.')
 
-    # put aid into queue
-    aid_queue: Queue[int] = Queue()
-    for aid in aids:
-        aid_queue.put(aid)
-    logger.info(f'{aid_queue.qsize()} aids put into queue.')
+        # put aid into queue
+        aid_queue: Queue[int] = Queue()
+        for aid in aids:
+            aid_queue.put(aid)
+        logger.info(f'{aid_queue.qsize()} aids put into queue.')
 
-    # create job
-    job = AddSprintVideoRecordJob('job', aid_queue, service)
+        # create job
+        job = AddSprintVideoRecordJob('job', aid_queue, service)
 
-    # start job
-    job.start()
+        # start job
+        job.start()
 
-    # wait for job
-    job.join()
+        # wait for job
+        job.join()
 
-    # collect statistic
-    job_stat = job.stat
+        # collect statistic
+        job_stat = job.stat
 
-    session.close()
+        session.close()
 
-    timer.stop()
+        timer.stop()
 
-    # summary
-    logger.info(f'Finish {script_fullname}!')
-    logger.info(timer.get_summary())
-    logger.info(job_stat.get_summary())
-    if job_stat.condition['exception'] > 0 \
-            or job_stat.condition['million_exception'] > 0 \
-            or job_stat.condition['million_success'] > 0:
-        sc_send_summary(script_fullname, timer, job_stat)
+        # run-record metrics (best-effort; a disabled recorder is a no-op)
+        recorder.add_job_stat_metrics('sprint-video-record', job_stat)
+
+        # summary
+        logger.info(f'Finish {script_fullname}!')
+        logger.info(timer.get_summary())
+        logger.info(job_stat.get_summary())
+        if job_stat.condition['exception'] > 0 \
+                or job_stat.condition['million_exception'] > 0 \
+                or job_stat.condition['million_success'] > 0:
+            sc_send_summary(script_fullname, timer, job_stat)
 
 
 def main():

--- a/runrecord/__init__.py
+++ b/runrecord/__init__.py
@@ -1,8 +1,8 @@
 from . import schema
 from .recorder import (
-    RunRecorder, display_status,
+    RunRecorder, track, display_status,
     RUNNING, SUCCEEDED, FAILED, DEFAULT_DB_PATH,
 )
 
-__all__ = ['RunRecorder', 'display_status', 'schema',
+__all__ = ['RunRecorder', 'track', 'display_status', 'schema',
            'RUNNING', 'SUCCEEDED', 'FAILED', 'DEFAULT_DB_PATH']

--- a/runrecord/recorder.py
+++ b/runrecord/recorder.py
@@ -13,6 +13,13 @@ Usage (see 51_hourly-video-record-add.py):
         recorder.finish('failed')
         raise
 
+Scripts with a single top-level body can use the ``track`` context manager
+instead, which runs that same lifecycle (see 12_/15_/17_/62_/71_):
+
+    with track('15_update-video-info') as recorder:
+        ... do the work ...
+        recorder.add_job_stat_metrics('video-update', stat)
+
 Every method is best-effort: any failure is logged at WARNING and swallowed, and
 `RunRecorder.start` returns a disabled (no-op) recorder if the database cannot be
 opened. Recording is an index over the logs, never a thing that can break a run.
@@ -23,13 +30,14 @@ import os
 import socket
 import subprocess
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from typing import Optional
 
 from ._sqlite import sqlite3
 from . import schema
 
-__all__ = ['RunRecorder', 'display_status', 'RUNNING', 'SUCCEEDED', 'FAILED']
+__all__ = ['RunRecorder', 'track', 'display_status', 'RUNNING', 'SUCCEEDED', 'FAILED']
 
 logger = logging.getLogger('runrecord')
 
@@ -182,6 +190,46 @@ class RunRecorder:
             pass
         self._conn = None
         self.enabled = False
+
+
+def _is_failure(exc: BaseException) -> bool:
+    """
+    Whether an exception leaving a tracked block should close the run as
+    'failed'. A clean ``exit()`` / ``exit(0)`` is a success; anything else --
+    a real exception, ``exit(1)``, KeyboardInterrupt -- is a failure.
+    """
+    if isinstance(exc, SystemExit):
+        return exc.code not in (0, None)
+    return True
+
+
+@contextmanager
+def track(script_name: str, db_path: Optional[str] = None):
+    """
+    Wrap a script run in the same lifecycle 51_ drives by hand: open a run
+    record, attach the active log-file locations, then close the record on the
+    way out -- 'succeeded' on a clean exit, 'failed' if the body raises (the
+    exception then propagates unchanged). A killed / power-lost process never
+    reaches the exit, so its row is left 'running' for the query side to derive
+    as 'stale' -- the signal that separates "did not finish" from "failed".
+
+        with track('15_update-video-info') as recorder:
+            ... do the work ...
+            recorder.add_job_stat_metrics('video-update', stat)
+
+    Best-effort like every other entry point here: a disabled recorder (no
+    driver, unwritable database, schema too new) turns every call into a no-op
+    and the block runs exactly as if it were not there.
+    """
+    recorder = RunRecorder.start(script_name, db_path=db_path)
+    recorder.attach_log_locations()
+    try:
+        yield recorder
+    except BaseException as e:
+        recorder.finish('failed' if _is_failure(e) else 'succeeded')
+        raise
+    else:
+        recorder.finish('succeeded')
 
 
 def display_status(status: str, started_at: str, finished_at: Optional[str] = None,

--- a/tests/test_run_record_track.py
+++ b/tests/test_run_record_track.py
@@ -1,0 +1,150 @@
+"""
+Tests for the ``runrecord.track`` context manager -- the shared run-record
+lifecycle used by the summary scripts (12_/15_/17_/62_/71_).
+
+``track`` runs the same open / attach-logs / close sequence 51_ drives by hand:
+'succeeded' on a clean exit, 'failed' if the body raises, and a row left
+'running' (for the query side to derive as 'stale') if the process is killed
+before the block exits.
+
+Run from the repo root:
+
+    python tests/test_run_record_track.py
+    # or
+    python -m unittest discover -s tests
+"""
+
+import logging
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runrecord import track  # noqa: E402
+from runrecord._sqlite import sqlite3  # noqa: E402
+
+
+class FakeStat:
+    """Duck-types job.JobStat for add_job_stat_metrics (total_count + condition)."""
+
+    def __init__(self, total_count, condition):
+        self.total_count = total_count
+        self.condition = condition
+
+
+def _rows(path, query, params=()):
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute(query, params).fetchall()
+    finally:
+        conn.close()
+
+
+class TrackLifecycleTest(unittest.TestCase):
+    def setUp(self):
+        self.path = os.path.join(tempfile.mkdtemp(), 'db.sqlite3')
+
+    def _status(self):
+        return _rows(self.path, 'SELECT status, finished_at FROM run')[0]
+
+    def test_clean_exit_records_succeeded(self):
+        with track('15_update-video-info', db_path=self.path) as rec:
+            self.assertTrue(rec.enabled)
+        status, finished_at = self._status()
+        self.assertEqual(status, 'succeeded')
+        self.assertTrue(finished_at)
+
+    def test_exception_records_failed_and_propagates(self):
+        class Boom(RuntimeError):
+            pass
+
+        with self.assertRaises(Boom):
+            with track('15_update-video-info', db_path=self.path):
+                raise Boom('kaboom')
+        status, finished_at = self._status()
+        self.assertEqual(status, 'failed')
+        self.assertTrue(finished_at)
+
+    def test_exit_nonzero_records_failed_and_propagates(self):
+        # 62_ calls exit(1) when the evocalrank fetch fails -- SystemExit(1),
+        # which must still close the run as 'failed', not leave it 'running'.
+        with self.assertRaises(SystemExit) as ctx:
+            with track('62_add-evocalrank-video', db_path=self.path):
+                exit(1)
+        self.assertEqual(ctx.exception.code, 1)
+        self.assertEqual(self._status()[0], 'failed')
+
+    def test_clean_exit_zero_records_succeeded(self):
+        with self.assertRaises(SystemExit):
+            with track('s', db_path=self.path):
+                sys.exit(0)
+        self.assertEqual(self._status()[0], 'succeeded')
+
+    def test_bare_exit_records_succeeded(self):
+        with self.assertRaises(SystemExit):
+            with track('s', db_path=self.path):
+                sys.exit()  # code is None -> a clean exit
+        self.assertEqual(self._status()[0], 'succeeded')
+
+    def test_keyboard_interrupt_records_failed(self):
+        with self.assertRaises(KeyboardInterrupt):
+            with track('s', db_path=self.path):
+                raise KeyboardInterrupt
+        self.assertEqual(self._status()[0], 'failed')
+
+    def test_metrics_and_logs_are_recorded_from_inside_the_block(self):
+        probe = logging.getLogger('track_test_probe')
+        probe.handlers = []
+        log_path = os.path.join(os.path.dirname(self.path), 's_INFO.log')
+        h = logging.FileHandler(log_path, encoding='utf-8')
+        h.setLevel(logging.INFO)
+        probe.addHandler(h)
+        self.addCleanup(h.close)
+
+        with track('17_add-member-follower-record', db_path=self.path) as rec:
+            rec.attach_log_locations(source_logger=probe)
+            rec.add_job_stat_metrics('follower-fetch', FakeStat(10, {'success': 9, 'exception': 1}))
+            rec.add_job_stat_metrics('follower-db-writer', FakeStat(9, {'batch_insert': 1}))
+
+        run_id = _rows(self.path, 'SELECT run_id FROM run')[0][0]
+        metrics = {
+            (scope, name): value
+            for scope, name, value in _rows(
+                self.path, 'SELECT scope, name, value FROM run_metric')
+        }
+        self.assertEqual(metrics[('follower-fetch', 'total_count')], 10.0)
+        self.assertEqual(metrics[('follower-fetch', 'success')], 9.0)
+        self.assertEqual(metrics[('follower-fetch', 'exception')], 1.0)
+        self.assertEqual(metrics[('follower-db-writer', 'batch_insert')], 1.0)
+        logs = _rows(self.path, 'SELECT level, path FROM run_log WHERE run_id = ?', (run_id,))
+        self.assertEqual(logs, [('INFO', log_path)])
+
+
+class TrackBestEffortTest(unittest.TestCase):
+    def test_unopenable_db_yields_disabled_recorder_and_body_still_runs(self):
+        # parent path is a regular file -> the database cannot be opened
+        f = tempfile.NamedTemporaryFile(delete=False)
+        f.close()
+        bad_path = os.path.join(f.name, 'nope', 'db.sqlite3')
+
+        ran = []
+        with track('s', db_path=bad_path) as rec:
+            self.assertFalse(rec.enabled)
+            rec.add_job_stat_metrics('x', FakeStat(1, {'a': 1}))  # no-op
+            ran.append(True)
+        self.assertEqual(ran, [True])
+
+    def test_disabled_recorder_does_not_swallow_a_body_exception(self):
+        f = tempfile.NamedTemporaryFile(delete=False)
+        f.close()
+        bad_path = os.path.join(f.name, 'nope', 'db.sqlite3')
+
+        with self.assertRaises(ValueError):
+            with track('s', db_path=bad_path):
+                raise ValueError('still propagates')
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/tests/test_summary_script_run_records.py
+++ b/tests/test_summary_script_run_records.py
@@ -1,0 +1,331 @@
+"""
+Per-entry-point verification that the five ``sc_send_summary`` production
+scripts (12_/15_/17_/62_/71_) now open, populate and close a run record without
+changing their Timer / JobStat summary or ServerChan behaviour.
+
+Each script is imported by file path; its collaborators (Service, Session, the
+Job classes / JobPool, ``requests``) are replaced with inert fakes and its
+``sc_send_summary`` with a spy, then the top-level work function is driven once
+for a normal run and once for a failing run. The assertions are:
+
+* a ``run`` row is written, keyed by the canonical ``script_id_script_name``;
+* it ends ``succeeded`` on a normal run and ``failed`` when the body raises;
+* the JobStat counters land in ``run_metric`` under the expected scopes;
+* ``sc_send_summary`` is still called with exactly the arguments it always got.
+
+These scripts import ``db`` / ``service`` (SQLAlchemy, requests). Where those
+are absent the whole module skips, matching ``test_run_record.py``'s handling of
+a bare checkout.
+"""
+
+import importlib.util
+import logging
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from runrecord._sqlite import sqlite3  # noqa: E402
+
+
+def _install_stub_conf():
+    """
+    ``conf/conf.ini`` is a git-ignored secret, so it is absent from a fresh
+    checkout and ``import db`` (which builds a SQLAlchemy engine at import
+    time) fails. Install an inert ``conf`` with dummy values: the engine
+    URL never has to be valid here -- every DB call is faked -- and this keeps
+    the test independent of real credentials.
+    """
+    if 'conf' in sys.modules and hasattr(sys.modules['conf'], 'get_db_args'):
+        try:
+            sys.modules['conf'].get_db_args()
+            return  # a real, populated conf is already importable
+        except Exception:
+            pass
+    stub = types.ModuleType('conf')
+    stub.CONFIG_PATH = ''
+    stub.CONFIG = None
+    stub.get_db_args = lambda: {
+        'user': 'stub', 'password': 'stub', 'host': '127.0.0.1',
+        'port': '3306', 'dbname': 'stub'}
+    stub.get_sckey = lambda: 'stub'
+    stub.__all__ = ['CONFIG_PATH', 'CONFIG', 'get_db_args', 'get_sckey']
+    sys.modules['conf'] = stub
+    sys.modules['conf.conf'] = stub
+
+
+try:
+    _install_stub_conf()
+    from job import JobStat
+    import db  # noqa: F401
+    import service  # noqa: F401
+    import serverchan  # noqa: F401
+    _DEPS = True
+except Exception as _e:  # pragma: no cover - depends on the environment
+    _DEPS = False
+    _DEPS_ERR = repr(_e)
+
+
+def _load(filename):
+    """Import a hyphenated top-level script by path under a safe module name."""
+    path = os.path.join(ROOT, filename)
+    name = 'scriptmod_' + filename.replace('-', '_').replace('.py', '')
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _stat(total_count=0, **conditions):
+    s = JobStat()
+    s.total_count = total_count
+    for k, v in conditions.items():
+        s.condition[k] = v
+    return s
+
+
+class _FakeService:
+    def __init__(self, *a, **kw):
+        pass
+
+
+class _FakeSession:
+    def execute(self, *a, **kw):
+        return []
+
+    def close(self):
+        pass
+
+
+class _FakeJob:
+    """Stands in for a single Job: start()/join() no-op, carries a .stat."""
+
+    def __init__(self, stat=None):
+        self.stat = stat if stat is not None else _stat()
+
+    def start(self):
+        pass
+
+    def join(self):
+        pass
+
+
+class _FakePool:
+    """Stands in for a JobPool: start() no-op, join() returns a merged JobStat."""
+
+    def __init__(self, merged):
+        self._merged = merged
+
+    def start(self):
+        pass
+
+    def join(self):
+        return self._merged
+
+
+def _db(path, query, params=()):
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute(query, params).fetchall()
+    finally:
+        conn.close()
+
+
+@unittest.skipUnless(_DEPS, 'db/service/job deps not importable in this environment')
+class SummaryScriptRunRecordTest(unittest.TestCase):
+    def setUp(self):
+        self.db_path = os.path.join(tempfile.mkdtemp(), 'run-records.sqlite3')
+        os.environ['TDD_RUN_RECORD_DB'] = self.db_path
+        self.addCleanup(os.environ.pop, 'TDD_RUN_RECORD_DB', None)
+        # keep the scripts' logging_init out of it -- attach_log_locations just
+        # finds no FileHandlers on the root logger, which is fine here.
+        logging.disable(logging.CRITICAL)
+        self.addCleanup(logging.disable, logging.NOTSET)
+
+    def _runs(self):
+        return _db(self.db_path,
+                   'SELECT run_id, script_name, status, finished_at FROM run '
+                   'ORDER BY started_at')
+
+    def _metrics(self, run_id):
+        out = {}
+        for scope, name, value in _db(
+                self.db_path,
+                'SELECT scope, name, value FROM run_metric WHERE run_id = ?',
+                (run_id,)):
+            out.setdefault(scope, {})[name] = value
+        return out
+
+    # ----------------------------------------------------------------- 12_ ---
+    def test_12_add_latest_video_with_tid_30(self):
+        m = _load('12_add-latest-video-with-tid-30.py')
+        newlist_stat = _stat(3, not_fully_loaded_page=1, get_newlist_exception=0)
+        add_stat = _stat(7, new_video=2, add_video_exception=0,
+                         commit_video_record_exception=0)
+
+        with mock.patch.object(m, 'Service', _FakeService), \
+             mock.patch.object(m, 'GetNewlistArchiveJob',
+                               lambda *a, **kw: _FakeJob(newlist_stat)), \
+             mock.patch.object(m, 'AddVideoFromArchiveJob',
+                               lambda *a, **kw: _FakeJob(add_stat)), \
+             mock.patch.object(m, 'sc_send_summary') as sc:
+            m.add_latest_video_with_tid_30()
+
+        (run_id, script_name, status, finished_at), = self._runs()
+        self.assertEqual(script_name, '12_add-latest-video-with-tid-30')
+        self.assertEqual(status, 'succeeded')
+        self.assertTrue(finished_at)
+        metrics = self._metrics(run_id)
+        self.assertEqual(metrics['get-newlist-archive']['total_count'], 3.0)
+        self.assertEqual(metrics['get-newlist-archive']['not_fully_loaded_page'], 1.0)
+        # 10 AddVideoFromArchiveJob stats merged (fake returns the same stat)
+        self.assertEqual(metrics['add-video-from-archive']['total_count'], 70.0)
+        self.assertEqual(metrics['add-video-from-archive']['new_video'], 20.0)
+        # conditional SC: no exception keys tripped -> not sent (unchanged rule)
+        sc.assert_not_called()
+
+    def test_12_failure_is_recorded(self):
+        m = _load('12_add-latest-video-with-tid-30.py')
+        with mock.patch.object(m, 'Service', _FakeService), \
+             mock.patch.object(m, 'GetNewlistArchiveJob',
+                               side_effect=RuntimeError('boom')), \
+             mock.patch.object(m, 'sc_send_summary'):
+            with self.assertRaises(RuntimeError):
+                m.add_latest_video_with_tid_30()
+        (_, _, status, _), = self._runs()
+        self.assertEqual(status, 'failed')
+
+    # ----------------------------------------------------------------- 15_ ---
+    def test_15_update_video_info(self):
+        m = _load('15_update-video-info.py')
+        merged = _stat(120, **{'0_update': 118, 'update_exception': 2})
+
+        with mock.patch.object(m, 'Service', _FakeService), \
+             mock.patch.object(m, 'Session', _FakeSession), \
+             mock.patch.object(m.DBOperation, 'query_all_video_bvids',
+                               staticmethod(lambda s: [])), \
+             mock.patch.object(m, 'JobPool', lambda *a, **kw: _FakePool(merged)), \
+             mock.patch.object(m, 'b2a', lambda bv: 1), \
+             mock.patch.object(m, 'sc_send_summary') as sc:
+            m.update_video_info()
+
+        (run_id, script_name, status, _), = self._runs()
+        self.assertEqual(script_name, '15_update-video-info')
+        self.assertEqual(status, 'succeeded')
+        metrics = self._metrics(run_id)
+        self.assertEqual(metrics['video-update']['total_count'], 120.0)
+        self.assertEqual(metrics['video-update']['update_exception'], 2.0)
+        # 15_ sends unconditionally; same (name, timer, merged stat) as before
+        sc.assert_called_once()
+        args = sc.call_args.args
+        self.assertEqual(args[0], '15_update-video-info')
+        self.assertIs(args[2], merged)
+
+    # ----------------------------------------------------------------- 17_ ---
+    def test_17_add_member_follower_record(self):
+        m = _load('17_add-member-follower-record.py')
+        fetch = _stat(100, success=100, exception=0)
+        writer = _stat(100, batch_insert=1, batch_insert_fail=0)
+        pools = iter([_FakePool(fetch), _FakePool(writer)])
+
+        with mock.patch.object(m, 'Service', _FakeService), \
+             mock.patch.object(m, 'Session', _FakeSession), \
+             mock.patch.object(m.DBOperation, 'query_all_member_mids',
+                               staticmethod(lambda session: [])), \
+             mock.patch.object(m, 'JobPool', lambda *a, **kw: next(pools)), \
+             mock.patch.object(m, 'sc_send_summary') as sc:
+            m.add_member_follower_record()
+
+        (run_id, script_name, status, _), = self._runs()
+        self.assertEqual(script_name, '17_add-member-follower-record')
+        self.assertEqual(status, 'succeeded')
+        metrics = self._metrics(run_id)
+        self.assertEqual(metrics['follower-fetch']['success'], 100.0)
+        self.assertEqual(metrics['follower-db-writer']['batch_insert'], 1.0)
+        # 17_ still passes the FETCH stat (not the writer stat) to ServerChan
+        sc.assert_called_once()
+        self.assertIs(sc.call_args.args[2], fetch)
+
+    # ----------------------------------------------------------------- 62_ ---
+    def test_62_add_evocalrank_video(self):
+        m = _load('62_add-evocalrank-video.py')
+        merged = _stat(5, success=5, other_exception=0)
+        resp = mock.Mock()
+        resp.json.return_value = {}  # no ranks -> no aids, still a clean run
+
+        with mock.patch.object(m, 'Service', _FakeService), \
+             mock.patch.object(m.requests, 'get', return_value=resp), \
+             mock.patch.object(m, 'AddVideoJob',
+                               lambda *a, **kw: _FakeJob(merged)), \
+             mock.patch.object(m, 'sc_send_summary') as sc:
+            m.add_evocalrank_video(700)
+
+        (run_id, script_name, status, _), = self._runs()
+        self.assertEqual(script_name, '62_add-evocalrank-video')
+        self.assertEqual(status, 'succeeded')
+        # merged over 50 fake jobs: total_count 5 * 50, condition scaled too
+        self.assertEqual(self._metrics(run_id)['add-evocalrank-video']['total_count'], 250.0)
+        # SC keeps its historical suffixed name
+        sc.assert_called_once()
+        self.assertEqual(sc.call_args.args[0],
+                         '62_add-evocalrank-video.add_evocalrank_video')
+
+    def test_62_fetch_failure_exits_and_records_failed(self):
+        m = _load('62_add-evocalrank-video.py')
+        resp = mock.Mock()
+        resp.raise_for_status.side_effect = RuntimeError('503')
+
+        with mock.patch.object(m, 'Service', _FakeService), \
+             mock.patch.object(m.requests, 'get', return_value=resp), \
+             mock.patch.object(m, 'sc_send_summary'):
+            with self.assertRaises(SystemExit) as ctx:
+                m.add_evocalrank_video(700)
+
+        self.assertEqual(ctx.exception.code, 1)
+        (_, _, status, finished_at), = self._runs()
+        self.assertEqual(status, 'failed')
+        self.assertTrue(finished_at)
+
+    # ----------------------------------------------------------------- 71_ ---
+    def test_71_add_sprint_video_record(self):
+        m = _load('71_add-sprint-video-record.py')
+        stat = _stat(13, success=12, exception=1)
+
+        with mock.patch.object(m, 'Service', _FakeService), \
+             mock.patch.object(m, 'Session', _FakeSession), \
+             mock.patch.object(m, 'AddSprintVideoRecordJob',
+                               lambda *a, **kw: _FakeJob(stat)), \
+             mock.patch.object(m, 'sc_send_summary') as sc:
+            m.add_sprint_video_record()
+
+        (run_id, script_name, status, _), = self._runs()
+        self.assertEqual(script_name, '71_add-sprint-video-record')
+        self.assertEqual(status, 'succeeded')
+        self.assertEqual(self._metrics(run_id)['sprint-video-record']['exception'], 1.0)
+        # conditional rule unchanged: exception > 0 -> SC is sent
+        sc.assert_called_once()
+        self.assertIs(sc.call_args.args[2], stat)
+
+    def test_71_no_exceptions_skips_serverchan(self):
+        m = _load('71_add-sprint-video-record.py')
+        stat = _stat(13, success=13)
+
+        with mock.patch.object(m, 'Service', _FakeService), \
+             mock.patch.object(m, 'Session', _FakeSession), \
+             mock.patch.object(m, 'AddSprintVideoRecordJob',
+                               lambda *a, **kw: _FakeJob(stat)), \
+             mock.patch.object(m, 'sc_send_summary') as sc:
+            m.add_sprint_video_record()
+
+        self.assertEqual(self._runs()[0][2], 'succeeded')
+        sc.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Bring the five cron scripts that call `sc_send_summary` into the run-record
system: `12_add-latest-video-with-tid-30`, `15_update-video-info`,
`17_add-member-follower-record`, `62_add-evocalrank-video`,
`71_add-sprint-video-record`.

Until now only `51_hourly-video-record-add` wrote a run record, so it was the
only entry point where a killed run could be told apart from a failed one.

## How

- New `runrecord.track` context manager — the same open / `attach_log_locations`
  / close lifecycle `51_` runs by hand, factored out so all five call sites get
  one reviewed implementation:

  ```python
  with track(script_fullname) as recorder:
      ... existing body ...
      recorder.add_job_stat_metrics('video-update', stat)
  ```

  On a clean exit it records `succeeded`; if the body raises (or calls
  `exit(1)`, as `62_` does when the evocalrank fetch fails) it records `failed`
  and re-raises unchanged; a process killed before the block exits leaves the
  row `running`, which the query CLI derives as `stale`. `exit()` / `exit(0)`
  counts as a clean exit.

- Each script records the `JobStat` counters it already computes as `run_metric`
  rows, under per-stage scopes that match the labels in its summary log
  (`follower-fetch` / `follower-db-writer`, `video-update`,
  `get-newlist-archive` / `add-video-from-archive`, etc.). Stage-timing
  accumulators (`*_ms`) are excluded, same as `51_`.

- `track` is best-effort like the rest of the package: a disabled recorder (no
  SQLite driver, unwritable DB, schema too new) makes every call a no-op and the
  script runs exactly as before.

## Behavior preserved

- Every `Timer` and `JobStat` summary log line is unchanged.
- Every `sc_send_summary` call is unchanged — same arguments, same position,
  including `62_`'s historical `.add_evocalrank_video` name suffix (the run
  record keys the canonical `62_add-evocalrank-video`) and the conditional sends
  in `12_` and `71_`.
- Only structured counts and the fixed run fields are persisted; no message
  bodies, tracebacks, or credential-bearing URLs.

The re-indentation from wrapping each work body in `with` accounts for most of
the diff; the logic changes are the `track` wrapper and the
`add_job_stat_metrics` calls.

## Verification

- `python -m unittest discover -s tests` — 91 tests pass.
  - `tests/test_run_record_track.py` (9): lifecycle of `track` — succeeded,
    failed on exception, failed on `exit(1)`, succeeded on `exit()`/`exit(0)`,
    KeyboardInterrupt, metrics/logs written from inside the block, disabled
    recorder still runs the body and still propagates its exceptions.
  - `tests/test_summary_script_run_records.py` (8): each of the five work
    functions driven once with faked collaborators — asserts the `run` row, its
    status, the metric scopes/values, and that `sc_send_summary` still receives
    exactly its previous arguments. Skips where `db`/`service` deps are absent.
- Exercised the `python -m runrecord` query CLI against a database populated by
  those runs: `list`, `list --status failed`, `show --latest --script …`,
  `show <id-prefix>`, and `--stale-after` all render the succeeded / failed /
  running→stale states correctly. No CLI friction found.

## Not included

No deployment. The production venv needs `pysqlite3-binary` (already in
`requirements.txt` since the store landed) for these to record; without a SQLite
driver they run unchanged with recording disabled.
