### PR TITLE
feat: run records for the two remaining scheduled scripts

### DIFF
--- a/18_member-total-stat-update.py
+++ b/18_member-total-stat-update.py
@@ -2,6 +2,7 @@ from db import Session, TddMemberTotalStatRecord
 from util import logging_init, get_ts_s, get_current_line_no, fullname
 from timer import Timer
 from serverchan import sc_send_critical
+from runrecord import track
 import logging
 
 script_id = '18'
@@ -15,67 +16,74 @@ def member_total_stat_update():
     timer = Timer()
     timer.start()
 
-    session = Session()
+    with track(script_fullname) as recorder:
+        session = Session()
 
-    try:
-        added = get_ts_s()
+        try:
+            added = get_ts_s()
 
-        sql = 'select ' \
-              'v.aid, v.mid as v_mid, ' \
-              'r.view, r.danmaku, r.reply, r.favorite, r.coin, r.share, r.like, ' \
-              's.mid as s_mid ' \
-              'from ' \
-              'tdd_video v ' \
-              'left join tdd_video_record r on v.laststat = r.id ' \
-              'left join tdd_video_staff s on v.aid = s.aid ' \
-              'where ' \
-              'v.mid is not null && v.laststat is not null;'
-        result = session.execute(sql)
-        result = [[r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]] for r in result]
-        result_len = len(result)
-        logger.info(f'Total {result_len} result got.')
+            sql = 'select ' \
+                  'v.aid, v.mid as v_mid, ' \
+                  'r.view, r.danmaku, r.reply, r.favorite, r.coin, r.share, r.like, ' \
+                  's.mid as s_mid ' \
+                  'from ' \
+                  'tdd_video v ' \
+                  'left join tdd_video_record r on v.laststat = r.id ' \
+                  'left join tdd_video_staff s on v.aid = s.aid ' \
+                  'where ' \
+                  'v.mid is not null && v.laststat is not null;'
+            result = session.execute(sql)
+            result = [[r[0], r[1], r[2], r[3], r[4], r[5], r[6], r[7], r[8], r[9]] for r in result]
+            result_len = len(result)
+            logger.info(f'Total {result_len} result got.')
 
-        mid_dict = {}
-        for r in result:
-            mid = r[1] if r[9] is None else r[9]  # if has staff, use staff mid instead
-            if mid not in mid_dict.keys():
-                mid_dict[mid] = TddMemberTotalStatRecord(added, mid)  # init mid in dict
-            mid_dict[mid].video_count += 1
-            mid_dict[mid].view += r[2]
-            mid_dict[mid].danmaku += r[3]
-            mid_dict[mid].reply += r[4]
-            mid_dict[mid].favorite += r[5]
-            mid_dict[mid].coin += r[6]
-            mid_dict[mid].share += r[7]
-            mid_dict[mid].like += r[8]
-        mid_dict_len = len(mid_dict)
-        logger.info(f'Total {mid_dict_len} items in mid_dict created.')
+            mid_dict = {}
+            for r in result:
+                mid = r[1] if r[9] is None else r[9]  # if has staff, use staff mid instead
+                if mid not in mid_dict.keys():
+                    mid_dict[mid] = TddMemberTotalStatRecord(added, mid)  # init mid in dict
+                mid_dict[mid].video_count += 1
+                mid_dict[mid].view += r[2]
+                mid_dict[mid].danmaku += r[3]
+                mid_dict[mid].reply += r[4]
+                mid_dict[mid].favorite += r[5]
+                mid_dict[mid].coin += r[6]
+                mid_dict[mid].share += r[7]
+                mid_dict[mid].like += r[8]
+            mid_dict_len = len(mid_dict)
+            logger.info(f'Total {mid_dict_len} items in mid_dict created.')
 
-        cnt = 0
-        for v in mid_dict.values():
-            session.add(v)
-            cnt += 1
-            if cnt % 100 == 0:
+            cnt = 0
+            for v in mid_dict.values():
+                session.add(v)
+                cnt += 1
+                if cnt % 100 == 0:
+                    session.commit()
+                    logger.info(f'{cnt} / {mid_dict_len} added')
+            if cnt % 100 != 0:
                 session.commit()
                 logger.info(f'{cnt} / {mid_dict_len} added')
