### PR TITLE
feat: batched trimmed video_view worker with per-item result contract

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,5 +37,8 @@ system where it lives.
 - Committed tests live in `tests/`. Run them from the repo root:
   `venv-3.11/bin/python -m unittest discover -s tests` (stdlib `unittest`, no
   extra deps; a plain `python` works too where `venv-3.11` isn't set up).
+- Worker (`.mjs`) tests are Node-based and live in `tests/` too. Run them from
+  the repo root with `node --test tests/` (built-in `node:test`, no deps,
+  Node ≥ 18; upstream traffic is mocked, no network needed).
 - Root-level `test-*.py` / `test-*.ipynb` / `test.py` are throwaway scratch and
   are git-ignored — don't put committed tests there, and don't rely on them.

--- a/service/workers/video_view/aws_lambda_batch.mjs
+++ b/service/workers/video_view/aws_lambda_batch.mjs
@@ -1,0 +1,197 @@
+// Batched trimmed video_view worker: fetches N video views from bilibili
+// CONCURRENTLY inside one invocation and returns per-item results. Companion
+// to aws_lambda.mjs (the single-aid trimmed worker), deployed as a SEPARATE
+// function so the single-aid path is never touched by this code.
+//
+// ============================== CONTRACT (v1) ==============================
+//
+// Request:
+//   GET /?aids=<token>[,<token>...]
+//
+//   - `aids` is a comma-separated list. Tokens are forwarded to the upstream
+//     `aid` query parameter AS-IS: no numeric validation, no trimming, no
+//     de-duplication. The upstream API is the authority on token validity,
+//     exactly like the single-aid worker (transparent-proxy philosophy).
+//     Duplicate tokens are each fetched independently and echoed 1:1.
+//     De-duplication is the CALLER's responsibility.
+//   - Missing `aids`, an empty `aids`, or more than MAX_AIDS tokens is a
+//     caller bug, answered loudly with HTTP 400 (shape below), never with a
+//     partial result.
+//
+// Response (HTTP 200 whenever the request shape is valid, even if every
+// single item failed -- failure is reported per item):
+//
+//   {
+//     "v": 1,                 // batch protocol version; callers MUST verify
+//     "requested": <int>,     // number of tokens received
+//     "results": [ <item>, ... ]   // same length and SAME ORDER as `aids`
+//   }
+//
+// Every item echoes its input token as `aid` (the raw string, exactly as it
+// appeared between the commas) and carries `ms` (wall-clock milliseconds this
+// item took, for calibration and debugging). Item variants, by `kind`:
+//
+//   { "aid", "ms", "kind": "json", "status": <upstream HTTP status>,
+//     "body": <object> }
+//       Upstream body parsed as JSON. When it has code === 0 and a
+//       data.stat object, `body` is the TRIMMED envelope -- identical
+//       field-for-field to what the single-aid worker returns (STAT_KEYS
+//       with `?? null` backfill). Anything else (deleted/hidden videos,
+//       -404, -400, ...) is the upstream JSON passed through UNMODIFIED,
+//       so the caller's per-item error handling matches the single path.
+//
+//   { "aid", "ms", "kind": "non_json", "status": <upstream HTTP status>,
+//     "body_snippet": <string> }
+//       Upstream body was not JSON (e.g. an HTML error page). First
+//       BODY_SNIPPET_MAX chars only.
+//
+//   { "aid", "ms", "kind": "item_timeout", "timeout_ms": <int> }
+//       This item's fetch exceeded PER_ITEM_TIMEOUT_MS and was aborted.
+//       Other items are unaffected.
+//
+//   { "aid", "ms", "kind": "fetch_error", "detail": <string> }
+//       The fetch itself failed (DNS, connect, TLS, ...). Other items are
+//       unaffected.
+//
+// Errors that are NOT per-item:
+//   HTTP 400  { "v": 1, "error": <string> }   -- malformed request (see above)
+//   HTTP 500  { "v": 1, "error": <string> }   -- unexpected handler failure
+//   Plus whatever the platform itself produces (function timeout, crash).
+//   Callers treat any non-200 / unparsable top level as a whole-batch
+//   failure and own the retry policy; this worker never retries upstream.
+//
+// Execution model: all items are fetched concurrently (duration of the
+// invocation ~= max of item durations, plus parse overhead). The upstream
+// User-Agent is whatever the runtime's fetch sends, matching the current
+// single-aid worker's behavior on purpose -- changing the upstream request
+// fingerprint is out of scope for the batching change.
+//
+// Tunables (initial hypotheses pending load-test calibration -- override via
+// Lambda environment variables without a code change):
+//   PER_ITEM_TIMEOUT_MS  default 4500   derived from the single-fetch p99.9
+//                                       (~3.3s) plus headroom; the function
+//                                       timeout must stay ABOVE this value
+//   MAX_AIDS             default 50     upper bound on tokens per request
+// ===========================================================================
+
+const baseUrl = new URL("http://api.bilibili.com/x/web-interface/view");
+
+// stat values are passed through untouched (no numeric coercion: view can be
+// the string "--" for hidden counts); vt/vv are missing on older videos.
+// MUST stay identical to the single-aid worker's list (aws_lambda.mjs).
+const STAT_KEYS = [
+  "aid", "view", "danmaku", "reply", "favorite", "coin", "share",
+  "now_rank", "his_rank", "like", "dislike", "vt", "vv",
+];
+
+const DEFAULT_PER_ITEM_TIMEOUT_MS = 4500;
+const DEFAULT_MAX_AIDS = 50;
+const BODY_SNIPPET_MAX = 2048;
+
+function intEnv(name, fallback) {
+  const parsed = parseInt(process.env[name], 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : fallback;
+}
+
+// build the item's `body`: trimmed envelope for a healthy view response,
+// upstream JSON unmodified for everything else -- same rules, same key
+// order as the single-aid worker
+function trimOrPassthrough(parsed) {
+  if (
+    parsed.code !== 0 ||
+    typeof parsed.data !== "object" || parsed.data === null ||
+    typeof parsed.data.stat !== "object" || parsed.data.stat === null
+  ) {
+    return parsed;
+  }
+  const stat = {};
+  for (const key of STAT_KEYS) {
+    stat[key] = parsed.data.stat[key] ?? null;
+  }
+  return {
+    code: parsed.code,
+    message: parsed.message,
+    ttl: parsed.ttl,
+    data: {
+      bvid: parsed.data.bvid,
+      aid: parsed.data.aid,
+      stat,
+    },
+  };
+}
+
+async function fetchOne(token, timeoutMs) {
+  const started = Date.now();
+  const item = { aid: token, ms: 0 };
+  try {
+    const url = new URL(baseUrl.href);
+    url.searchParams.set("aid", token);
+    const response = await fetch(url.href, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const text = await response.text();
+    item.status = response.status;
+    try {
+      item.body = trimOrPassthrough(JSON.parse(text));
+      item.kind = "json";
+    } catch {
+      item.kind = "non_json";
+      item.body_snippet = text.slice(0, BODY_SNIPPET_MAX);
+    }
+  } catch (error) {
+    if (error && (error.name === "TimeoutError" || error.name === "AbortError")) {
+      item.kind = "item_timeout";
+      item.timeout_ms = timeoutMs;
+    } else {
+      item.kind = "fetch_error";
+      item.detail = (error && error.message) || String(error);
+    }
+  }
+  item.ms = Date.now() - started;
+  return item;
+}
+
+function badRequest(message) {
+  return {
+    statusCode: 400,
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ v: 1, error: message }),
+  };
+}
+
+export const handler = async (event) => {
+  try {
+    const timeoutMs = intEnv("PER_ITEM_TIMEOUT_MS", DEFAULT_PER_ITEM_TIMEOUT_MS);
+    const maxAids = intEnv("MAX_AIDS", DEFAULT_MAX_AIDS);
+
+    const aids = (event.queryStringParameters || {}).aids;
+    if (typeof aids !== "string" || aids.length === 0) {
+      return badRequest("missing aids parameter");
+    }
+    const tokens = aids.split(",");
+    if (tokens.length > maxAids) {
+      return badRequest(`too many aids: ${tokens.length} > ${maxAids}`);
+    }
+
+    // all items in flight at once; fetchOne never rejects, so Promise.all
+    // preserves order and cannot fail as a whole
+    const results = await Promise.all(
+      tokens.map((token) => fetchOne(token, timeoutMs)));
+
+    return {
+      statusCode: 200,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ v: 1, requested: tokens.length, results }),
+    };
+  } catch (error) {
+    console.error("Unexpected batch handler failure:", error);
+    return {
+      statusCode: 500,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        v: 1,
+        error: (error && error.message) || "Internal Server Error",
+      }),
+    };
+  }
+};