-        if cnt % 100 != 0:
-            session.commit()
-            logger.info(f'{cnt} / {mid_dict_len} added')
-    except Exception as e:
-        message = f'Exception occurred when updating member total stat! error: {e}'
-        logger.critical(message)
-        sc_send_critical(script_fullname, message, __file__, get_current_line_no())
-        session.rollback()
+        except Exception as e:
+            message = f'Exception occurred when updating member total stat! error: {e}'
+            logger.critical(message)
+            sc_send_critical(script_fullname, message, __file__, get_current_line_no())
+            session.rollback()
+            session.close()
+            exit(1)
+
         session.close()
-        exit(1)
 
-    session.close()
+        timer.stop()
 
-    timer.stop()
+        # run-record metrics (best-effort; a disabled recorder is a no-op).
+        # Only the counts this script already computes -- no fabricated JobStat.
+        recorder.add_metric('member-total-stat', 'result_rows', result_len, 'count')
+        recorder.add_metric('member-total-stat', 'member_count', mid_dict_len, 'count')
+        recorder.add_metric('member-total-stat', 'records_added', cnt, 'count')
 
-    # summary
-    logger.info(f'Finish {script_fullname}!')
-    logger.info(timer.get_summary())
+        # summary
+        logger.info(f'Finish {script_fullname}!')
+        logger.info(timer.get_summary())
 
 
 def main():

--- a/72_add-sprint-daily.py
+++ b/72_add-sprint-daily.py
@@ -3,6 +3,7 @@ from db import Session
 import datetime
 from timer import Timer
 from serverchan import sc_send, sc_send_critical
+from runrecord import track
 from util import logging_init, get_ts_s, ts_s_to_str, get_current_line_no, fullname
 import math
 import logging
@@ -18,132 +19,144 @@ def add_sprint_daily():
     timer = Timer()
     timer.start()
 
-    session = Session()
+    with track(script_fullname) as recorder:
+        session = Session()
 
-    try:
-        # get now time to format as date
-        date = datetime.datetime.now().strftime('%Y%m%d')
+        try:
+            # get now time to format as date
+            date = datetime.datetime.now().strftime('%Y%m%d')
 
-        # calc start ts and end ts
-        end_ts = int(time.mktime(time.strptime(date, "%Y%m%d"))) + 60 * 60 * 6
-        start_ts = end_ts - 60 * 60 * 24
+            # calc start ts and end ts
+            end_ts = int(time.mktime(time.strptime(date, "%Y%m%d"))) + 60 * 60 * 6
+            start_ts = end_ts - 60 * 60 * 24
 
-        # get start records
-        result = session.execute(f'select aid, `view` from tdd_sprint_video_record '
-                                 f'where added >= {start_ts} && added < {start_ts + 30 * 60}')
-        start_records = [(r['aid'], r['view']) for r in result]
-        start_records_view = {}
-        for (aid, view) in start_records:
-            if aid not in start_records_view.keys():
-                start_records_view[aid] = view
-        logger.info(f'Total {len(start_records_view)} start video got.')
+            # get start records
+            result = session.execute(f'select aid, `view` from tdd_sprint_video_record '
+                                     f'where added >= {start_ts} && added < {start_ts + 30 * 60}')
+            start_records = [(r['aid'], r['view']) for r in result]
+            start_records_view = {}
+            for (aid, view) in start_records:
+                if aid not in start_records_view.keys():
+                    start_records_view[aid] = view
+            logger.info(f'Total {len(start_records_view)} start video got.')
 
-        # get end records
-        result = session.execute(f'select aid, `view` from tdd_sprint_video_record '
-                                 f'where added >= {end_ts} && added < {end_ts + 30 * 60}')
-        end_records = [(r['aid'], r['view']) for r in result]
-        end_records_view = {}
-        for (aid, view) in end_records:
-            if aid not in end_records_view.keys():
-                end_records_view[aid] = view
-        logger.info(f'Total {len(end_records_view)} end video got.')
+            # get end records
+            result = session.execute(f'select aid, `view` from tdd_sprint_video_record '
+                                     f'where added >= {end_ts} && added < {end_ts + 30 * 60}')
+            end_records = [(r['aid'], r['view']) for r in result]
+            end_records_view = {}
+            for (aid, view) in end_records:
+                if aid not in end_records_view.keys():
+                    end_records_view[aid] = view
+            logger.info(f'Total {len(end_records_view)} end video got.')
 
-        # assemble records
-        new_video_aids = []
-        million_video_aids = []
-        view_incr_total = 0
-        video_total = 0
-        for aid in set(list(start_records_view.keys()) + list(end_records_view.keys())):
-            if aid not in start_records_view.keys():
-                logger.info(f'New video detected. aid: {aid}')
-                new_video_aids.append(aid)
-                result = session.execute(f'select `view` from tdd_sprint_video_record '
-                                         f'where aid = {aid} order by added limit 1')
-                start_view = [r['view'] for r in result][0]
-            else:
-                start_view = start_records_view[aid]
+            # assemble records
+            new_video_aids = []
+            million_video_aids = []
+            view_incr_total = 0
+            video_total = 0
+            for aid in set(list(start_records_view.keys()) + list(end_records_view.keys())):
+                if aid not in start_records_view.keys():
+                    logger.info(f'New video detected. aid: {aid}')
+                    new_video_aids.append(aid)
+                    result = session.execute(f'select `view` from tdd_sprint_video_record '
+                                             f'where aid = {aid} order by added limit 1')
+                    start_view = [r['view'] for r in result][0]
+                else:
+                    start_view = start_records_view[aid]
 
-            if aid not in end_records_view.keys():
-                logger.info(f'New million video detected. aid: {aid}')
-                million_video_aids.append(aid)
-                end_view = 1000000
-            else:
-                end_view = end_records_view[aid]
+                if aid not in end_records_view.keys():
+                    logger.info(f'New million video detected. aid: {aid}')
+                    million_video_aids.append(aid)
+                    end_view = 1000000
+                else:
+                    end_view = end_records_view[aid]
 
-            view_incr = end_view - start_view
-            view_incr_total += view_incr
+                view_incr = end_view - start_view
+                view_incr_total += view_incr
 
-            if end_view == 1000000:
-                continue
+                if end_view == 1000000:
+                    continue
 
-            # calc pday
-            added = get_ts_s()
-            result = session.execute(f'select created from tdd_sprint_video where aid = {aid}')
-            created = [r['created'] for r in result][0]
-            pday = math.floor((added - created) / (24 * 60 * 60))
+                # calc pday
+                added = get_ts_s()
+                result = session.execute(f'select created from tdd_sprint_video where aid = {aid}')
+                created = [r['created'] for r in result][0]
+                pday = math.floor((added - created) / (24 * 60 * 60))
 
-            # calc lday
-            # if no view incr, lday is 9999999
-            lday = math.floor((1000000 - end_view) / view_incr) if view_incr != 0 else 9999999
+                # calc lday
+                # if no view incr, lday is 9999999
+                lday = math.floor((1000000 - end_view) / view_incr) if view_incr != 0 else 9999999
 