--- a/tests/aws_lambda_batch.test.mjs
+++ b/tests/aws_lambda_batch.test.mjs
@@ -1,0 +1,259 @@
+// Contract tests for the batched trimmed video_view worker
+// (service/workers/video_view/aws_lambda_batch.mjs).
+//
+// Run from the repo root:  node --test tests/
+//
+// All upstream traffic is mocked by replacing globalThis.fetch -- no real
+// network request is ever made. Each test rebuilds the mock, so tests are
+// order-independent.
+
+import { test, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { handler } from "../service/workers/video_view/aws_lambda_batch.mjs";
+
+const realFetch = globalThis.fetch;
+
+// a healthy upstream view payload for the given aid, with the season/staff
+// bloat the trimmer must strip
+function viewPayload(aid) {
+  return {
+    code: 0,
+    message: "0",
+    ttl: 1,
+    data: {
+      bvid: `BV_mock_${aid}`,
+      aid: Number(aid),
+      videos: 1,
+      tid: 30,
+      title: "mock title",
+      staff: [{ mid: 1, name: "x" }],
+      stat: {
+        aid: Number(aid),
+        view: 100,
+        danmaku: 1,
+        reply: 2,
+        favorite: 3,
+        coin: 4,
+        share: 5,
+        now_rank: 0,
+        his_rank: 13,
+        like: 6,
+        dislike: 0,
+        // vt / vv intentionally absent -> trimmer must backfill null
+      },
+    },
+  };
+}
+
+function jsonResponse(obj, status = 200) {
+  return {
+    status,
+    text: async () => JSON.stringify(obj),
+  };
+}
+
+function mockFetch(perAid) {
+  // perAid: async (aidToken, init) -> Response-like; records call order
+  const calls = [];
+  globalThis.fetch = async (href, init) => {
+    const aid = new URL(href).searchParams.get("aid");
+    calls.push(aid);
+    return perAid(aid, init);
+  };
+  return calls;
+}
+
+async function invoke(aids) {
+  const event =
+    aids === undefined
+      ? { queryStringParameters: {} }
+      : { queryStringParameters: { aids } };
+  // AbortSignal.timeout timers are unref'ed; with fetch mocked there is no
+  // socket keeping the event loop alive, so hold it open until the handler
+  // settles (a real runtime never needs this)
+  const keepAlive = setInterval(() => {}, 100);
+  try {
+    const res = await handler(event);
+    return { res, body: JSON.parse(res.body) };
+  } finally {
+    clearInterval(keepAlive);
+  }
+}
+
+beforeEach(() => {
+  delete process.env.PER_ITEM_TIMEOUT_MS;
+  delete process.env.MAX_AIDS;
+});
+
+afterEach(() => {
+  globalThis.fetch = realFetch;
+  delete process.env.PER_ITEM_TIMEOUT_MS;
+  delete process.env.MAX_AIDS;
+});
+
+test("normal batch: trimmed items, input order, token echo, v/requested", async () => {
+  mockFetch(async (aid) => jsonResponse(viewPayload(aid)));
+  const { res, body } = await invoke("170001,42,7");
+
+  assert.equal(res.statusCode, 200);
+  assert.equal(body.v, 1);
+  assert.equal(body.requested, 3);
+  assert.equal(body.results.length, 3);
+  assert.deepEqual(body.results.map((r) => r.aid), ["170001", "42", "7"]);
+
+  for (const item of body.results) {
+    assert.equal(item.kind, "json");
+    assert.equal(item.status, 200);
+    assert.equal(typeof item.ms, "number");
+    // trimmed envelope: exactly code/message/ttl/data, data exactly
+    // bvid/aid/stat -- the 200KB-class keys (videos, title, staff...) gone
+    assert.deepEqual(Object.keys(item.body), ["code", "message", "ttl", "data"]);
+    assert.deepEqual(Object.keys(item.body.data), ["bvid", "aid", "stat"]);
+    assert.equal(item.body.data.bvid, `BV_mock_${item.aid}`);
+    // absent vt/vv backfilled to null, same as the single-aid worker
+    assert.equal(item.body.data.stat.vt, null);
+    assert.equal(item.body.data.stat.vv, null);
+    assert.equal(item.body.data.stat.view, 100);
+  }
+});
+
+test("upstream error code passes through unmodified", async () => {
+  const notFound = { code: -404, message: "啥都木有", ttl: 1 };
+  mockFetch(async (aid) =>
+    aid === "2" ? jsonResponse(notFound) : jsonResponse(viewPayload(aid)));
+  const { body } = await invoke("1,2");
+
+  assert.equal(body.results[0].kind, "json");
+  assert.equal(body.results[0].body.code, 0);
+  assert.equal(body.results[1].kind, "json");
+  assert.deepEqual(body.results[1].body, notFound); // byte-for-byte passthrough
+});
+
+test("non-JSON upstream becomes non_json with truncated snippet", async () => {
+  const html = "<!DOCTYPE html>" + "x".repeat(5000);
+  mockFetch(async () => ({ status: 404, text: async () => html }));
+  const { body } = await invoke("1");
+
+  const item = body.results[0];
+  assert.equal(item.kind, "non_json");
+  assert.equal(item.status, 404);
+  assert.equal(item.body_snippet.length, 2048);
+  assert.ok(item.body_snippet.startsWith("<!DOCTYPE html>"));
+  assert.equal(item.body, undefined);
+});
+
+test("per-item timeout aborts only that item", async () => {
+  process.env.PER_ITEM_TIMEOUT_MS = "40";
+  mockFetch(async (aid, init) => {
+    if (aid === "slow") {
+      // never resolves; rejects with the abort reason when the signal fires,
+      // which is how undici's fetch surfaces AbortSignal.timeout
+      return new Promise((_, reject) => {
+        init.signal.addEventListener("abort", () => reject(init.signal.reason));
+      });
+    }
+    return jsonResponse(viewPayload(aid));
+  });
+  const { body } = await invoke("1,slow,3");
+
+  assert.equal(body.results[0].kind, "json");
+  assert.equal(body.results[2].kind, "json");
+  const slow = body.results[1];
+  assert.equal(slow.aid, "slow");
+  assert.equal(slow.kind, "item_timeout");
+  assert.equal(slow.timeout_ms, 40);
+  assert.ok(slow.ms >= 30, `ms should reflect the wait, got ${slow.ms}`);
+});
+
+test("duplicate aids are fetched independently and echoed 1:1", async () => {
+  const calls = mockFetch(async (aid) => jsonResponse(viewPayload(aid)));
+  const { body } = await invoke("9,9,9");
+
+  assert.equal(body.requested, 3);
+  assert.deepEqual(calls, ["9", "9", "9"]); // one upstream fetch per token
+  assert.deepEqual(body.results.map((r) => r.aid), ["9", "9", "9"]);
+});
+
+test("invalid tokens are forwarded as-is; upstream verdict passes through", async () => {
+  const badReq = { code: -400, message: "请求错误", ttl: 1 };
+  const calls = mockFetch(async (aid) =>
+    /^\d+$/.test(aid) ? jsonResponse(viewPayload(aid)) : jsonResponse(badReq));
+  const { body } = await invoke("abc,, 5,6");
+
+  // every token forwarded untouched, including empty and space-prefixed
+  assert.deepEqual(calls, ["abc", "", " 5", "6"]);
+  assert.deepEqual(body.results.map((r) => r.aid), ["abc", "", " 5", "6"]);
+  assert.deepEqual(body.results[0].body, badReq);
+  assert.deepEqual(body.results[1].body, badReq);
+  assert.deepEqual(body.results[2].body, badReq);
+  assert.equal(body.results[3].body.code, 0);
+});
+
+test("missing and empty aids answer 400, no upstream fetch", async () => {
+  const calls = mockFetch(async () => {
+    throw new Error("must not fetch");
+  });
+  for (const args of [undefined, ""]) {
+    const { res, body } = await invoke(args);
+    assert.equal(res.statusCode, 400);
+    assert.equal(body.v, 1);
+    assert.match(body.error, /aids/);
+  }
+  assert.equal(calls.length, 0);
+});
+
+test("more than MAX_AIDS tokens answers 400, no upstream fetch", async () => {
+  process.env.MAX_AIDS = "3";
+  const calls = mockFetch(async () => {
+    throw new Error("must not fetch");
+  });
+  const { res, body } = await invoke("1,2,3,4");
+
+  assert.equal(res.statusCode, 400);
+  assert.match(body.error, /too many aids: 4 > 3/);
+  assert.equal(calls.length, 0);
+});
+
+test("network failure becomes fetch_error for that item only", async () => {
+  mockFetch(async (aid) => {
+    if (aid === "down") throw new TypeError("fetch failed: ECONNRESET");
+    return jsonResponse(viewPayload(aid));
+  });
+  const { body } = await invoke("1,down");
+
+  assert.equal(body.results[0].kind, "json");
+  const down = body.results[1];
+  assert.equal(down.kind, "fetch_error");
+  assert.match(down.detail, /ECONNRESET/);
+});
+
+test("mixed batch keeps order across all result kinds", async () => {
+  process.env.PER_ITEM_TIMEOUT_MS = "40";
+  mockFetch(async (aid, init) => {
+    switch (aid) {
+      case "ok":
+        return jsonResponse(viewPayload("1"));
+      case "gone":
+        return jsonResponse({ code: -404, message: "nope", ttl: 1 });
+      case "html":
+        return { status: 502, text: async () => "<html>bad gateway</html>" };
+      case "slow":
+        return new Promise((_, reject) => {
+          init.signal.addEventListener("abort", () => reject(init.signal.reason));
+        });
+      default:
+        throw new Error("boom");
+    }
+  });
+  const { body } = await invoke("ok,gone,html,slow,err");
+
+  assert.deepEqual(
+    body.results.map((r) => [r.aid, r.kind]),
+    [
+      ["ok", "json"],
+      ["gone", "json"],
+      ["html", "non_json"],
+      ["slow", "item_timeout"],
+      ["err", "fetch_error"],
+    ]);
+});


### PR DESCRIPTION
## What

A batch variant of the trimmed `video_view` worker: `service/workers/video_view/aws_lambda_batch.mjs`. It fetches N aids **concurrently inside one invocation** and reports success/failure **per item**, so a single bad aid can never fail — or force a retry of — a whole batch.

**Repo-only.** Nothing is deployed by this PR: it is intended to run as a *separate* function later, and the existing single-aid worker (`aws_lambda.mjs`) and all client code are untouched (`git diff` shows only the new worker, its tests, and one AGENTS.md note).

## Contract (v1) — full spec in the file header

- `GET /?aids=a,b,c` → `200 {v:1, requested, results[]}`; results are in **input order**, each item echoes its **raw token** and carries per-item `ms`.
- Item kinds:
  - `json` — upstream JSON; trimmed envelope when `code==0` (identical field-for-field to the single worker, incl. `?? null` backfill of `vt`/`vv`), otherwise the upstream body **passed through unmodified** so per-item error handling matches the single path;
  - `non_json` — 2KB snippet + upstream status;
  - `item_timeout` — that item aborted, others unaffected;
  - `fetch_error` — connect/DNS/TLS failure, others unaffected.
- Malformed requests (missing/empty `aids`, more than `MAX_AIDS` tokens) answer **400 loudly**, never a partial result. Otherwise tokens are forwarded **as-is** — no numeric validation, no trimming, no dedup — keeping the upstream API the authority (same transparent-proxy philosophy as the existing workers; dedup is the caller's job).
- Only platform-level failures (crash, function timeout) fail a whole batch; the worker never retries upstream.

## Deliberate choices

- **Upstream User-Agent unchanged** (runtime default, matching the current single worker) — changing the upstream request fingerprint is out of scope for the batching change.
- **Tunables are initial hypotheses pending load-test calibration**, not final design: `PER_ITEM_TIMEOUT_MS=4500` (single-fetch p99.9 ≈ 3.3 s + headroom) and `MAX_AIDS=50`, both overridable via environment variables so calibration needs no code change. The function timeout must stay above the per-item timeout.

## Tests

`node --test tests/` — 10 contract tests over a mocked `fetch` (zero network): normal batch/trim shape/order/echo, error-code passthrough, non-JSON snippet + truncation, per-item timeout isolation, duplicates fetched 1:1, invalid tokens forwarded, 400 on missing/empty/over-limit with no upstream call, fetch_error isolation, mixed-kind ordering.

```
# tests 10 / pass 10 / fail 0
```

Existing Python suite unaffected: `python3 -m unittest discover -s tests` → 120 tests OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)