-            session.execute(f'insert into tdd_sprint_daily_record (added, `date`, aid, `view`, viewincr, pday, lday) '
-                            f'values ({added}, "{date}", {aid}, {end_view}, {view_incr}, {pday}, {lday})')
+                session.execute(f'insert into tdd_sprint_daily_record (added, `date`, aid, `view`, viewincr, pday, lday) '
+                                f'values ({added}, "{date}", {aid}, {end_view}, {view_incr}, {pday}, {lday})')
+                session.commit()
+                logger.info(f'Add new daily record. '
+                            f'added: {added}, date: {date}, aid: {aid}, end_view: {end_view}, view_incr: {view_incr}, '
+                            f'pday: {pday}, lday: {lday}')
+
+                video_total += 1
+
+            # calc view incr incr
+            result = session.execute('select `viewincr` from tdd_sprint_daily '
+                                     'where viewincr is not NULL order by id desc limit 1')
+            last_view_incr = [r['viewincr'] for r in result][0]
+            view_incr_incr = view_incr_total - last_view_incr
+
+            # make str
+            newvids_str = ''
+            for aid in new_video_aids:
+                newvids_str += f'{aid};'
+            millvids_str = ''
+            for aid in million_video_aids:
+                millvids_str += f'{aid};'
+
+            session.execute(f'insert into tdd_sprint_daily '
+                            f'(added, `date`, correct, vidnum, newvids, millvids, viewincr, viewincrincr, comment) '
+                            f'values ({get_ts_s()}, "{date}", 1, {video_total}, "{newvids_str}", "{millvids_str}", '
+                            f'{view_incr_total}, {view_incr_incr}, "")')
             session.commit()
-            logger.info(f'Add new daily record. '
-                        f'added: {added}, date: {date}, aid: {aid}, end_view: {end_view}, view_incr: {view_incr}, '
-                        f'pday: {pday}, lday: {lday}')
+            logger.info(f'Add new daily summary. '
+                        f'added: {get_ts_s()}, date: {date}, video_total: {video_total}, '
+                        f'newvids_str: {newvids_str}, millvids_str: {millvids_str}, '
+                        f'view_incr_total: {view_incr_total}, view_incr_incr: {view_incr_incr}')
+        except Exception as e:
+            message = f'Exception occurred when updating member total stat! error: {e}'
+            logger.critical(message)
+            sc_send_critical(script_fullname, message, __file__, get_current_line_no())
+            session.rollback()
+            session.close()
+            exit(1)
 
-            video_total += 1
-
-        # calc view incr incr
-        result = session.execute('select `viewincr` from tdd_sprint_daily '
-                                 'where viewincr is not NULL order by id desc limit 1')
-        last_view_incr = [r['viewincr'] for r in result][0]
-        view_incr_incr = view_incr_total - last_view_incr
-
-        # make str
-        newvids_str = ''
-        for aid in new_video_aids:
-            newvids_str += f'{aid};'
-        millvids_str = ''
-        for aid in million_video_aids:
-            millvids_str += f'{aid};'
-
-        session.execute(f'insert into tdd_sprint_daily '
-                        f'(added, `date`, correct, vidnum, newvids, millvids, viewincr, viewincrincr, comment) '
-                        f'values ({get_ts_s()}, "{date}", 1, {video_total}, "{newvids_str}", "{millvids_str}", '
-                        f'{view_incr_total}, {view_incr_incr}, "")')
-        session.commit()
-        logger.info(f'Add new daily summary. '
-                    f'added: {get_ts_s()}, date: {date}, video_total: {video_total}, '
-                    f'newvids_str: {newvids_str}, millvids_str: {millvids_str}, '
-                    f'view_incr_total: {view_incr_total}, view_incr_incr: {view_incr_incr}')
-    except Exception as e:
-        message = f'Exception occurred when updating member total stat! error: {e}'
-        logger.critical(message)
-        sc_send_critical(script_fullname, message, __file__, get_current_line_no())
-        session.rollback()
         session.close()
-        exit(1)
 
-    session.close()
+        timer.stop()
 
-    timer.stop()
+        # run-record metrics (best-effort; a disabled recorder is a no-op).
+        # Only the numbers this script already computes -- no fabricated JobStat,
+        # and none of the message/aid-list text goes into the database.
+        recorder.add_metric('sprint-daily', 'start_videos', len(start_records_view), 'count')
+        recorder.add_metric('sprint-daily', 'end_videos', len(end_records_view), 'count')
+        recorder.add_metric('sprint-daily', 'daily_records_added', video_total, 'count')
+        recorder.add_metric('sprint-daily', 'new_videos', len(new_video_aids), 'count')
+        recorder.add_metric('sprint-daily', 'million_videos', len(million_video_aids), 'count')
+        recorder.add_metric('sprint-daily', 'view_incr_total', view_incr_total, 'views')
+        recorder.add_metric('sprint-daily', 'view_incr_incr', view_incr_incr, 'views')
 
-    # make summary
-    summary = \
-        '# add sprint daily done!\n\n' \
-        f'{timer.get_summary()}\n\n' \
-        f'date: {date}, video_total: {video_total}\n\n' \
-        f'newvids_str: {newvids_str}, millvids_str: {millvids_str}\n\n' \
-        f'view_incr_total: {view_incr_total}, view_incr_incr: {view_incr_incr}\n\n' \
-        f'by bunnyxt, {ts_s_to_str(get_ts_s())}'
+        # make summary
+        summary = \
+            '# add sprint daily done!\n\n' \
+            f'{timer.get_summary()}\n\n' \
+            f'date: {date}, video_total: {video_total}\n\n' \
+            f'newvids_str: {newvids_str}, millvids_str: {millvids_str}\n\n' \
+            f'view_incr_total: {view_incr_total}, view_incr_incr: {view_incr_incr}\n\n' \
+            f'by bunnyxt, {ts_s_to_str(get_ts_s())}'
 
-    logger.info('Finish add sprint daily!')
-    logger.warning(summary)
+        logger.info('Finish add sprint daily!')
+        logger.warning(summary)
 
-    # send sc
-    sc_send('Finish add sprint daily!', summary)
+        # send sc
+        sc_send('Finish add sprint daily!', summary)
 
 
 def main():

--- a/tests/test_remaining_script_run_records.py
+++ b/tests/test_remaining_script_run_records.py
@@ -1,0 +1,311 @@
+"""
+Per-entry-point verification that the two remaining production scripts that do
+*not* call ``sc_send_summary`` -- ``18_member-total-stat-update.py`` and
+``72_add-sprint-daily.py`` -- now open, populate and close a run record without
+changing their Timer / logging / ServerChan behaviour.
+
+Same approach as ``test_summary_script_run_records.py``: each script is imported
+by file path, its DB session / ServerChan calls are replaced with inert fakes or
+spies, and its top-level work function is driven once for a normal run and once
+for a failing run. The assertions are:
+
+* a ``run`` row is written, keyed by the canonical ``script_id_script_name``;
+* it ends ``succeeded`` on a normal run and ``failed`` when the body raises and
+  the script's own ``except`` calls ``exit(1)``;
+* only the plain counts each script already computes land in ``run_metric``
+  (no fabricated JobStat, no message text);
+* ``sc_send`` / ``sc_send_critical`` are still called exactly as before.
+
+These scripts import ``db`` (SQLAlchemy). Where that is absent the whole module
+skips, matching ``test_run_record.py``'s handling of a bare checkout.
+"""
+
+import importlib.util
+import logging
+import os
+import sys
+import tempfile
+import types
+import unittest
+from unittest import mock
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+from runrecord._sqlite import sqlite3  # noqa: E402
+
+
+def _install_stub_conf():
+    """
+    ``conf/conf.ini`` is a git-ignored secret, so on a fresh checkout
+    ``import db`` (which builds a SQLAlchemy engine at import time) fails.
+    Install an inert ``conf`` with dummy values -- every DB call is faked here,
+    so the engine URL never has to be valid.
+    """
+    if 'conf' in sys.modules and hasattr(sys.modules['conf'], 'get_db_args'):
+        try:
+            sys.modules['conf'].get_db_args()
+            return  # a real, populated conf is already importable
+        except Exception:
+            pass
+    stub = types.ModuleType('conf')
+    stub.CONFIG_PATH = ''
+    stub.CONFIG = None
+    stub.get_db_args = lambda: {
+        'user': 'stub', 'password': 'stub', 'host': '127.0.0.1',
+        'port': '3306', 'dbname': 'stub'}
+    stub.get_sckey = lambda: 'stub'
+    stub.__all__ = ['CONFIG_PATH', 'CONFIG', 'get_db_args', 'get_sckey']
+    sys.modules['conf'] = stub
+    sys.modules['conf.conf'] = stub
+
+
+try:
+    _install_stub_conf()
+    import db  # noqa: F401
+    import serverchan  # noqa: F401
+    _DEPS = True
+except Exception as _e:  # pragma: no cover - depends on the environment
+    _DEPS = False
+    _DEPS_ERR = repr(_e)
+
+
+def _load(filename):
+    """Import a hyphenated top-level script by path under a safe module name."""
+    path = os.path.join(ROOT, filename)
+    name = 'scriptmod_' + filename.replace('-', '_').replace('.py', '')
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _db(path, query, params=()):
+    conn = sqlite3.connect(path)
+    try:
+        return conn.execute(query, params).fetchall()
+    finally:
+        conn.close()
+
+
+class _RunRecordTestBase(unittest.TestCase):
+    def setUp(self):
+        self.db_path = os.path.join(tempfile.mkdtemp(), 'run-records.sqlite3')
+        os.environ['TDD_RUN_RECORD_DB'] = self.db_path
+        self.addCleanup(os.environ.pop, 'TDD_RUN_RECORD_DB', None)
+        logging.disable(logging.CRITICAL)
+        self.addCleanup(logging.disable, logging.NOTSET)
+
+    def _runs(self):
+        return _db(self.db_path,
+                   'SELECT run_id, script_name, status, finished_at FROM run '
+                   'ORDER BY started_at')
+
+    def _metrics(self, run_id):
+        out = {}
+        for scope, name, value, unit in _db(
+                self.db_path,
+                'SELECT scope, name, value, unit FROM run_metric WHERE run_id = ?',
+                (run_id,)):
+            out.setdefault(scope, {})[name] = (value, unit)
+        return out
+
+
+# --------------------------------------------------------------------- 18_ ---
+
+class _MemberStatSession:
+    """Fake SQLAlchemy session for 18_: execute() returns preset rows."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.added = []
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+
+    def execute(self, *a, **kw):
+        return list(self._rows)
+
+    def add(self, obj):
+        self.added.append(obj)
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+@unittest.skipUnless(_DEPS, 'db/serverchan deps not importable in this environment')
+class MemberTotalStatUpdateRunRecordTest(_RunRecordTestBase):
+    def test_normal_run_records_succeeded_with_counts(self):
+        m = _load('18_member-total-stat-update.py')
+        # [aid, v_mid, view, danmaku, reply, favorite, coin, share, like, s_mid]
+        rows = [
+            [1, 100, 10, 1, 1, 1, 1, 1, 1, None],
+            [2, 100, 20, 2, 2, 2, 2, 2, 2, None],
+            [3, 200, 30, 3, 3, 3, 3, 3, 3, None],
+        ]
+        session = _MemberStatSession(rows)
+
+        with mock.patch.object(m, 'Session', lambda: session), \
+             mock.patch.object(m, 'sc_send_critical') as sc_crit:
+            m.member_total_stat_update()
+
+        (run_id, script_name, status, finished_at), = self._runs()
+        self.assertEqual(script_name, '18_member-total-stat-update')
+        self.assertEqual(status, 'succeeded')
+        self.assertTrue(finished_at)
+        sc_crit.assert_not_called()
+
+        metrics = self._metrics(run_id)['member-total-stat']
+        self.assertEqual(metrics['result_rows'], (3.0, 'count'))
+        self.assertEqual(metrics['member_count'], (2.0, 'count'))
+        self.assertEqual(metrics['records_added'], (2.0, 'count'))
+        # every recorded name is a plain count -- nothing error-like fabricated
+        self.assertEqual(set(metrics), {'result_rows', 'member_count', 'records_added'})
+        # completeness signal: one ORM row per distinct member was staged
+        self.assertEqual(len(session.added), 2)
+
+    def test_no_data_still_records_succeeded(self):
+        m = _load('18_member-total-stat-update.py')
+        session = _MemberStatSession([])
+
+        with mock.patch.object(m, 'Session', lambda: session), \
+             mock.patch.object(m, 'sc_send_critical'):
+            m.member_total_stat_update()
+
+        (run_id, _, status, _), = self._runs()
+        self.assertEqual(status, 'succeeded')
+        metrics = self._metrics(run_id)['member-total-stat']
+        self.assertEqual(metrics['result_rows'], (0.0, 'count'))
+        self.assertEqual(metrics['records_added'], (0.0, 'count'))
+
+    def test_failure_is_recorded_and_critical_still_sent(self):
+        m = _load('18_member-total-stat-update.py')
+
+        class _Boom(_MemberStatSession):
+            def execute(self, *a, **kw):
+                raise RuntimeError('db lost connection')
+
+        session = _Boom([])
+        with mock.patch.object(m, 'Session', lambda: session), \
+             mock.patch.object(m, 'sc_send_critical') as sc_crit:
+            with self.assertRaises(SystemExit) as ctx:
+                m.member_total_stat_update()
+
+        self.assertEqual(ctx.exception.code, 1)
+        (_, _, status, finished_at), = self._runs()
+        self.assertEqual(status, 'failed')
+        self.assertTrue(finished_at)
+        # existing critical/notification path is unchanged
+        sc_crit.assert_called_once()
+        self.assertEqual(session.rollbacks, 1)
+
+
+# --------------------------------------------------------------------- 72_ ---
+
+class _SprintSession:
+    """Fake SQLAlchemy session for 72_: execute() answers by SQL substring."""
+
+    def __init__(self, responder):
+        self._responder = responder
+        self.commits = 0
+        self.rollbacks = 0
+        self.closed = False
+
+    def execute(self, sql, *a, **kw):
+        return self._responder(str(sql).lower())
+
+    def commit(self):
+        self.commits += 1
+
+    def rollback(self):
+        self.rollbacks += 1
+
+    def close(self):
+        self.closed = True
+
+
+def _sprint_responder(now_s):
+    def responder(sql):
+        if 'order by added limit 1' in sql:            # per-new-video start view
+            return [{'view': 100}]
+        if 'from tdd_sprint_video_record' in sql:      # start + end range queries
+            return [{'aid': 111, 'view': 900000}, {'aid': 222, 'view': 950000}]
+        if 'from tdd_sprint_video where aid' in sql:   # created lookup
+            return [{'created': now_s - 100 * 24 * 3600}]
+        if 'insert into tdd_sprint_daily_record' in sql:
+            return []
+        if 'from tdd_sprint_daily' in sql:             # last viewincr
+            return [{'viewincr': 1000}]
+        if 'insert into tdd_sprint_daily' in sql:
+            return []
+        return []
+    return responder
+
+
+@unittest.skipUnless(_DEPS, 'db/serverchan deps not importable in this environment')
+class AddSprintDailyRunRecordTest(_RunRecordTestBase):
+    def test_normal_run_records_succeeded_with_metrics(self):
+        m = _load('72_add-sprint-daily.py')
+        session = _SprintSession(_sprint_responder(m.get_ts_s()))
+
+        with mock.patch.object(m, 'Session', lambda: session), \
+             mock.patch.object(m, 'sc_send') as sc, \
+             mock.patch.object(m, 'sc_send_critical') as sc_crit:
+            m.add_sprint_daily()
+
+        (run_id, script_name, status, finished_at), = self._runs()
+        self.assertEqual(script_name, '72_add-sprint-daily')
+        self.assertEqual(status, 'succeeded')
+        self.assertTrue(finished_at)
+        sc_crit.assert_not_called()
+
+        metrics = self._metrics(run_id)['sprint-daily']
+        self.assertEqual(metrics['start_videos'], (2.0, 'count'))
+        self.assertEqual(metrics['end_videos'], (2.0, 'count'))
+        self.assertEqual(metrics['daily_records_added'], (2.0, 'count'))
+        self.assertEqual(metrics['new_videos'], (0.0, 'count'))
+        self.assertEqual(metrics['million_videos'], (0.0, 'count'))
+        self.assertEqual(metrics['view_incr_total'], (0.0, 'views'))
+        self.assertEqual(metrics['view_incr_incr'], (-1000.0, 'views'))
+
+        # unchanged behaviour: still a plain sc_send with the same title, and the
+        # summary body (which carries an aid list) never reaches the database
+        sc.assert_called_once()
+        self.assertEqual(sc.call_args.args[0], 'Finish add sprint daily!')
+        # only numeric metrics are stored -- no aid lists / summary text
+        for _run_id, _scope, name, value in _db(
+                self.db_path, 'SELECT run_id, scope, name, value FROM run_metric'):
+            self.assertNotIn(';', name)
+            self.assertIsInstance(value, float)
+
+    def test_failure_is_recorded_and_critical_still_sent(self):
+        m = _load('72_add-sprint-daily.py')
+
+        def _boom(_sql):
+            raise RuntimeError('db lost connection')
+
+        session = _SprintSession(_boom)
+        with mock.patch.object(m, 'Session', lambda: session), \
+             mock.patch.object(m, 'sc_send') as sc, \
+             mock.patch.object(m, 'sc_send_critical') as sc_crit:
+            with self.assertRaises(SystemExit) as ctx:
+                m.add_sprint_daily()
+
+        self.assertEqual(ctx.exception.code, 1)
+        (_, _, status, finished_at), = self._runs()
+        self.assertEqual(status, 'failed')
+        self.assertTrue(finished_at)
+        sc_crit.assert_called_once()
+        sc.assert_not_called()
+        self.assertEqual(session.rollbacks, 1)
+
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)


### PR DESCRIPTION
## What

Wire the `runrecord.track` context manager (added in #54) into the last two
scheduled entry points that had no run record:

- `18_member-total-stat-update.py`
- `72_add-sprint-daily.py`

Neither calls `sc_send_summary` and neither builds a `JobStat`, so only the
plain counts each script already computes are persisted as `run_metric` rows —
no fabricated job statistics.

## Behavior

Each run now persists one row:

- `succeeded` on a clean exit
- `failed` when the body raises and the script's own `except` calls `exit(1)`
- a row left `running` — surfaced as `stale` by `python -m runrecord` — when the
  process is killed before it finishes

These scripts previously had no way to distinguish "did not finish" from
"failed".

### Metrics

| Script | scope | metrics |
|---|---|---|
| `18_` | `member-total-stat` | `result_rows`, `member_count`, `records_added` (unit `count`) |
| `72_` | `sprint-daily` | `start_videos`, `end_videos`, `daily_records_added`, `new_videos`, `million_videos` (unit `count`); `view_incr_total`, `view_incr_incr` (unit `views`) |

## Unchanged

- Every `Timer` / logging line is preserved.
- `72_`'s `sc_send('Finish add sprint daily!', summary)` call is unchanged.
- Both scripts' `logger.critical` + `sc_send_critical` + `session.rollback()` +
  `exit(1)` failure path is preserved, now inside the tracked block so the row
  is closed as `failed` before the process exits.
- `track` is best-effort: a disabled recorder turns every call into a no-op and
  the script runs exactly as before.
- Only integers reach the database. The `72_` summary string (which contains an
  aid list) and all ServerChan message bodies stay out of it; `run_log` stores
  only the `log/NN_{INFO,WARNING}.log` paths.

The diff is an indentation-only wrap plus the import and the metric calls
(`git diff -w` is ~21 added lines).

## Tests

`tests/test_remaining_script_run_records.py` loads each script by path, fakes
its DB session / ServerChan calls, and drives the work function once for a
normal run and once for a failing run. It asserts the `run` row, terminal
status, metric scopes/values/units, and that `sc_send` / `sc_send_critical` are
still called exactly as before. The module skips where SQLAlchemy is absent,
matching the existing run-record tests.

```
python -m unittest discover -s tests
Ran 96 tests — OK   (14 skipped without SQLAlchemy)
```

Verified end to end with the read-only `python -m runrecord` CLI against a
scratch database: `list`, `list --status failed`, `list --status stale`, and
`show --latest --script …` for both scripts all render the expected rows,
metrics and derived states.