### PR TITLE
feat: opt-in batched client path for trimmed video_view records

### DIFF
--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -13,8 +13,10 @@ from serverchan import sc_send_critical
 from collections import namedtuple, defaultdict, Counter
 from typing import Optional
 from core import RecordNew
+from conf import get_video_view_trimmed_batch_conf
 from service import Service
-from job import FetchVideoRecordJob, BatchInsertVideoRecordJob, UpdateVideoJob, Job, JobPool
+from job import FetchVideoRecordJob, BatchInsertVideoRecordJob, UpdateVideoJob, Job, JobPool, \
+    VideoViewTrimmedBatchConfig, VideoViewTrimmedBatchState
 from runrecord import RunRecorder
 from timer import Timer
 import logging
@@ -103,6 +105,24 @@ def fetch_and_batch_insert_records(
     # job_num so bumping workers can't silently break keep-alive.
     service = Service(mode='worker', pool_maxsize=job_num + 32)
 
+    # trimmed video_view batch path, conf-driven and OFF by default (missing
+    # section == batch_size 0 == single-aid path only, byte-identical to the
+    # pre-batch behavior). One shared state = one run-wide kill-switch.
+    batch_size, batch_fraction = get_video_view_trimmed_batch_conf()
+    batch_config = None
+    batch_state = None
+    fetch_ensure_conditions = ['success', 'code_error', 'other_exception',
+                               'record_dropped_queue_full', 'duration_limit_reached']
+    if batch_size > 0 and batch_fraction > 0:
+        batch_config = VideoViewTrimmedBatchConfig(
+            batch_size=batch_size, batch_fraction=batch_fraction)
+        batch_state = VideoViewTrimmedBatchState()
+        log.info(f'video_view_trimmed batch path ENABLED: batch_size={batch_size}, '
+                 f'batch_fraction={batch_fraction}, max_attempts={batch_config.max_attempts}')
+        fetch_ensure_conditions += ['batch_request', 'batch_whole_failure',
+                                    'batch_misalignment', 'batch_item_retry',
+                                    'batch_fallback_single', 'batch_duplicate_single_path']
+
     # put aid into queue
     aid_queue: Queue[int] = Queue()
     for aid in need_insert_aid_list:
@@ -127,12 +147,12 @@ def fetch_and_batch_insert_records(
     fetch_pool = JobPool(
         [FetchVideoRecordJob(f'job_{i}', aid_queue, fetched_record_queue, service,
                              code_error_aid_queue=code_error_aid_queue,
-                             duration_limit_s=duration_limit_s)
+                             duration_limit_s=duration_limit_s,
+                             batch_config=batch_config, batch_state=batch_state)
          for i in range(job_num)],
         progress_total=len(need_insert_aid_list),
         progress_label=fetch_label,
-        ensure_conditions=['success', 'code_error', 'other_exception',
-                           'record_dropped_queue_full', 'duration_limit_reached'],
+        ensure_conditions=fetch_ensure_conditions,
         logger_name=logger_name)
     writer_pool = JobPool(
         [BatchInsertVideoRecordJob('writer_0', fetched_record_queue, record_queue,

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -16,7 +16,7 @@ from core import RecordNew
 from conf import get_video_view_trimmed_batch_conf
 from service import Service
 from job import FetchVideoRecordJob, BatchInsertVideoRecordJob, UpdateVideoJob, Job, JobPool, \
-    VideoViewTrimmedBatchConfig, VideoViewTrimmedBatchState
+    VideoViewTrimmedBatchConfig, VideoViewTrimmedBatchController
 from runrecord import RunRecorder
 from timer import Timer
 import logging
@@ -107,21 +107,27 @@ def fetch_and_batch_insert_records(
 
     # trimmed video_view batch path, conf-driven and OFF by default (missing
     # section == batch_size 0 == single-aid path only, byte-identical to the
-    # pre-batch behavior). One shared state = one run-wide kill-switch.
-    batch_size, batch_fraction = get_video_view_trimmed_batch_conf()
-    batch_config = None
-    batch_state = None
+    # pre-batch behavior). ONE controller instance is shared by the whole
+    # fetch pool: it owns the run-wide circuit breaker and the pool-wide cap
+    # on simultaneous batch invocations.
+    batch_size, batch_fraction, max_concurrent_batches = get_video_view_trimmed_batch_conf()
+    batch_controller = None
     fetch_ensure_conditions = ['success', 'code_error', 'other_exception',
                                'record_dropped_queue_full', 'duration_limit_reached']
-    if batch_size > 0 and batch_fraction > 0:
-        batch_config = VideoViewTrimmedBatchConfig(
-            batch_size=batch_size, batch_fraction=batch_fraction)
-        batch_state = VideoViewTrimmedBatchState()
+    if batch_size > 0 and batch_fraction > 0 and max_concurrent_batches > 0:
+        batch_controller = VideoViewTrimmedBatchController(VideoViewTrimmedBatchConfig(
+            batch_size=batch_size, batch_fraction=batch_fraction,
+            max_concurrent_batches=max_concurrent_batches))
         log.info(f'video_view_trimmed batch path ENABLED: batch_size={batch_size}, '
-                 f'batch_fraction={batch_fraction}, max_attempts={batch_config.max_attempts}')
+                 f'batch_fraction={batch_fraction}, '
+                 f'max_concurrent_batches={max_concurrent_batches} '
+                 f'(upstream in-flight from batch path <= '
+                 f'{batch_size * max_concurrent_batches}), '
+                 f'max_attempts={batch_controller.config.max_attempts}')
         fetch_ensure_conditions += ['batch_request', 'batch_whole_failure',
                                     'batch_misalignment', 'batch_item_retry',
-                                    'batch_fallback_single', 'batch_duplicate_single_path']
+                                    'batch_fallback_single', 'batch_duplicate_single_path',
+                                    'batch_concurrency_throttled', 'batch_discarded_after_trip']
 
     # put aid into queue
     aid_queue: Queue[int] = Queue()
@@ -148,7 +154,7 @@ def fetch_and_batch_insert_records(
         [FetchVideoRecordJob(f'job_{i}', aid_queue, fetched_record_queue, service,
                              code_error_aid_queue=code_error_aid_queue,
                              duration_limit_s=duration_limit_s,
-                             batch_config=batch_config, batch_state=batch_state)
+                             batch_controller=batch_controller)
          for i in range(job_num)],
         progress_total=len(need_insert_aid_list),
         progress_label=fetch_label,

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -122,12 +122,12 @@ def fetch_and_batch_insert_records(
                  f'batch_fraction={batch_fraction}, '
                  f'max_concurrent_batches={max_concurrent_batches} '
                  f'(upstream in-flight from batch path <= '
-                 f'{batch_size * max_concurrent_batches}), '
-                 f'max_attempts={batch_controller.config.max_attempts}')
+                 f'{batch_size * max_concurrent_batches})')
         fetch_ensure_conditions += ['batch_request', 'batch_whole_failure',
-                                    'batch_misalignment', 'batch_item_retry',
+                                    'batch_misalignment', 'batch_item_fallback_single',
                                     'batch_fallback_single', 'batch_duplicate_single_path',
-                                    'batch_concurrency_throttled', 'batch_discarded_after_trip']
+                                    'batch_concurrency_throttled', 'batch_discarded_after_trip',
+                                    'batch_dropped_at_deadline']
 
     # put aid into queue
     aid_queue: Queue[int] = Queue()

--- a/conf/conf.ini.example
+++ b/conf/conf.ini.example
@@ -12,6 +12,10 @@ sckey = your sckey
 ; (or a missing section) keeps behavior byte-identical to the single-aid path.
 ; batch_size: aids per batch request (worker default caps at 50)
 ; batch_fraction: 0-1 share of aids routed through the batch path
+; max_concurrent_batches: pool-wide cap on simultaneous batch invocations
+;   (upstream in-flight from the batch path = batch_size x this; default 30,
+;   an initial assumption pending calibration)
 [video_view_trimmed_batch]
 batch_size = 0
 batch_fraction = 0
+max_concurrent_batches = 30

--- a/conf/conf.ini.example
+++ b/conf/conf.ini.example
@@ -7,3 +7,11 @@ dbname = tdd
 
 [serverchan]
 sckey = your sckey
+
+; trimmed video_view batch path (51_ record fetch). DEFAULT OFF: batch_size = 0
+; (or a missing section) keeps behavior byte-identical to the single-aid path.
+; batch_size: aids per batch request (worker default caps at 50)
+; batch_fraction: 0-1 share of aids routed through the batch path
+[video_view_trimmed_batch]
+batch_size = 0
+batch_fraction = 0

--- a/conf/conf.py
+++ b/conf/conf.py
@@ -10,6 +10,12 @@ __all__ = ['CONFIG_PATH', 'CONFIG',
 # worker answer 400 on every batch and burn the whole run down to fallback
 VIDEO_VIEW_TRIMMED_BATCH_SIZE_MAX = 50
 
+# default pool-wide cap on simultaneous batch invocations when the conf
+# option is absent. An INITIAL SAFE ASSUMPTION for calibration, not a chosen
+# concurrency: it keeps batch-path upstream in-flight (batch_size x this) at
+# or below today's ~300 for batch_size <= 10.
+VIDEO_VIEW_TRIMMED_BATCH_MAX_CONCURRENT_DEFAULT = 30
+
 # use config parser to load config
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'conf.ini')
 CONFIG = configparser.ConfigParser()
@@ -24,23 +30,31 @@ def get_sckey():
     return CONFIG.get('serverchan', 'sckey')
 
 
-def get_video_view_trimmed_batch_conf() -> tuple[int, float]:
+def get_video_view_trimmed_batch_conf() -> tuple[int, float, int]:
     """
-    (batch_size, batch_fraction) for the trimmed video_view batch path.
+    (batch_size, batch_fraction, max_concurrent_batches) for the trimmed
+    video_view batch path.
 
     Fail-safe by construction: a missing conf.ini, missing section, missing
     option, or unparsable/out-of-range value all come back as the disabled
-    (0, 0.0) -- the batch path must never turn on by accident. batch_size is
-    capped at the batch worker's MAX_AIDS default; batch_fraction is clamped
-    into [0, 1].
+    (0, 0.0, 0) -- the batch path must never turn on by accident, and a
+    nonsensical concurrency cap (<= 0 would deadlock the gate) disables it
+    rather than guessing. batch_size is capped at the batch worker's MAX_AIDS
+    default; batch_fraction is clamped into [0, 1].
     """
+    disabled = (0, 0.0, 0)
     try:
         batch_size = CONFIG.getint(
             'video_view_trimmed_batch', 'batch_size', fallback=0)
         batch_fraction = CONFIG.getfloat(
             'video_view_trimmed_batch', 'batch_fraction', fallback=0.0)
+        max_concurrent_batches = CONFIG.getint(
+            'video_view_trimmed_batch', 'max_concurrent_batches',
+            fallback=VIDEO_VIEW_TRIMMED_BATCH_MAX_CONCURRENT_DEFAULT)
     except ValueError:
-        return 0, 0.0
-    if batch_size <= 0 or batch_fraction <= 0.0:
-        return 0, 0.0
-    return min(batch_size, VIDEO_VIEW_TRIMMED_BATCH_SIZE_MAX), min(batch_fraction, 1.0)
+        return disabled
+    if batch_size <= 0 or batch_fraction <= 0.0 or max_concurrent_batches <= 0:
+        return disabled
+    return (min(batch_size, VIDEO_VIEW_TRIMMED_BATCH_SIZE_MAX),
+            min(batch_fraction, 1.0),
+            max_concurrent_batches)

--- a/conf/conf.py
+++ b/conf/conf.py
@@ -2,7 +2,13 @@ import configparser
 import os
 
 __all__ = ['CONFIG_PATH', 'CONFIG',
-           'get_db_args', 'get_sckey']
+           'get_db_args', 'get_sckey',
+           'get_video_view_trimmed_batch_conf']
+
+# hard client-side cap on batch size, mirroring the batch worker's default
+# MAX_AIDS (aws_lambda_batch.mjs): a larger configured value would make the
+# worker answer 400 on every batch and burn the whole run down to fallback
+VIDEO_VIEW_TRIMMED_BATCH_SIZE_MAX = 50
 
 # use config parser to load config
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), 'conf.ini')
@@ -16,3 +22,25 @@ def get_db_args():
 
 def get_sckey():
     return CONFIG.get('serverchan', 'sckey')
+
+
+def get_video_view_trimmed_batch_conf() -> tuple[int, float]:
+    """
+    (batch_size, batch_fraction) for the trimmed video_view batch path.
+
+    Fail-safe by construction: a missing conf.ini, missing section, missing
+    option, or unparsable/out-of-range value all come back as the disabled
+    (0, 0.0) -- the batch path must never turn on by accident. batch_size is
+    capped at the batch worker's MAX_AIDS default; batch_fraction is clamped
+    into [0, 1].
+    """
+    try:
+        batch_size = CONFIG.getint(
+            'video_view_trimmed_batch', 'batch_size', fallback=0)
+        batch_fraction = CONFIG.getfloat(
+            'video_view_trimmed_batch', 'batch_fraction', fallback=0.0)
+    except ValueError:
+        return 0, 0.0
+    if batch_size <= 0 or batch_fraction <= 0.0:
+        return 0, 0.0
+    return min(batch_size, VIDEO_VIEW_TRIMMED_BATCH_SIZE_MAX), min(batch_fraction, 1.0)

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -79,6 +79,9 @@ class FetchVideoRecordJob(Job):
         self.code_error_aid_queue = code_error_aid_queue
         self.duration_limit_s = duration_limit_s
         self.duration_limit_due_ts_s = None
+        # set once the job has counted its duration-limit hit, so the
+        # several places that can observe the deadline never double-count
+        self._duration_limit_counted = False
         self.put_timeout_s = put_timeout_s
         # ONE controller instance is shared by the whole pool: it carries the
         # batch knobs plus the two cross-job concerns (concurrency gate,
@@ -90,6 +93,16 @@ class FetchVideoRecordJob(Job):
     def _deadline_reached(self) -> bool:
         return (self.duration_limit_due_ts_s is not None
                 and get_ts_s() >= self.duration_limit_due_ts_s)
+
+    def _count_duration_limit_reached(self):
+        """Mark this job as having hit its duration limit -- exactly once,
+        whichever code path saw the deadline first. The pool summary's
+        duration_limit_reached is THE number that says whether the 04:00 full
+        scan finished inside its window, so every deadline exit must land in
+        it, and never twice for one job."""
+        if not self._duration_limit_counted:
+            self._duration_limit_counted = True
+            self.stat.condition['duration_limit_reached'] += 1
 
     def _put_record(self, record) -> bool:
         """Bounded put with a timeout. False -> queue still full, caller decides."""
@@ -221,7 +234,7 @@ class FetchVideoRecordJob(Job):
                                  if buffer else '')
                 self.logger.info(f'Duration limit reached. Now exit. '
                                  f'{self.aid_queue.qsize()} aid(s) left unfetched.{buffered_note}')
-                self.stat.condition['duration_limit_reached'] += 1
+                self._count_duration_limit_reached()
                 break
 
             try:
@@ -396,11 +409,14 @@ class FetchVideoRecordJob(Job):
 
     def _drop_at_deadline(self, aids: list) -> bool:
         """The run deadline passed while this batch was still waiting to be
-        sent: same treatment as aids left in the queue at the deadline (the
-        loop-top check ends the job next), but counted so it is visible."""
+        sent: same treatment as aids left in the queue at the deadline, but
+        counted so it is visible. Also records the duration-limit hit itself:
+        when this is the final flush after the queue drained, the caller
+        breaks straight out and the loop-top check never runs again."""
         self.logger.info(f'Duration limit reached before the batch could be sent. '
                          f'{len(aids)} buffered aid(s) dropped.')
         self.stat.condition['batch_dropped_at_deadline'] += len(aids)
+        self._count_duration_limit_reached()
         return True
 
     def _fallback_to_single(self, aids: list) -> bool:

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -1,13 +1,88 @@
 from .Job import Job
-from service import Service, CodeError
+from service import Service, CodeError, MisalignmentError
 from timer import Timer
 from queue import Queue, Empty, Full
 from core import RecordNew
+from threading import Lock
 from util import format_ts_ms, get_ts_s, ts_s_to_str
-from task import fetch_video_record_via_video_view
-from typing import Optional
+from task import fetch_video_record_via_video_view, build_video_record_via_video_view
+from typing import NamedTuple, Optional
+import random
+import time
 
-__all__ = ['FetchVideoRecordJob']
+__all__ = ['FetchVideoRecordJob',
+           'VideoViewTrimmedBatchConfig', 'VideoViewTrimmedBatchState']
+
+
+class VideoViewTrimmedBatchConfig(NamedTuple):
+    """
+    Knobs of the trimmed video_view BATCH path (default off -- a job built
+    without a config runs the single-aid path untouched). batch_size /
+    batch_fraction values are the canary staircase's dials and are INITIAL
+    HYPOTHESES pending load-test calibration, like the batch timeouts in
+    service/Service.py.
+    """
+    # aids per batch request (conf caps this at the worker's MAX_AIDS)
+    batch_size: int
+    # 0-1 share of aids routed through the batch path; the rest (and every
+    # aid after a kill-switch trip) take the single-aid path
+    batch_fraction: float
+    # total tries per aid before giving up, aligned with the single path's
+    # Service retry=3 semantics
+    max_attempts: int = 3
+
+
+class VideoViewTrimmedBatchState:
+    """
+    Run-scope state of the batch path, SHARED by every FetchVideoRecordJob in
+    a pool (thread-safe): the kill-switch plus the consecutive whole-batch
+    failure counter behind it. Tripping is one-way for the run -- once
+    disabled, every remaining aid takes the single-aid path.
+
+    Trip conditions (per the migration design):
+    - any misalignment (trip(), called by the job that saw it), or
+    - CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT whole-batch failures in a row
+      pool-wide with no success in between -- the self-healing path when the
+      batch worker is dead, deleted, or unreachable.
+    """
+
+    CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT = 3
+
+    def __init__(self):
+        self._lock = Lock()
+        self._enabled = True
+        self._consecutive_whole_batch_failures = 0
+        self.trip_reason: Optional[str] = None
+
+    def is_enabled(self) -> bool:
+        with self._lock:
+            return self._enabled
+
+    def record_batch_success(self):
+        with self._lock:
+            self._consecutive_whole_batch_failures = 0
+
+    def record_whole_batch_failure(self) -> bool:
+        """Count one whole-batch failure. True iff THIS call tripped the
+        kill-switch (so exactly one job logs the critical line)."""
+        with self._lock:
+            self._consecutive_whole_batch_failures += 1
+            if (self._enabled and self._consecutive_whole_batch_failures
+                    >= self.CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT):
+                self._enabled = False
+                self.trip_reason = 'consecutive whole-batch failures'
+                return True
+            return False
+
+    def trip(self, reason: str) -> bool:
+        """Disable the batch path outright (misalignment). True iff THIS call
+        flipped the switch (so exactly one job logs the critical line)."""
+        with self._lock:
+            if not self._enabled:
+                return False
+            self._enabled = False
+            self.trip_reason = reason
+            return True
 
 
 class FetchVideoRecordJob(Job):
@@ -26,6 +101,18 @@ class FetchVideoRecordJob(Job):
     whole life) -- unbounded DB concurrency from the fetch tier, which is what
     deadlocked the 2026-07-15 04:00 full scan. It also cost a fetch slot and
     pulled a FULL (untrimmed, up to 2.8MB) view payload per code error.
+
+    Optional BATCH mode (batch_config + batch_state, both or neither): a
+    batch_fraction share of aids is buffered into batches of batch_size and
+    fetched through Service.get_video_view_trimmed_batch, one Lambda invocation
+    per batch instead of one per aid. Per-item outcomes route exactly like the
+    single path (success -> record_queue, CodeError -> code_error_aid_queue);
+    failed ITEMS are retried alone (max_attempts per aid, mixed into later
+    batches), never the whole batch. A whole-batch transport failure charges
+    every aid in it one attempt. The shared batch_state is the kill-switch:
+    any misalignment, or 3 consecutive whole-batch failures pool-wide, sends
+    every remaining aid down the single-aid path for the rest of the run.
+    Without a config the process loop is byte-identical to the pre-batch one.
     """
 
     # give up on a record after this long stuck on a full queue, so a dead
@@ -37,7 +124,9 @@ class FetchVideoRecordJob(Job):
                  service: Service,
                  code_error_aid_queue: 'Optional[Queue[Optional[int]]]' = None,
                  duration_limit_s: Optional[int] = None,
-                 put_timeout_s: float = 30.0):
+                 put_timeout_s: float = 30.0,
+                 batch_config: Optional[VideoViewTrimmedBatchConfig] = None,
+                 batch_state: Optional[VideoViewTrimmedBatchState] = None):
         super().__init__(name)
         self.aid_queue = aid_queue
         self.record_queue = record_queue
@@ -48,6 +137,10 @@ class FetchVideoRecordJob(Job):
         self.duration_limit_s = duration_limit_s
         self.duration_limit_due_ts_s = None
         self.put_timeout_s = put_timeout_s
+        # batch path: needs BOTH the config (knobs) and the pool-shared state
+        # (kill-switch); anything less runs the single-aid path only
+        self.batch_config = batch_config
+        self.batch_state = batch_state
 
     def _put_record(self, record) -> bool:
         """Bounded put with a timeout. False -> queue still full, caller decides."""
@@ -57,15 +150,209 @@ class FetchVideoRecordJob(Job):
         except Full:
             return False
 
+    def _put_record_with_backpressure(self, aid: int, record: RecordNew) -> bool:
+        """
+        Put one record, waiting out writer backpressure but never forever.
+        False -> the writer is stalled or dead (or the deadline hit while
+        waiting) and the job must exit, same as the single path always did.
+        """
+        # record_queue is BOUNDED, so put() can block when the writer
+        # falls behind -- that backpressure is intentional. What is not
+        # acceptable is blocking FOREVER: if every writer dies (or
+        # cannot get a DB connection), an unbounded wait here hangs the
+        # whole pool past the hour, and the duration-limit check at the
+        # top of the loop is never reached again. Time out, re-check the
+        # deadline, and give up on the record rather than the run.
+        put_wait_s = 0.0
+        while not self._put_record(record):
+            put_wait_s += self.put_timeout_s
+            hit_deadline = (self.duration_limit_due_ts_s is not None
+                            and get_ts_s() >= self.duration_limit_due_ts_s)
+            if hit_deadline or put_wait_s >= self.MAX_PUT_WAIT_S:
+                self.logger.error(
+                    f'Record queue still full after {put_wait_s:.0f}s -- writer stalled '
+                    f'or dead. Dropping record and exiting. aid: {aid}')
+                self.stat.condition['record_dropped_queue_full'] += 1
+                return False
+            self.logger.warning(
+                f'Record queue full for {put_wait_s:.0f}s -- writer is stalled or dead. '
+                f'Still waiting. aid: {aid}')
+        self.stat.condition['success'] += 1
+        return True
+
+    def _fetch_single(self, aid: int) -> bool:
+        """One aid through the single-aid path (fetch, route, count). This IS
+        the pre-batch loop body. False -> the job must exit."""
+        self.logger.debug(f'Now start fetch video record. aid: {aid}')
+        timer = Timer()
+        timer.start()
+
+        stage_stat = {}  # per-stage durations, filled by the task (http_ms)
+        try:
+            record = fetch_video_record_via_video_view(
+                aid, self.service, out_stat=stage_stat)
+        except CodeError as e:
+            # hand off to the UpdateVideoJob pool: refreshing tdd_video.code
+            # is what drops this aid out of future need_insert lists, but it
+            # is DB work and must not happen on a fetch worker
+            if self.code_error_aid_queue is not None:
+                self.code_error_aid_queue.put(aid)
+                self.logger.info(
+                    f'Code error, queued for video update. aid: {aid}, error: {e}')
+            else:
+                self.logger.error(f'Fail to fetch video record. aid: {aid}, error: {e}')
+            self.stat.condition['code_error'] += 1
+        except Exception as e:
+            self.logger.error(f'Fail to fetch video record. aid: {aid}, error: {e}')
+            self.stat.condition['other_exception'] += 1
+        else:
+            if not self._put_record_with_backpressure(aid, record):
+                return False
+
+        timer.stop()
+        # accumulate per-stage durations into the pool stats (JobPool's
+        # heartbeat turns *_ms keys into live per-aid stage averages) and
+        # emit a greppable per-aid line for offline analysis (--debug file)
+        for stage_key, stage_ms in stage_stat.items():
+            self.stat.condition[stage_key] += stage_ms
+        self.logger.debug(
+            f'TIMING aid={aid} '
+            + ' '.join(f'{k[:-3]}={v}ms' for k, v in stage_stat.items())
+            + f' total={timer.get_duration_ms()}ms')
+        self.stat.total_count += 1
+        self.stat.total_duration_ms += timer.get_duration_ms()
+        return True
+
+    def _fallback_batch_to_single(self, batch: list) -> bool:
+        """Run every (aid, attempt) of a discarded batch through the single-aid
+        path (which brings its own internal retries). False -> job must exit."""
+        for batch_aid, _ in batch:
+            self.stat.condition['batch_fallback_single'] += 1
+            if not self._fetch_single(batch_aid):
+                return False
+        return True
+
+    def _finalize_batch_aid(self, batch_ms: int):
+        """Per-aid closing bookkeeping for an aid whose FINAL outcome came from
+        a batch (success / code_error / attempts exhausted -- not a retry).
+        batch_ms is the whole batch round-trip: it is the wall-clock latency
+        this aid experienced, which keeps http_ms / STAGE AVG comparable with
+        the single path's per-aid timing."""
+        self.stat.condition['http_ms'] += batch_ms
+        self.stat.total_count += 1
+        self.stat.total_duration_ms += batch_ms
+
+    def _process_batch(self, batch: list) -> Optional[list]:
+        """
+        Dispatch one assembled batch of (aid, attempts_spent) entries. Returns
+        the entries to re-buffer for retry (only the failed items, to be mixed
+        with new aids), or None if the job must exit (writer stalled/dead,
+        same contract as the single path).
+        """
+        # the kill-switch may have tripped between assembly and dispatch
+        if not self.batch_state.is_enabled():
+            return None if not self._fallback_batch_to_single(batch) else []
+
+        aids = [batch_aid for batch_aid, _ in batch]
+        self.stat.condition['batch_request'] += 1
+        batch_start = time.perf_counter()
+        try:
+            items = self.service.get_video_view_trimmed_batch(aids)
+        except MisalignmentError as e:
+            # the batch path is returning data that cannot be trusted (wrong
+            # endpoint, protocol break, misrouted payloads). Not a per-item
+            # problem: discard the WHOLE batch result, kill the path for the
+            # rest of the run, refetch these aids over the single path.
+            self.stat.condition['batch_misalignment'] += 1
+            if self.batch_state.trip(f'misalignment: {e}'):
+                self.logger.critical(
+                    f'Batch path misalignment -- batch path disabled for the rest of '
+                    f'this run, remaining aids take the single-aid path. error: {e}')
+            else:
+                self.logger.error(f'Batch path misalignment (path already disabled). '
+                                  f'aids: {aids}, error: {e}')
+            return None if not self._fallback_batch_to_single(batch) else []
+        except Exception as e:
+            # whole-batch failure: transport (HTTP != 200, unparsable top
+            # level, endpoint unconfigured -> ServiceError) or an unexpected
+            # bug. Broad on purpose, like the single path's except Exception:
+            # nothing per-item arrived, every aid in the batch pays one
+            # attempt, and a worker thread must never die mid-run over it
+            # (the kill-switch caps how long a broken path can spin).
+            batch_ms = int((time.perf_counter() - batch_start) * 1000)
+            self.stat.condition['batch_whole_failure'] += 1
+            self.logger.error(f'Whole-batch failure. aids: {aids}, error: {e}')
+            if self.batch_state.record_whole_batch_failure():
+                self.logger.critical(
+                    f'{VideoViewTrimmedBatchState.CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT} '
+                    f'consecutive whole-batch failures -- batch path disabled for the '
+                    f'rest of this run, remaining aids take the single-aid path.')
+                return None if not self._fallback_batch_to_single(batch) else []
+            # colddown before the retry wave, mirroring the single path's
+            # between-trial sleep (Service._get)
+            time.sleep(random.random() * 0.5 + 0.75)
+            retry = []
+            for batch_aid, attempts_spent in batch:
+                attempts_spent += 1
+                if attempts_spent >= self.batch_config.max_attempts:
+                    self.logger.error(f'Fail to fetch video record (batch attempts '
+                                      f'exhausted). aid: {batch_aid}, error: {e}')
+                    self.stat.condition['other_exception'] += 1
+                    self._finalize_batch_aid(batch_ms)
+                else:
+                    retry.append((batch_aid, attempts_spent))
+            return retry
+
+        batch_ms = int((time.perf_counter() - batch_start) * 1000)
+        self.batch_state.record_batch_success()
+        self.logger.debug(f'BATCH TIMING aids={aids} http={batch_ms}ms')
+
+        # per-item routing, mirroring the single path outcome for outcome
+        retry = []
+        for (batch_aid, attempts_spent), item in zip(batch, items):
+            if item.view is not None:
+                record = build_video_record_via_video_view(batch_aid, item.view)
+                if not self._put_record_with_backpressure(batch_aid, record):
+                    return None
+            elif isinstance(item.error, CodeError):
+                if self.code_error_aid_queue is not None:
+                    self.code_error_aid_queue.put(batch_aid)
+                    self.logger.info(f'Code error, queued for video update. '
+                                     f'aid: {batch_aid}, error: {item.error}')
+                else:
+                    self.logger.error(
+                        f'Fail to fetch video record. aid: {batch_aid}, error: {item.error}')
+                self.stat.condition['code_error'] += 1
+            else:
+                # transient per-item failure: retry THIS item only
+                attempts_spent += 1
+                if attempts_spent >= self.batch_config.max_attempts:
+                    self.logger.error(f'Fail to fetch video record (batch attempts '
+                                      f'exhausted). aid: {batch_aid}, error: {item.error}')
+                    self.stat.condition['other_exception'] += 1
+                else:
+                    self.stat.condition['batch_item_retry'] += 1
+                    retry.append((batch_aid, attempts_spent))
+                    continue  # not final: no per-aid bookkeeping yet
+            self._finalize_batch_aid(batch_ms)
+        return retry
+
     def process(self):
         if self.duration_limit_s is not None:
             self.duration_limit_due_ts_s = get_ts_s() + self.duration_limit_s
             self.logger.info(f'Duration limit due at {ts_s_to_str(self.duration_limit_due_ts_s)}.')
 
+        batch_on = self.batch_config is not None and self.batch_state is not None
+        # (aid, attempts_spent) waiting for dispatch; retried items re-enter
+        # here and mix with new aids
+        batch_buffer: list = []
+
         while True:
             if self.duration_limit_due_ts_s is not None and get_ts_s() >= self.duration_limit_due_ts_s:
+                buffered_note = (f' ({len(batch_buffer)} aid(s) buffered for batch dropped)'
+                                 if batch_buffer else '')
                 self.logger.info(f'Duration limit reached. Now exit. '
-                                 f'{self.aid_queue.qsize()} aid(s) left unfetched.')
+                                 f'{self.aid_queue.qsize()} aid(s) left unfetched.{buffered_note}')
                 # surface the cut in the pool summary, not just in a log line:
                 # on the 04:00 full scan this is THE number that says whether we
                 # finished inside the 40-minute window
@@ -78,63 +365,36 @@ class FetchVideoRecordJob(Job):
             try:
                 aid = self.aid_queue.get_nowait()
             except Empty:
-                break
-            self.logger.debug(f'Now start fetch video record. aid: {aid}')
-            timer = Timer()
-            timer.start()
-
-            stage_stat = {}  # per-stage durations, filled by the task (http_ms)
-            try:
-                record = fetch_video_record_via_video_view(
-                    aid, self.service, out_stat=stage_stat)
-            except CodeError as e:
-                # hand off to the UpdateVideoJob pool: refreshing tdd_video.code
-                # is what drops this aid out of future need_insert lists, but it
-                # is DB work and must not happen on a fetch worker
-                if self.code_error_aid_queue is not None:
-                    self.code_error_aid_queue.put(aid)
-                    self.logger.info(
-                        f'Code error, queued for video update. aid: {aid}, error: {e}')
-                else:
-                    self.logger.error(f'Fail to fetch video record. aid: {aid}, error: {e}')
-                self.stat.condition['code_error'] += 1
-            except Exception as e:
-                self.logger.error(f'Fail to fetch video record. aid: {aid}, error: {e}')
-                self.stat.condition['other_exception'] += 1
-            else:
-                # record_queue is BOUNDED, so put() can block when the writer
-                # falls behind -- that backpressure is intentional. What is not
-                # acceptable is blocking FOREVER: if every writer dies (or
-                # cannot get a DB connection), an unbounded wait here hangs the
-                # whole pool past the hour, and the duration-limit check at the
-                # top of the loop is never reached again. Time out, re-check the
-                # deadline, and give up on the record rather than the run.
-                put_wait_s = 0.0
-                while not self._put_record(record):
-                    put_wait_s += self.put_timeout_s
-                    hit_deadline = (self.duration_limit_due_ts_s is not None
-                                    and get_ts_s() >= self.duration_limit_due_ts_s)
-                    if hit_deadline or put_wait_s >= self.MAX_PUT_WAIT_S:
-                        self.logger.error(
-                            f'Record queue still full after {put_wait_s:.0f}s -- writer stalled '
-                            f'or dead. Dropping record and exiting. aid: {aid}')
-                        self.stat.condition['record_dropped_queue_full'] += 1
+                if batch_buffer:
+                    # flush the partial batch (and keep looping: its retries
+                    # re-enter the buffer until resolved or exhausted). With no
+                    # new aids left a retry-only buffer would redispatch back to
+                    # back; colddown first, mirroring the single path's
+                    # between-trial sleep (Service._get)
+                    if all(attempts_spent > 0 for _, attempts_spent in batch_buffer):
+                        time.sleep(random.random() * 0.5 + 0.75)
+                    batch_buffer = self._process_batch(batch_buffer)
+                    if batch_buffer is None:
                         return
-                    self.logger.warning(
-                        f'Record queue full for {put_wait_s:.0f}s -- writer is stalled or dead. '
-                        f'Still waiting. aid: {aid}')
-                self.stat.condition['success'] += 1
+                    continue
+                break
 
-            timer.stop()
-            # accumulate per-stage durations into the pool stats (JobPool's
-            # heartbeat turns *_ms keys into live per-aid stage averages) and
-            # emit a greppable per-aid line for offline analysis (--debug file)
-            for stage_key, stage_ms in stage_stat.items():
-                self.stat.condition[stage_key] += stage_ms
-            self.logger.debug(
-                f'TIMING aid={aid} '
-                + ' '.join(f'{k[:-3]}={v}ms' for k, v in stage_stat.items())
-                + f' total={timer.get_duration_ms()}ms')
-            self.stat.total_count += 1
-            self.stat.total_duration_ms += timer.get_duration_ms()
-
+            if (batch_on and self.batch_state.is_enabled()
+                    and random.random() < self.batch_config.batch_fraction):
+                if any(batch_aid == aid for batch_aid, _ in batch_buffer):
+                    # duplicate of an aid already buffered: the worker contract
+                    # leaves de-duplication to the caller, so never send the
+                    # same token twice in one batch -- this occurrence takes
+                    # the single path instead
+                    self.stat.condition['batch_duplicate_single_path'] += 1
+                    if not self._fetch_single(aid):
+                        return
+                else:
+                    batch_buffer.append((aid, 0))
+                    if len(batch_buffer) >= self.batch_config.batch_size:
+                        batch_buffer = self._process_batch(batch_buffer)
+                        if batch_buffer is None:
+                            return
+            else:
+                if not self._fetch_single(aid):
+                    return

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -1,6 +1,5 @@
 from .Job import Job
-from .VideoViewTrimmedBatchController import \
-    VideoViewTrimmedBatchController, BatchEntry, BatchDispatchResult
+from .VideoViewTrimmedBatchController import VideoViewTrimmedBatchController
 from service import Service, CodeError, MisalignmentError
 from timer import Timer
 from queue import Queue, Empty, Full
@@ -38,13 +37,22 @@ class FetchVideoRecordJob(Job):
     - batch_controller set -> _run_batch_path_loop(): a batch_fraction share
       of aids is buffered into batches of batch_size and fetched through
       Service.get_video_view_trimmed_batch; everything else takes the single
-      path. Per-item outcomes route exactly like the single path; only failed
-      ITEMS are retried (max_attempts per aid, mixed into later batches). The
-      pool-shared controller bounds simultaneous batch invocations and owns
-      the circuit breaker (see its docstring for the precise breaker
-      definition); once the breaker fires, every remaining aid -- including
-      results still in flight, which are discarded on return -- takes the
-      untouched single-aid path.
+      path. Reliability-first policy -- the batch path is an optimisation
+      layered on the single path, never a second retry machine:
+        * item ok          -> record, exactly as the single path would
+        * item CodeError   -> code_error_aid_queue, exactly as the single path
+        * item transient   -> THAT aid is refetched over the single path
+                              right away (Service's own retry=3 handles it)
+        * whole-batch fail -> every aid of the batch is refetched over the
+                              single path, and the breaker is tripped: the
+                              path is unavailable, stop using it this run
+        * misalignment     -> same fallback, breaker tripped: the path's DATA
+                              cannot be trusted
+      The pool-shared controller bounds simultaneous batch invocations and
+      holds the breaker; once tripped, every remaining aid -- including
+      responses still in flight, which are discarded on return -- takes the
+      untouched single-aid path. No aid is ever dropped because of the batch
+      path; the worst case is a few extra single-aid calls.
     """
 
     # give up on a record after this long stuck on a full queue, so a dead
@@ -53,7 +61,7 @@ class FetchVideoRecordJob(Job):
     MAX_PUT_WAIT_S = 300.0
 
     # wait for a batch-invocation slot in slices this long, re-checking the
-    # run deadline and the circuit breaker between waits
+    # run deadline and the breaker between waits
     SLOT_WAIT_SLICE_S = 1.0
 
     def __init__(self, name: str, aid_queue: Queue[int], record_queue: 'Queue[Optional[RecordNew]]',
@@ -201,12 +209,11 @@ class FetchVideoRecordJob(Job):
 
     def _run_batch_path_loop(self):
         """Pull aids, route each to the batch buffer or the single path, and
-        dispatch batches. Failure policy, retry accounting and the breaker all
-        live in _dispatch_batch / the controller; this loop only moves aids."""
+        dispatch full batches (plus the partial one left when the queue
+        drains). Nothing comes back from a dispatch: every aid handed to
+        _dispatch_batch is resolved there, one way or another."""
         config = self.batch_controller.config
-        # entries waiting for dispatch; retried items re-enter here and mix
-        # with new aids
-        buffer: list[BatchEntry] = []
+        buffer: list[int] = []  # aids waiting for dispatch
 
         while True:
             if self._deadline_reached():
@@ -220,24 +227,13 @@ class FetchVideoRecordJob(Job):
             try:
                 aid = self.aid_queue.get_nowait()
             except Empty:
-                if buffer:
-                    # flush the partial batch (and keep looping: its retries
-                    # re-enter the buffer until resolved or exhausted). With no
-                    # new aids left a retry-only buffer would redispatch back to
-                    # back; colddown first, mirroring the single path's
-                    # between-trial sleep (Service._get)
-                    if all(entry.attempts_spent > 0 for entry in buffer):
-                        time.sleep(random.random() * 0.5 + 0.75)
-                    result = self._dispatch_batch(buffer)
-                    if result.should_stop:
-                        return
-                    buffer = result.retries
-                    continue
+                if buffer and not self._dispatch_batch(buffer):
+                    return
                 break
 
             if (self.batch_controller.is_enabled()
                     and random.random() < config.batch_fraction):
-                if any(entry.aid == aid for entry in buffer):
+                if aid in buffer:
                     # duplicate of an aid already buffered: the worker contract
                     # leaves de-duplication to the caller, so never send the
                     # same token twice in one batch -- this occurrence takes
@@ -246,24 +242,28 @@ class FetchVideoRecordJob(Job):
                     if not self._fetch_single(aid):
                         return
                 else:
-                    buffer.append(BatchEntry(aid=aid, attempts_spent=0))
+                    buffer.append(aid)
                     if len(buffer) >= config.batch_size:
-                        result = self._dispatch_batch(buffer)
-                        if result.should_stop:
+                        if not self._dispatch_batch(buffer):
                             return
-                        buffer = result.retries
+                        buffer = []
             else:
                 if not self._fetch_single(aid):
                     return
 
     # --- batch dispatch -------------------------------------------------------
 
-    def _dispatch_batch(self, entries: list) -> BatchDispatchResult:
-        """Run one assembled batch through gate -> HTTP -> interpretation."""
+    def _dispatch_batch(self, aids: list) -> bool:
+        """
+        Resolve one assembled batch: gate -> HTTP -> per-item routing, with
+        every failure mode ending in the single-aid path (see the class
+        docstring). Returns False only when the job must exit (record writer
+        stalled or dead), the same contract as _fetch_single.
+        """
         # breaker check before spending a slot; a batch assembled just before
         # the trip goes straight to the single path
         if not self.batch_controller.is_enabled():
-            return self._fallback_result(entries)
+            return self._fallback_to_single(aids)
 
         # concurrency gate: bounds simultaneous batch invocations pool-wide
         if not self.batch_controller.try_acquire_slot(0):
@@ -273,30 +273,52 @@ class FetchVideoRecordJob(Job):
             self.stat.condition['batch_concurrency_throttled'] += 1
             while not self.batch_controller.try_acquire_slot(self.SLOT_WAIT_SLICE_S):
                 if self._deadline_reached():
-                    # hand the entries back untouched; the loop-top deadline
-                    # check is the single place that logs and counts the drop
-                    return BatchDispatchResult(retries=entries, should_stop=False)
+                    # the run is over: same treatment as aids left in the
+                    # queue at the deadline, but counted so it is visible
+                    self.logger.info(f'Duration limit reached while waiting for a batch '
+                                     f'slot. {len(aids)} buffered aid(s) dropped.')
+                    self.stat.condition['batch_dropped_at_deadline'] += len(aids)
+                    return True
                 if not self.batch_controller.is_enabled():
-                    return self._fallback_result(entries)
+                    return self._fallback_to_single(aids)
 
-        aids = [entry.aid for entry in entries]
         self.stat.condition['batch_request'] += 1
         batch_start = time.perf_counter()
         try:
             try:
                 items = self.service.get_video_view_trimmed_batch(aids)
             finally:
-                # release before any fallback/retry work -- holding a slot
-                # through single-path refetches would starve the batch path
+                # release before any fallback work -- holding a slot through
+                # single-path refetches would starve the batch path
                 self.batch_controller.release_slot()
         except MisalignmentError as e:
-            return self._on_misalignment(e, aids, entries)
+            # the path's data cannot be trusted (wrong endpoint, protocol
+            # break, misrouted payloads): discard the whole result, stop using
+            # the path this run, refetch these aids over the single path
+            self.stat.condition['batch_misalignment'] += 1
+            if self.batch_controller.trip(f'misalignment: {e}'):
+                self.logger.critical(
+                    f'Batch path misalignment -- batch path disabled for the rest of '
+                    f'this run, remaining aids take the single-aid path. error: {e}')
+            else:
+                self.logger.error(f'Batch path misalignment (path already disabled). '
+                                  f'aids: {aids}, error: {e}')
+            return self._fallback_to_single(aids)
         except Exception as e:
-            # broad on purpose, like the single path's except Exception: a
-            # bug-shaped error must degrade like a transport failure, never
-            # kill a worker thread mid-run
-            batch_ms = int((time.perf_counter() - batch_start) * 1000)
-            return self._on_whole_batch_failure(e, aids, entries, batch_ms)
+            # nothing per-item arrived (transport failure, worker error
+            # envelope, endpoint unconfigured, or an unexpected bug -- broad
+            # on purpose, like the single path's except Exception): the path
+            # is unavailable, stop using it this run rather than retrying it,
+            # and refetch these aids over the single path
+            self.stat.condition['batch_whole_failure'] += 1
+            if self.batch_controller.trip(f'whole-batch failure: {e}'):
+                self.logger.critical(
+                    f'Whole-batch failure -- batch path disabled for the rest of this '
+                    f'run, remaining aids take the single-aid path. aids: {aids}, error: {e}')
+            else:
+                self.logger.error(f'Whole-batch failure (path already disabled). '
+                                  f'aids: {aids}, error: {e}')
+            return self._fallback_to_single(aids)
         batch_ms = int((time.perf_counter() - batch_start) * 1000)
 
         # RE-CHECK the breaker before interpreting anything: this response may
@@ -311,107 +333,50 @@ class FetchVideoRecordJob(Job):
             self.logger.warning(
                 f'Discarding an in-flight batch response returned after the batch path '
                 f'was disabled; refetching over the single-aid path. aids: {aids}')
-            return self._fallback_result(entries)
+            return self._fallback_to_single(aids)
 
-        self.batch_controller.record_batch_success()
         self.logger.debug(f'BATCH TIMING aids={aids} http={batch_ms}ms')
 
         # per-item routing, mirroring the single path outcome for outcome
-        retries = []
-        for entry, item in zip(entries, items):
+        for aid, item in zip(aids, items):
             if item.view is not None:
-                record = build_video_record_via_video_view(entry.aid, item.view)
-                if not self._put_record_with_backpressure(entry.aid, record):
-                    return BatchDispatchResult(retries=[], should_stop=True)
+                record = build_video_record_via_video_view(aid, item.view)
+                if not self._put_record_with_backpressure(aid, record):
+                    return False
             elif isinstance(item.error, CodeError):
                 if self.code_error_aid_queue is not None:
-                    self.code_error_aid_queue.put(entry.aid)
+                    self.code_error_aid_queue.put(aid)
                     self.logger.info(f'Code error, queued for video update. '
-                                     f'aid: {entry.aid}, error: {item.error}')
+                                     f'aid: {aid}, error: {item.error}')
                 else:
                     self.logger.error(
-                        f'Fail to fetch video record. aid: {entry.aid}, error: {item.error}')
+                        f'Fail to fetch video record. aid: {aid}, error: {item.error}')
                 self.stat.condition['code_error'] += 1
             else:
-                # transient per-item failure: retry THIS item only
-                attempts_spent = entry.attempts_spent + 1
-                if attempts_spent >= self.batch_controller.config.max_attempts:
-                    self.logger.error(f'Fail to fetch video record (batch attempts '
-                                      f'exhausted). aid: {entry.aid}, error: {item.error}')
-                    self.stat.condition['other_exception'] += 1
-                else:
-                    self.stat.condition['batch_item_retry'] += 1
-                    retries.append(BatchEntry(entry.aid, attempts_spent))
-                    continue  # not final: no per-aid bookkeeping yet
-            self._finalize_batch_aid(batch_ms)
-        return BatchDispatchResult(retries=retries, should_stop=False)
-
-    def _on_misalignment(self, error, aids, entries) -> BatchDispatchResult:
-        """The batch path returned data that cannot be trusted (wrong endpoint,
-        protocol break, misrouted payloads). Not a per-item problem: discard
-        the WHOLE batch result, fire the breaker for the rest of the run,
-        refetch these aids over the single path."""
-        self.stat.condition['batch_misalignment'] += 1
-        if self.batch_controller.trip(f'misalignment: {error}'):
-            self.logger.critical(
-                f'Batch path misalignment -- batch path disabled for the rest of '
-                f'this run, remaining aids take the single-aid path. error: {error}')
-        else:
-            self.logger.error(f'Batch path misalignment (path already disabled). '
-                              f'aids: {aids}, error: {error}')
-        return self._fallback_result(entries)
-
-    def _on_whole_batch_failure(self, error, aids, entries, batch_ms) -> BatchDispatchResult:
-        """Nothing per-item arrived (transport failure, worker error envelope,
-        endpoint unconfigured, or an unexpected bug): every aid in the batch
-        pays one attempt; the breaker counts one completion-order failure."""
-        self.stat.condition['batch_whole_failure'] += 1
-        self.logger.error(f'Whole-batch failure. aids: {aids}, error: {error}')
-        if self.batch_controller.record_whole_batch_failure():
-            self.logger.critical(
-                f'{VideoViewTrimmedBatchController.CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT} '
-                f'consecutive whole-batch failures -- batch path disabled for the '
-                f'rest of this run, remaining aids take the single-aid path.')
-            return self._fallback_result(entries)
-        if not self.batch_controller.is_enabled():
-            # another job fired the breaker while this batch was in flight;
-            # retrying over the dead path would only burn attempts
-            return self._fallback_result(entries)
-        # colddown before the retry wave, mirroring the single path's
-        # between-trial sleep (Service._get)
-        time.sleep(random.random() * 0.5 + 0.75)
-        retries = []
-        for entry in entries:
-            attempts_spent = entry.attempts_spent + 1
-            if attempts_spent >= self.batch_controller.config.max_attempts:
-                self.logger.error(f'Fail to fetch video record (batch attempts '
-                                  f'exhausted). aid: {entry.aid}, error: {error}')
-                self.stat.condition['other_exception'] += 1
-                self._finalize_batch_aid(batch_ms)
-            else:
-                retries.append(BatchEntry(entry.aid, attempts_spent))
-        return BatchDispatchResult(retries=retries, should_stop=False)
-
-    def _fallback_result(self, entries: list) -> BatchDispatchResult:
-        """Send a discarded batch down the single path, as a dispatch result."""
-        return BatchDispatchResult(
-            retries=[], should_stop=not self._fallback_batch_to_single(entries))
-
-    def _fallback_batch_to_single(self, entries: list) -> bool:
-        """Run every entry of a discarded batch through the single-aid path
-        (which brings its own internal retries). False -> job must exit."""
-        for entry in entries:
-            self.stat.condition['batch_fallback_single'] += 1
-            if not self._fetch_single(entry.aid):
-                return False
+                # transient per-item failure (item timeout, fetch error,
+                # non-JSON or non-200 upstream): THIS aid goes over the
+                # single path now, whose own retry=3 is the retry policy.
+                # _fetch_single does its own per-aid bookkeeping.
+                self.logger.debug(f'Batch item failed, refetching over the single-aid '
+                                  f'path. aid: {aid}, error: {item.error}')
+                self.stat.condition['batch_item_fallback_single'] += 1
+                if not self._fetch_single(aid):
+                    return False
+                continue
+            # per-aid closing bookkeeping for an aid resolved by the batch.
+            # batch_ms is the whole batch round-trip: it is the wall-clock
+            # latency this aid experienced, which keeps http_ms / STAGE AVG
+            # comparable with the single path's per-aid timing
+            self.stat.condition['http_ms'] += batch_ms
+            self.stat.total_count += 1
+            self.stat.total_duration_ms += batch_ms
         return True
 
-    def _finalize_batch_aid(self, batch_ms: int):
-        """Per-aid closing bookkeeping for an aid whose FINAL outcome came from
-        a batch (success / code_error / attempts exhausted -- not a retry).
-        batch_ms is the whole batch round-trip: it is the wall-clock latency
-        this aid experienced, which keeps http_ms / STAGE AVG comparable with
-        the single path's per-aid timing."""
-        self.stat.condition['http_ms'] += batch_ms
-        self.stat.total_count += 1
-        self.stat.total_duration_ms += batch_ms
+    def _fallback_to_single(self, aids: list) -> bool:
+        """Run every aid of a discarded batch through the single-aid path
+        (which brings its own internal retries). False -> job must exit."""
+        for aid in aids:
+            self.stat.condition['batch_fallback_single'] += 1
+            if not self._fetch_single(aid):
+                return False
+        return True

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -231,8 +231,19 @@ class FetchVideoRecordJob(Job):
                     return
                 break
 
-            if (self.batch_controller.is_enabled()
-                    and random.random() < config.batch_fraction):
+            # observe the breaker ONCE per aid. If it fired while this buffer
+            # was assembling, resolve the buffer over the single path right
+            # now -- before touching the aid just dequeued -- instead of
+            # holding it until the queue drains (where a deadline could drop
+            # it). No job keeps a batch buffer past the moment it sees the
+            # breaker open.
+            batch_enabled = self.batch_controller.is_enabled()
+            if buffer and not batch_enabled:
+                if not self._fallback_to_single(buffer):
+                    return
+                buffer = []
+
+            if batch_enabled and random.random() < config.batch_fraction:
                 if aid in buffer:
                     # duplicate of an aid already buffered: the worker contract
                     # leaves de-duplication to the caller, so never send the
@@ -273,20 +284,27 @@ class FetchVideoRecordJob(Job):
             self.stat.condition['batch_concurrency_throttled'] += 1
             while not self.batch_controller.try_acquire_slot(self.SLOT_WAIT_SLICE_S):
                 if self._deadline_reached():
-                    # the run is over: same treatment as aids left in the
-                    # queue at the deadline, but counted so it is visible
-                    self.logger.info(f'Duration limit reached while waiting for a batch '
-                                     f'slot. {len(aids)} buffered aid(s) dropped.')
-                    self.stat.condition['batch_dropped_at_deadline'] += len(aids)
-                    return True
+                    return self._drop_at_deadline(aids)
                 if not self.batch_controller.is_enabled():
                     return self._fallback_to_single(aids)
 
-        self.stat.condition['batch_request'] += 1
+        # SLOT HELD from here to the finally below -- exactly one release on
+        # every path. The breaker may have fired, or the deadline passed,
+        # between the last check and the successful acquire (typically while
+        # blocked in the wait above), so re-check BEFORE sending; when
+        # abandoning, the slot is given back first and the fallback/drop work
+        # runs unthrottled afterwards.
+        abandon = None
         batch_start = time.perf_counter()
         try:
             try:
-                items = self.service.get_video_view_trimmed_batch(aids)
+                if not self.batch_controller.is_enabled():
+                    abandon = 'tripped'
+                elif self._deadline_reached():
+                    abandon = 'deadline'
+                else:
+                    self.stat.condition['batch_request'] += 1
+                    items = self.service.get_video_view_trimmed_batch(aids)
             finally:
                 # release before any fallback work -- holding a slot through
                 # single-path refetches would starve the batch path
@@ -319,6 +337,10 @@ class FetchVideoRecordJob(Job):
                 self.logger.error(f'Whole-batch failure (path already disabled). '
                                   f'aids: {aids}, error: {e}')
             return self._fallback_to_single(aids)
+        if abandon == 'tripped':
+            return self._fallback_to_single(aids)
+        if abandon == 'deadline':
+            return self._drop_at_deadline(aids)
         batch_ms = int((time.perf_counter() - batch_start) * 1000)
 
         # RE-CHECK the breaker before interpreting anything: this response may
@@ -370,6 +392,15 @@ class FetchVideoRecordJob(Job):
             self.stat.condition['http_ms'] += batch_ms
             self.stat.total_count += 1
             self.stat.total_duration_ms += batch_ms
+        return True
+
+    def _drop_at_deadline(self, aids: list) -> bool:
+        """The run deadline passed while this batch was still waiting to be
+        sent: same treatment as aids left in the queue at the deadline (the
+        loop-top check ends the job next), but counted so it is visible."""
+        self.logger.info(f'Duration limit reached before the batch could be sent. '
+                         f'{len(aids)} buffered aid(s) dropped.')
+        self.stat.condition['batch_dropped_at_deadline'] += len(aids)
         return True
 
     def _fallback_to_single(self, aids: list) -> bool:

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -1,88 +1,17 @@
 from .Job import Job
+from .VideoViewTrimmedBatchController import \
+    VideoViewTrimmedBatchController, BatchEntry, BatchDispatchResult
 from service import Service, CodeError, MisalignmentError
 from timer import Timer
 from queue import Queue, Empty, Full
 from core import RecordNew
-from threading import Lock
 from util import format_ts_ms, get_ts_s, ts_s_to_str
 from task import fetch_video_record_via_video_view, build_video_record_via_video_view
-from typing import NamedTuple, Optional
+from typing import Optional
 import random
 import time
 
-__all__ = ['FetchVideoRecordJob',
-           'VideoViewTrimmedBatchConfig', 'VideoViewTrimmedBatchState']
-
-
-class VideoViewTrimmedBatchConfig(NamedTuple):
-    """
-    Knobs of the trimmed video_view BATCH path (default off -- a job built
-    without a config runs the single-aid path untouched). batch_size /
-    batch_fraction values are the canary staircase's dials and are INITIAL
-    HYPOTHESES pending load-test calibration, like the batch timeouts in
-    service/Service.py.
-    """
-    # aids per batch request (conf caps this at the worker's MAX_AIDS)
-    batch_size: int
-    # 0-1 share of aids routed through the batch path; the rest (and every
-    # aid after a kill-switch trip) take the single-aid path
-    batch_fraction: float
-    # total tries per aid before giving up, aligned with the single path's
-    # Service retry=3 semantics
-    max_attempts: int = 3
-
-
-class VideoViewTrimmedBatchState:
-    """
-    Run-scope state of the batch path, SHARED by every FetchVideoRecordJob in
-    a pool (thread-safe): the kill-switch plus the consecutive whole-batch
-    failure counter behind it. Tripping is one-way for the run -- once
-    disabled, every remaining aid takes the single-aid path.
-
-    Trip conditions (per the migration design):
-    - any misalignment (trip(), called by the job that saw it), or
-    - CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT whole-batch failures in a row
-      pool-wide with no success in between -- the self-healing path when the
-      batch worker is dead, deleted, or unreachable.
-    """
-
-    CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT = 3
-
-    def __init__(self):
-        self._lock = Lock()
-        self._enabled = True
-        self._consecutive_whole_batch_failures = 0
-        self.trip_reason: Optional[str] = None
-
-    def is_enabled(self) -> bool:
-        with self._lock:
-            return self._enabled
-
-    def record_batch_success(self):
-        with self._lock:
-            self._consecutive_whole_batch_failures = 0
-
-    def record_whole_batch_failure(self) -> bool:
-        """Count one whole-batch failure. True iff THIS call tripped the
-        kill-switch (so exactly one job logs the critical line)."""
-        with self._lock:
-            self._consecutive_whole_batch_failures += 1
-            if (self._enabled and self._consecutive_whole_batch_failures
-                    >= self.CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT):
-                self._enabled = False
-                self.trip_reason = 'consecutive whole-batch failures'
-                return True
-            return False
-
-    def trip(self, reason: str) -> bool:
-        """Disable the batch path outright (misalignment). True iff THIS call
-        flipped the switch (so exactly one job logs the critical line)."""
-        with self._lock:
-            if not self._enabled:
-                return False
-            self._enabled = False
-            self.trip_reason = reason
-            return True
+__all__ = ['FetchVideoRecordJob']
 
 
 class FetchVideoRecordJob(Job):
@@ -102,17 +31,20 @@ class FetchVideoRecordJob(Job):
     deadlocked the 2026-07-15 04:00 full scan. It also cost a fetch slot and
     pulled a FULL (untrimmed, up to 2.8MB) view payload per code error.
 
-    Optional BATCH mode (batch_config + batch_state, both or neither): a
-    batch_fraction share of aids is buffered into batches of batch_size and
-    fetched through Service.get_video_view_trimmed_batch, one Lambda invocation
-    per batch instead of one per aid. Per-item outcomes route exactly like the
-    single path (success -> record_queue, CodeError -> code_error_aid_queue);
-    failed ITEMS are retried alone (max_attempts per aid, mixed into later
-    batches), never the whole batch. A whole-batch transport failure charges
-    every aid in it one attempt. The shared batch_state is the kill-switch:
-    any misalignment, or 3 consecutive whole-batch failures pool-wide, sends
-    every remaining aid down the single-aid path for the rest of the run.
-    Without a config the process loop is byte-identical to the pre-batch one.
+    Two mutually exclusive process loops, chosen once at start:
+
+    - batch_controller is None -> _run_single_path_loop(): the pre-batch
+      behavior, verbatim. This is the production default.
+    - batch_controller set -> _run_batch_path_loop(): a batch_fraction share
+      of aids is buffered into batches of batch_size and fetched through
+      Service.get_video_view_trimmed_batch; everything else takes the single
+      path. Per-item outcomes route exactly like the single path; only failed
+      ITEMS are retried (max_attempts per aid, mixed into later batches). The
+      pool-shared controller bounds simultaneous batch invocations and owns
+      the circuit breaker (see its docstring for the precise breaker
+      definition); once the breaker fires, every remaining aid -- including
+      results still in flight, which are discarded on return -- takes the
+      untouched single-aid path.
     """
 
     # give up on a record after this long stuck on a full queue, so a dead
@@ -120,13 +52,16 @@ class FetchVideoRecordJob(Job):
     # duration limit normally ends the wait first)
     MAX_PUT_WAIT_S = 300.0
 
+    # wait for a batch-invocation slot in slices this long, re-checking the
+    # run deadline and the circuit breaker between waits
+    SLOT_WAIT_SLICE_S = 1.0
+
     def __init__(self, name: str, aid_queue: Queue[int], record_queue: 'Queue[Optional[RecordNew]]',
                  service: Service,
                  code_error_aid_queue: 'Optional[Queue[Optional[int]]]' = None,
                  duration_limit_s: Optional[int] = None,
                  put_timeout_s: float = 30.0,
-                 batch_config: Optional[VideoViewTrimmedBatchConfig] = None,
-                 batch_state: Optional[VideoViewTrimmedBatchState] = None):
+                 batch_controller: Optional[VideoViewTrimmedBatchController] = None):
         super().__init__(name)
         self.aid_queue = aid_queue
         self.record_queue = record_queue
@@ -137,10 +72,16 @@ class FetchVideoRecordJob(Job):
         self.duration_limit_s = duration_limit_s
         self.duration_limit_due_ts_s = None
         self.put_timeout_s = put_timeout_s
-        # batch path: needs BOTH the config (knobs) and the pool-shared state
-        # (kill-switch); anything less runs the single-aid path only
-        self.batch_config = batch_config
-        self.batch_state = batch_state
+        # ONE controller instance is shared by the whole pool: it carries the
+        # batch knobs plus the two cross-job concerns (concurrency gate,
+        # circuit breaker). None -> single-aid path only.
+        self.batch_controller = batch_controller
+
+    # --- pieces shared by both loops ----------------------------------------
+
+    def _deadline_reached(self) -> bool:
+        return (self.duration_limit_due_ts_s is not None
+                and get_ts_s() >= self.duration_limit_due_ts_s)
 
     def _put_record(self, record) -> bool:
         """Bounded put with a timeout. False -> queue still full, caller decides."""
@@ -166,9 +107,7 @@ class FetchVideoRecordJob(Job):
         put_wait_s = 0.0
         while not self._put_record(record):
             put_wait_s += self.put_timeout_s
-            hit_deadline = (self.duration_limit_due_ts_s is not None
-                            and get_ts_s() >= self.duration_limit_due_ts_s)
-            if hit_deadline or put_wait_s >= self.MAX_PUT_WAIT_S:
+            if self._deadline_reached() or put_wait_s >= self.MAX_PUT_WAIT_S:
                 self.logger.error(
                     f'Record queue still full after {put_wait_s:.0f}s -- writer stalled '
                     f'or dead. Dropping record and exiting. aid: {aid}')
@@ -182,7 +121,7 @@ class FetchVideoRecordJob(Job):
 
     def _fetch_single(self, aid: int) -> bool:
         """One aid through the single-aid path (fetch, route, count). This IS
-        the pre-batch loop body. False -> the job must exit."""
+        the pre-batch loop body, verbatim. False -> the job must exit."""
         self.logger.debug(f'Now start fetch video record. aid: {aid}')
         timer = Timer()
         timer.start()
@@ -223,136 +162,26 @@ class FetchVideoRecordJob(Job):
         self.stat.total_duration_ms += timer.get_duration_ms()
         return True
 
-    def _fallback_batch_to_single(self, batch: list) -> bool:
-        """Run every (aid, attempt) of a discarded batch through the single-aid
-        path (which brings its own internal retries). False -> job must exit."""
-        for batch_aid, _ in batch:
-            self.stat.condition['batch_fallback_single'] += 1
-            if not self._fetch_single(batch_aid):
-                return False
-        return True
-
-    def _finalize_batch_aid(self, batch_ms: int):
-        """Per-aid closing bookkeeping for an aid whose FINAL outcome came from
-        a batch (success / code_error / attempts exhausted -- not a retry).
-        batch_ms is the whole batch round-trip: it is the wall-clock latency
-        this aid experienced, which keeps http_ms / STAGE AVG comparable with
-        the single path's per-aid timing."""
-        self.stat.condition['http_ms'] += batch_ms
-        self.stat.total_count += 1
-        self.stat.total_duration_ms += batch_ms
-
-    def _process_batch(self, batch: list) -> Optional[list]:
-        """
-        Dispatch one assembled batch of (aid, attempts_spent) entries. Returns
-        the entries to re-buffer for retry (only the failed items, to be mixed
-        with new aids), or None if the job must exit (writer stalled/dead,
-        same contract as the single path).
-        """
-        # the kill-switch may have tripped between assembly and dispatch
-        if not self.batch_state.is_enabled():
-            return None if not self._fallback_batch_to_single(batch) else []
-
-        aids = [batch_aid for batch_aid, _ in batch]
-        self.stat.condition['batch_request'] += 1
-        batch_start = time.perf_counter()
-        try:
-            items = self.service.get_video_view_trimmed_batch(aids)
-        except MisalignmentError as e:
-            # the batch path is returning data that cannot be trusted (wrong
-            # endpoint, protocol break, misrouted payloads). Not a per-item
-            # problem: discard the WHOLE batch result, kill the path for the
-            # rest of the run, refetch these aids over the single path.
-            self.stat.condition['batch_misalignment'] += 1
-            if self.batch_state.trip(f'misalignment: {e}'):
-                self.logger.critical(
-                    f'Batch path misalignment -- batch path disabled for the rest of '
-                    f'this run, remaining aids take the single-aid path. error: {e}')
-            else:
-                self.logger.error(f'Batch path misalignment (path already disabled). '
-                                  f'aids: {aids}, error: {e}')
-            return None if not self._fallback_batch_to_single(batch) else []
-        except Exception as e:
-            # whole-batch failure: transport (HTTP != 200, unparsable top
-            # level, endpoint unconfigured -> ServiceError) or an unexpected
-            # bug. Broad on purpose, like the single path's except Exception:
-            # nothing per-item arrived, every aid in the batch pays one
-            # attempt, and a worker thread must never die mid-run over it
-            # (the kill-switch caps how long a broken path can spin).
-            batch_ms = int((time.perf_counter() - batch_start) * 1000)
-            self.stat.condition['batch_whole_failure'] += 1
-            self.logger.error(f'Whole-batch failure. aids: {aids}, error: {e}')
-            if self.batch_state.record_whole_batch_failure():
-                self.logger.critical(
-                    f'{VideoViewTrimmedBatchState.CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT} '
-                    f'consecutive whole-batch failures -- batch path disabled for the '
-                    f'rest of this run, remaining aids take the single-aid path.')
-                return None if not self._fallback_batch_to_single(batch) else []
-            # colddown before the retry wave, mirroring the single path's
-            # between-trial sleep (Service._get)
-            time.sleep(random.random() * 0.5 + 0.75)
-            retry = []
-            for batch_aid, attempts_spent in batch:
-                attempts_spent += 1
-                if attempts_spent >= self.batch_config.max_attempts:
-                    self.logger.error(f'Fail to fetch video record (batch attempts '
-                                      f'exhausted). aid: {batch_aid}, error: {e}')
-                    self.stat.condition['other_exception'] += 1
-                    self._finalize_batch_aid(batch_ms)
-                else:
-                    retry.append((batch_aid, attempts_spent))
-            return retry
-
-        batch_ms = int((time.perf_counter() - batch_start) * 1000)
-        self.batch_state.record_batch_success()
-        self.logger.debug(f'BATCH TIMING aids={aids} http={batch_ms}ms')
-
-        # per-item routing, mirroring the single path outcome for outcome
-        retry = []
-        for (batch_aid, attempts_spent), item in zip(batch, items):
-            if item.view is not None:
-                record = build_video_record_via_video_view(batch_aid, item.view)
-                if not self._put_record_with_backpressure(batch_aid, record):
-                    return None
-            elif isinstance(item.error, CodeError):
-                if self.code_error_aid_queue is not None:
-                    self.code_error_aid_queue.put(batch_aid)
-                    self.logger.info(f'Code error, queued for video update. '
-                                     f'aid: {batch_aid}, error: {item.error}')
-                else:
-                    self.logger.error(
-                        f'Fail to fetch video record. aid: {batch_aid}, error: {item.error}')
-                self.stat.condition['code_error'] += 1
-            else:
-                # transient per-item failure: retry THIS item only
-                attempts_spent += 1
-                if attempts_spent >= self.batch_config.max_attempts:
-                    self.logger.error(f'Fail to fetch video record (batch attempts '
-                                      f'exhausted). aid: {batch_aid}, error: {item.error}')
-                    self.stat.condition['other_exception'] += 1
-                else:
-                    self.stat.condition['batch_item_retry'] += 1
-                    retry.append((batch_aid, attempts_spent))
-                    continue  # not final: no per-aid bookkeeping yet
-            self._finalize_batch_aid(batch_ms)
-        return retry
+    # --- the two process loops ----------------------------------------------
 
     def process(self):
         if self.duration_limit_s is not None:
             self.duration_limit_due_ts_s = get_ts_s() + self.duration_limit_s
             self.logger.info(f'Duration limit due at {ts_s_to_str(self.duration_limit_due_ts_s)}.')
 
-        batch_on = self.batch_config is not None and self.batch_state is not None
-        # (aid, attempts_spent) waiting for dispatch; retried items re-enter
-        # here and mix with new aids
-        batch_buffer: list = []
+        if self.batch_controller is None:
+            self._run_single_path_loop()
+        else:
+            self._run_batch_path_loop()
 
+    def _run_single_path_loop(self):
+        """The pre-batch process loop, unchanged -- what production runs while
+        the batch path is off. Kept free of any batch bookkeeping so it stays
+        trivially diffable against the original implementation."""
         while True:
-            if self.duration_limit_due_ts_s is not None and get_ts_s() >= self.duration_limit_due_ts_s:
-                buffered_note = (f' ({len(batch_buffer)} aid(s) buffered for batch dropped)'
-                                 if batch_buffer else '')
+            if self._deadline_reached():
                 self.logger.info(f'Duration limit reached. Now exit. '
-                                 f'{self.aid_queue.qsize()} aid(s) left unfetched.{buffered_note}')
+                                 f'{self.aid_queue.qsize()} aid(s) left unfetched.')
                 # surface the cut in the pool summary, not just in a log line:
                 # on the 04:00 full scan this is THE number that says whether we
                 # finished inside the 40-minute window
@@ -365,23 +194,50 @@ class FetchVideoRecordJob(Job):
             try:
                 aid = self.aid_queue.get_nowait()
             except Empty:
-                if batch_buffer:
+                break
+
+            if not self._fetch_single(aid):
+                return
+
+    def _run_batch_path_loop(self):
+        """Pull aids, route each to the batch buffer or the single path, and
+        dispatch batches. Failure policy, retry accounting and the breaker all
+        live in _dispatch_batch / the controller; this loop only moves aids."""
+        config = self.batch_controller.config
+        # entries waiting for dispatch; retried items re-enter here and mix
+        # with new aids
+        buffer: list[BatchEntry] = []
+
+        while True:
+            if self._deadline_reached():
+                buffered_note = (f' ({len(buffer)} aid(s) buffered for batch dropped)'
+                                 if buffer else '')
+                self.logger.info(f'Duration limit reached. Now exit. '
+                                 f'{self.aid_queue.qsize()} aid(s) left unfetched.{buffered_note}')
+                self.stat.condition['duration_limit_reached'] += 1
+                break
+
+            try:
+                aid = self.aid_queue.get_nowait()
+            except Empty:
+                if buffer:
                     # flush the partial batch (and keep looping: its retries
                     # re-enter the buffer until resolved or exhausted). With no
                     # new aids left a retry-only buffer would redispatch back to
                     # back; colddown first, mirroring the single path's
                     # between-trial sleep (Service._get)
-                    if all(attempts_spent > 0 for _, attempts_spent in batch_buffer):
+                    if all(entry.attempts_spent > 0 for entry in buffer):
                         time.sleep(random.random() * 0.5 + 0.75)
-                    batch_buffer = self._process_batch(batch_buffer)
-                    if batch_buffer is None:
+                    result = self._dispatch_batch(buffer)
+                    if result.should_stop:
                         return
+                    buffer = result.retries
                     continue
                 break
 
-            if (batch_on and self.batch_state.is_enabled()
-                    and random.random() < self.batch_config.batch_fraction):
-                if any(batch_aid == aid for batch_aid, _ in batch_buffer):
+            if (self.batch_controller.is_enabled()
+                    and random.random() < config.batch_fraction):
+                if any(entry.aid == aid for entry in buffer):
                     # duplicate of an aid already buffered: the worker contract
                     # leaves de-duplication to the caller, so never send the
                     # same token twice in one batch -- this occurrence takes
@@ -390,11 +246,172 @@ class FetchVideoRecordJob(Job):
                     if not self._fetch_single(aid):
                         return
                 else:
-                    batch_buffer.append((aid, 0))
-                    if len(batch_buffer) >= self.batch_config.batch_size:
-                        batch_buffer = self._process_batch(batch_buffer)
-                        if batch_buffer is None:
+                    buffer.append(BatchEntry(aid=aid, attempts_spent=0))
+                    if len(buffer) >= config.batch_size:
+                        result = self._dispatch_batch(buffer)
+                        if result.should_stop:
                             return
+                        buffer = result.retries
             else:
                 if not self._fetch_single(aid):
                     return
+
+    # --- batch dispatch -------------------------------------------------------
+
+    def _dispatch_batch(self, entries: list) -> BatchDispatchResult:
+        """Run one assembled batch through gate -> HTTP -> interpretation."""
+        # breaker check before spending a slot; a batch assembled just before
+        # the trip goes straight to the single path
+        if not self.batch_controller.is_enabled():
+            return self._fallback_result(entries)
+
+        # concurrency gate: bounds simultaneous batch invocations pool-wide
+        if not self.batch_controller.try_acquire_slot(0):
+            # gate is biting: count it once per dispatch (observability for
+            # calibration), then wait in slices so a held-up slot can never
+            # blind this job to the run deadline or to the breaker firing
+            self.stat.condition['batch_concurrency_throttled'] += 1
+            while not self.batch_controller.try_acquire_slot(self.SLOT_WAIT_SLICE_S):
+                if self._deadline_reached():
+                    # hand the entries back untouched; the loop-top deadline
+                    # check is the single place that logs and counts the drop
+                    return BatchDispatchResult(retries=entries, should_stop=False)
+                if not self.batch_controller.is_enabled():
+                    return self._fallback_result(entries)
+
+        aids = [entry.aid for entry in entries]
+        self.stat.condition['batch_request'] += 1
+        batch_start = time.perf_counter()
+        try:
+            try:
+                items = self.service.get_video_view_trimmed_batch(aids)
+            finally:
+                # release before any fallback/retry work -- holding a slot
+                # through single-path refetches would starve the batch path
+                self.batch_controller.release_slot()
+        except MisalignmentError as e:
+            return self._on_misalignment(e, aids, entries)
+        except Exception as e:
+            # broad on purpose, like the single path's except Exception: a
+            # bug-shaped error must degrade like a transport failure, never
+            # kill a worker thread mid-run
+            batch_ms = int((time.perf_counter() - batch_start) * 1000)
+            return self._on_whole_batch_failure(e, aids, entries, batch_ms)
+        batch_ms = int((time.perf_counter() - batch_start) * 1000)
+
+        # RE-CHECK the breaker before interpreting anything: this response may
+        # have been in flight when another job tripped it (misalignment means
+        # the path's data cannot be trusted, this response included). Discard
+        # it wholesale and refetch over the single path. A trip landing after
+        # this check, while items are being written, is a residual window we
+        # accept: every item below has already passed its own full identity
+        # validation, so the recheck is defense in depth, not the last line.
+        if not self.batch_controller.is_enabled():
+            self.stat.condition['batch_discarded_after_trip'] += 1
+            self.logger.warning(
+                f'Discarding an in-flight batch response returned after the batch path '
+                f'was disabled; refetching over the single-aid path. aids: {aids}')
+            return self._fallback_result(entries)
+
+        self.batch_controller.record_batch_success()
+        self.logger.debug(f'BATCH TIMING aids={aids} http={batch_ms}ms')
+
+        # per-item routing, mirroring the single path outcome for outcome
+        retries = []
+        for entry, item in zip(entries, items):
+            if item.view is not None:
+                record = build_video_record_via_video_view(entry.aid, item.view)
+                if not self._put_record_with_backpressure(entry.aid, record):
+                    return BatchDispatchResult(retries=[], should_stop=True)
+            elif isinstance(item.error, CodeError):
+                if self.code_error_aid_queue is not None:
+                    self.code_error_aid_queue.put(entry.aid)
+                    self.logger.info(f'Code error, queued for video update. '
+                                     f'aid: {entry.aid}, error: {item.error}')
+                else:
+                    self.logger.error(
+                        f'Fail to fetch video record. aid: {entry.aid}, error: {item.error}')
+                self.stat.condition['code_error'] += 1
+            else:
+                # transient per-item failure: retry THIS item only
+                attempts_spent = entry.attempts_spent + 1
+                if attempts_spent >= self.batch_controller.config.max_attempts:
+                    self.logger.error(f'Fail to fetch video record (batch attempts '
+                                      f'exhausted). aid: {entry.aid}, error: {item.error}')
+                    self.stat.condition['other_exception'] += 1
+                else:
+                    self.stat.condition['batch_item_retry'] += 1
+                    retries.append(BatchEntry(entry.aid, attempts_spent))
+                    continue  # not final: no per-aid bookkeeping yet
+            self._finalize_batch_aid(batch_ms)
+        return BatchDispatchResult(retries=retries, should_stop=False)
+
+    def _on_misalignment(self, error, aids, entries) -> BatchDispatchResult:
+        """The batch path returned data that cannot be trusted (wrong endpoint,
+        protocol break, misrouted payloads). Not a per-item problem: discard
+        the WHOLE batch result, fire the breaker for the rest of the run,
+        refetch these aids over the single path."""
+        self.stat.condition['batch_misalignment'] += 1
+        if self.batch_controller.trip(f'misalignment: {error}'):
+            self.logger.critical(
+                f'Batch path misalignment -- batch path disabled for the rest of '
+                f'this run, remaining aids take the single-aid path. error: {error}')
+        else:
+            self.logger.error(f'Batch path misalignment (path already disabled). '
+                              f'aids: {aids}, error: {error}')
+        return self._fallback_result(entries)
+
+    def _on_whole_batch_failure(self, error, aids, entries, batch_ms) -> BatchDispatchResult:
+        """Nothing per-item arrived (transport failure, worker error envelope,
+        endpoint unconfigured, or an unexpected bug): every aid in the batch
+        pays one attempt; the breaker counts one completion-order failure."""
+        self.stat.condition['batch_whole_failure'] += 1
+        self.logger.error(f'Whole-batch failure. aids: {aids}, error: {error}')
+        if self.batch_controller.record_whole_batch_failure():
+            self.logger.critical(
+                f'{VideoViewTrimmedBatchController.CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT} '
+                f'consecutive whole-batch failures -- batch path disabled for the '
+                f'rest of this run, remaining aids take the single-aid path.')
+            return self._fallback_result(entries)
+        if not self.batch_controller.is_enabled():
+            # another job fired the breaker while this batch was in flight;
+            # retrying over the dead path would only burn attempts
+            return self._fallback_result(entries)
+        # colddown before the retry wave, mirroring the single path's
+        # between-trial sleep (Service._get)
+        time.sleep(random.random() * 0.5 + 0.75)
+        retries = []
+        for entry in entries:
+            attempts_spent = entry.attempts_spent + 1
+            if attempts_spent >= self.batch_controller.config.max_attempts:
+                self.logger.error(f'Fail to fetch video record (batch attempts '
+                                  f'exhausted). aid: {entry.aid}, error: {error}')
+                self.stat.condition['other_exception'] += 1
+                self._finalize_batch_aid(batch_ms)
+            else:
+                retries.append(BatchEntry(entry.aid, attempts_spent))
+        return BatchDispatchResult(retries=retries, should_stop=False)
+
+    def _fallback_result(self, entries: list) -> BatchDispatchResult:
+        """Send a discarded batch down the single path, as a dispatch result."""
+        return BatchDispatchResult(
+            retries=[], should_stop=not self._fallback_batch_to_single(entries))
+
+    def _fallback_batch_to_single(self, entries: list) -> bool:
+        """Run every entry of a discarded batch through the single-aid path
+        (which brings its own internal retries). False -> job must exit."""
+        for entry in entries:
+            self.stat.condition['batch_fallback_single'] += 1
+            if not self._fetch_single(entry.aid):
+                return False
+        return True
+
+    def _finalize_batch_aid(self, batch_ms: int):
+        """Per-aid closing bookkeeping for an aid whose FINAL outcome came from
+        a batch (success / code_error / attempts exhausted -- not a retry).
+        batch_ms is the whole batch round-trip: it is the wall-clock latency
+        this aid experienced, which keeps http_ms / STAGE AVG comparable with
+        the single path's per-aid timing."""
+        self.stat.condition['http_ms'] += batch_ms
+        self.stat.total_count += 1
+        self.stat.total_duration_ms += batch_ms

--- a/job/VideoViewTrimmedBatchController.py
+++ b/job/VideoViewTrimmedBatchController.py
@@ -1,52 +1,32 @@
 from threading import BoundedSemaphore, Lock
 from typing import NamedTuple, Optional
 
-__all__ = ['VideoViewTrimmedBatchConfig', 'VideoViewTrimmedBatchController',
-           'BatchEntry', 'BatchDispatchResult']
+__all__ = ['VideoViewTrimmedBatchConfig', 'VideoViewTrimmedBatchController']
 
 
 class VideoViewTrimmedBatchConfig(NamedTuple):
     """
     Knobs of the trimmed video_view BATCH path (default off -- a job built
-    without a controller runs the single-aid path untouched). batch_size,
-    batch_fraction and max_concurrent_batches are the canary staircase's dials
-    and are INITIAL HYPOTHESES pending load-test calibration, like the batch
-    timeouts in service/Service.py -- none of them is an approved final value.
+    without a controller runs the single-aid path untouched). All three are
+    the canary staircase's dials and INITIAL HYPOTHESES pending load-test
+    calibration, like the batch timeouts in service/Service.py -- none of them
+    is an approved final value.
     """
     # aids per batch request (conf caps this at the worker's MAX_AIDS)
     batch_size: int
     # 0-1 share of aids routed through the batch path; the rest (and every
-    # aid after a kill-switch trip) take the single-aid path
+    # aid after the breaker fires) take the single-aid path
     batch_fraction: float
     # pool-wide cap on SIMULTANEOUS batch invocations. Without it, every one
     # of the pool's fetch threads (300 in 51_) could hold a batch in flight at
     # batch_fraction=1, putting batch_size x 300 requests on the upstream at
     # once. The cap bounds upstream in-flight from the batch path at
     # batch_size x max_concurrent_batches, INDEPENDENT of the fetch thread
-    # count; the single-aid path (including kill-switch fallback) is
-    # deliberately NOT throttled by it. Default 30 keeps batch-path upstream
-    # in-flight at or below today's 300 for batch_size <= 10 -- an initial
-    # safe assumption for the calibration experiments, NOT a chosen W.
+    # count; the single-aid path (including breaker fallback) is deliberately
+    # NOT throttled by it. Default 30 keeps batch-path upstream in-flight at
+    # or below today's 300 for batch_size <= 10 -- an initial safe assumption
+    # for the calibration experiments, NOT a chosen W.
     max_concurrent_batches: int = 30
-    # total tries per aid before giving up, aligned with the single path's
-    # Service retry=3 semantics
-    max_attempts: int = 3
-
-
-class BatchEntry(NamedTuple):
-    """One aid waiting in (or dispatched from) a job's batch buffer."""
-    aid: int
-    attempts_spent: int  # failed tries so far; max_attempts total tries per aid
-
-
-class BatchDispatchResult(NamedTuple):
-    """Outcome of dispatching one batch, returned to the job's batch loop."""
-    # failed entries to put back in the buffer (attempts_spent already
-    # incremented); they mix with new aids into later batches
-    retries: list
-    # True -> the job must exit NOW (record writer stalled or dead), the same
-    # contract as the single-aid path's drop-and-exit
-    should_stop: bool
 
 
 class VideoViewTrimmedBatchController:
@@ -56,41 +36,25 @@ class VideoViewTrimmedBatchController:
     cross-job concerns:
 
     1. The CONCURRENCY GATE (a semaphore of max_concurrent_batches slots):
-       jobs must hold a slot around the batch HTTP call, bounding simultaneous
+       jobs hold a slot around the batch HTTP call, bounding simultaneous
        batch invocations pool-wide. Only batch invocations are gated -- the
        single-aid path never touches the controller.
 
-    2. The CIRCUIT BREAKER (kill-switch). Precise definition:
-
-       - Outcomes are recorded in COMPLETION order -- the order in which jobs
-         report them after their batch call returns -- which under concurrency
-         is not the dispatch order.
-       - record_whole_batch_failure() counts one whole-batch failure;
-         record_batch_success() (called only for a response that passed FULL
-         envelope + per-item identity validation) resets that count to zero.
-       - The breaker trips when CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT failures
-         are recorded with no validated success recorded in between. In-flight
-         batches do not delay or prevent the trip; conversely, their successes
-         (once recorded) reset the count, so a healthy worker with many
-         batches in flight is not tripped by a sprinkle of transient failures
-         unless three of them complete back to back with no success landing
-         between them -- and a spurious trip only costs falling back to the
-         always-correct single-aid path for the rest of the run.
-       - trip(reason) fires the breaker immediately regardless of the count
-         (misalignment: the path's DATA cannot be trusted).
-       - Tripping is one-way for the run. Jobs must re-check is_enabled()
-         when a batch response comes back, BEFORE interpreting it: a response
-         already in flight when the breaker tripped must be discarded and its
-         aids refetched over the single-aid path.
+    2. The CIRCUIT BREAKER: a one-way, run-scoped switch. Any job may trip it
+       (trip(reason)); once tripped, every remaining aid takes the single-aid
+       path, and a batch response still in flight at trip time is discarded
+       by its job on return (jobs re-check is_enabled() before interpreting a
+       response). Trip causes, decided by the job: a misalignment (the
+       path's DATA cannot be trusted) or ANY whole-batch failure (the path is
+       unavailable; a few extra single-aid calls beat any retry bookkeeping).
+       There is deliberately no failure counting, no retry state and no
+       backoff in here: reliability and auditability first.
     """
-
-    CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT = 3
 
     def __init__(self, config: VideoViewTrimmedBatchConfig):
         self.config = config
         self._lock = Lock()
         self._enabled = True
-        self._consecutive_whole_batch_failures = 0
         self.trip_reason: Optional[str] = None
         self._slots = BoundedSemaphore(config.max_concurrent_batches)
 
@@ -100,26 +64,9 @@ class VideoViewTrimmedBatchController:
         with self._lock:
             return self._enabled
 
-    def record_batch_success(self):
-        """A batch response passed full validation: reset the failure streak."""
-        with self._lock:
-            self._consecutive_whole_batch_failures = 0
-
-    def record_whole_batch_failure(self) -> bool:
-        """Count one whole-batch failure (in completion order). True iff THIS
-        call tripped the breaker (so exactly one job logs the critical line)."""
-        with self._lock:
-            self._consecutive_whole_batch_failures += 1
-            if (self._enabled and self._consecutive_whole_batch_failures
-                    >= self.CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT):
-                self._enabled = False
-                self.trip_reason = 'consecutive whole-batch failures'
-                return True
-            return False
-
     def trip(self, reason: str) -> bool:
-        """Fire the breaker outright (misalignment). True iff THIS call
-        flipped it (so exactly one job logs the critical line)."""
+        """Disable the batch path for the rest of the run. True iff THIS call
+        flipped the switch (so exactly one job logs the critical line)."""
         with self._lock:
             if not self._enabled:
                 return False

--- a/job/VideoViewTrimmedBatchController.py
+++ b/job/VideoViewTrimmedBatchController.py
@@ -1,0 +1,141 @@
+from threading import BoundedSemaphore, Lock
+from typing import NamedTuple, Optional
+
+__all__ = ['VideoViewTrimmedBatchConfig', 'VideoViewTrimmedBatchController',
+           'BatchEntry', 'BatchDispatchResult']
+
+
+class VideoViewTrimmedBatchConfig(NamedTuple):
+    """
+    Knobs of the trimmed video_view BATCH path (default off -- a job built
+    without a controller runs the single-aid path untouched). batch_size,
+    batch_fraction and max_concurrent_batches are the canary staircase's dials
+    and are INITIAL HYPOTHESES pending load-test calibration, like the batch
+    timeouts in service/Service.py -- none of them is an approved final value.
+    """
+    # aids per batch request (conf caps this at the worker's MAX_AIDS)
+    batch_size: int
+    # 0-1 share of aids routed through the batch path; the rest (and every
+    # aid after a kill-switch trip) take the single-aid path
+    batch_fraction: float
+    # pool-wide cap on SIMULTANEOUS batch invocations. Without it, every one
+    # of the pool's fetch threads (300 in 51_) could hold a batch in flight at
+    # batch_fraction=1, putting batch_size x 300 requests on the upstream at
+    # once. The cap bounds upstream in-flight from the batch path at
+    # batch_size x max_concurrent_batches, INDEPENDENT of the fetch thread
+    # count; the single-aid path (including kill-switch fallback) is
+    # deliberately NOT throttled by it. Default 30 keeps batch-path upstream
+    # in-flight at or below today's 300 for batch_size <= 10 -- an initial
+    # safe assumption for the calibration experiments, NOT a chosen W.
+    max_concurrent_batches: int = 30
+    # total tries per aid before giving up, aligned with the single path's
+    # Service retry=3 semantics
+    max_attempts: int = 3
+
+
+class BatchEntry(NamedTuple):
+    """One aid waiting in (or dispatched from) a job's batch buffer."""
+    aid: int
+    attempts_spent: int  # failed tries so far; max_attempts total tries per aid
+
+
+class BatchDispatchResult(NamedTuple):
+    """Outcome of dispatching one batch, returned to the job's batch loop."""
+    # failed entries to put back in the buffer (attempts_spent already
+    # incremented); they mix with new aids into later batches
+    retries: list
+    # True -> the job must exit NOW (record writer stalled or dead), the same
+    # contract as the single-aid path's drop-and-exit
+    should_stop: bool
+
+
+class VideoViewTrimmedBatchController:
+    """
+    Pool-shared runtime state of the batch path. ONE instance per run is
+    shared by every FetchVideoRecordJob in the fetch pool, and owns the two
+    cross-job concerns:
+
+    1. The CONCURRENCY GATE (a semaphore of max_concurrent_batches slots):
+       jobs must hold a slot around the batch HTTP call, bounding simultaneous
+       batch invocations pool-wide. Only batch invocations are gated -- the
+       single-aid path never touches the controller.
+
+    2. The CIRCUIT BREAKER (kill-switch). Precise definition:
+
+       - Outcomes are recorded in COMPLETION order -- the order in which jobs
+         report them after their batch call returns -- which under concurrency
+         is not the dispatch order.
+       - record_whole_batch_failure() counts one whole-batch failure;
+         record_batch_success() (called only for a response that passed FULL
+         envelope + per-item identity validation) resets that count to zero.
+       - The breaker trips when CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT failures
+         are recorded with no validated success recorded in between. In-flight
+         batches do not delay or prevent the trip; conversely, their successes
+         (once recorded) reset the count, so a healthy worker with many
+         batches in flight is not tripped by a sprinkle of transient failures
+         unless three of them complete back to back with no success landing
+         between them -- and a spurious trip only costs falling back to the
+         always-correct single-aid path for the rest of the run.
+       - trip(reason) fires the breaker immediately regardless of the count
+         (misalignment: the path's DATA cannot be trusted).
+       - Tripping is one-way for the run. Jobs must re-check is_enabled()
+         when a batch response comes back, BEFORE interpreting it: a response
+         already in flight when the breaker tripped must be discarded and its
+         aids refetched over the single-aid path.
+    """
+
+    CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT = 3
+
+    def __init__(self, config: VideoViewTrimmedBatchConfig):
+        self.config = config
+        self._lock = Lock()
+        self._enabled = True
+        self._consecutive_whole_batch_failures = 0
+        self.trip_reason: Optional[str] = None
+        self._slots = BoundedSemaphore(config.max_concurrent_batches)
+
+    # --- circuit breaker ---------------------------------------------------
+
+    def is_enabled(self) -> bool:
+        with self._lock:
+            return self._enabled
+
+    def record_batch_success(self):
+        """A batch response passed full validation: reset the failure streak."""
+        with self._lock:
+            self._consecutive_whole_batch_failures = 0
+
+    def record_whole_batch_failure(self) -> bool:
+        """Count one whole-batch failure (in completion order). True iff THIS
+        call tripped the breaker (so exactly one job logs the critical line)."""
+        with self._lock:
+            self._consecutive_whole_batch_failures += 1
+            if (self._enabled and self._consecutive_whole_batch_failures
+                    >= self.CONSECUTIVE_WHOLE_BATCH_FAILURE_LIMIT):
+                self._enabled = False
+                self.trip_reason = 'consecutive whole-batch failures'
+                return True
+            return False
+
+    def trip(self, reason: str) -> bool:
+        """Fire the breaker outright (misalignment). True iff THIS call
+        flipped it (so exactly one job logs the critical line)."""
+        with self._lock:
+            if not self._enabled:
+                return False
+            self._enabled = False
+            self.trip_reason = reason
+            return True
+
+    # --- concurrency gate --------------------------------------------------
+
+    def try_acquire_slot(self, timeout_s: float) -> bool:
+        """Wait up to timeout_s for a batch-invocation slot (timeout_s <= 0 is
+        an instant probe). Callers loop on this (re-checking their deadline
+        and the breaker between waits) rather than blocking indefinitely."""
+        if timeout_s <= 0:
+            return self._slots.acquire(blocking=False)
+        return self._slots.acquire(timeout=timeout_s)
+
+    def release_slot(self):
+        self._slots.release()

--- a/job/__init__.py
+++ b/job/__init__.py
@@ -7,6 +7,7 @@ from .AddVideoRecordJob import *
 from .AddVideoFromArchiveJob import *
 from .BatchInsertVideoRecordJob import *
 from .FetchVideoRecordJob import *
+from .VideoViewTrimmedBatchController import *
 from .GetNewlistArchiveJob import *
 from .Job import *
 from .JobStat import *

--- a/service/Service.py
+++ b/service/Service.py
@@ -6,20 +6,39 @@ import time
 import random
 from pathlib import Path
 from typing import Optional, Callable, Literal
-from .error import ResponseError, FormatError, CodeError
+from .error import ResponseError, FormatError, CodeError, MisalignmentError
 from .response import \
     VideoViewOwner, VideoViewStat, VideoViewStaffItem, VideoView, VideoViewTrimmed, \
+    VideoViewTrimmedBatchItem, \
     VideoTag, VideoTags, \
     MemberCard, \
     MemberRelation, \
     NewlistPage, NewlistArchiveStat, NewlistArchiveOwner, NewlistArchive, Newlist
+from util import a2b
 import logging
 
 logger = logging.getLogger('Service')
 
 RequestMode = Literal['direct', 'worker']
 
-__all__ = ['Service', 'RequestMode']
+__all__ = ['Service', 'RequestMode',
+           'BATCH_PROTOCOL_VERSION', 'BATCH_READ_TIMEOUT_S', 'BATCH_DEADLINE_S']
+
+# --- trimmed video_view batch path tunables ---------------------------------
+# INITIAL HYPOTHESES pending load-test calibration against the deployed batch
+# worker -- do not treat as approved final values. The timeout-chain invariant
+# that MUST hold whatever the calibrated numbers become:
+#
+#   client deadline (12s) > client read timeout (8s)
+#     > batch fn timeout (6s, Lambda side) > per-item timeout (4.5s, worker)
+#
+# i.e. each inner layer gives up before the outer one abandons it, with >= 2s
+# of headroom per step -- the single-path incident where client timeout ==
+# function timeout (5s == 5s) turned worker-side timeouts into opaque
+# client-side ones, and this chain is how that stays fixed.
+BATCH_PROTOCOL_VERSION = 1
+BATCH_READ_TIMEOUT_S = 8.0
+BATCH_DEADLINE_S = 12.0
 
 
 class Service:
@@ -27,7 +46,7 @@ class Service:
     def __init__(
             self, headers: Optional[dict] = None, retry: int = 3, timeout: float = 5.0, colddown_factor: float = 1.0,
             mode: RequestMode = 'direct', pool_maxsize: int = 256, deadline: float = 10.0,
-            min_throughput_bps: float = 80_000.0
+            min_throughput_bps: float = 80_000.0, endpoints: Optional[dict] = None
     ):
         # set default config
         self._headers = headers if headers is not None else {}
@@ -61,20 +80,24 @@ class Service:
         self._session.mount('http://', adapter)
         self._session.mount('https://', adapter)
 
-        # load endpoints
-        try:
-            with Path(__file__).with_name('endpoints.json').open('r') as f:
-                self.endpoints = json.load(f)
-        except FileNotFoundError:
-            logger.critical("The file 'endpoints.json' was not found.")
-            exit(1)
-        except json.JSONDecodeError:
-            logger.critical('Invalid JSON format in endpoints.json.')
-            exit(1)
-        except Exception as e:
-            logger.critical(
-                f'An unexpected error occurred when load and parse endpoints.json file. {e}')
-            exit(1)
+        # load endpoints (injectable for tests; production always loads the
+        # git-ignored endpoints.json next to this file)
+        if endpoints is not None:
+            self.endpoints = endpoints
+        else:
+            try:
+                with Path(__file__).with_name('endpoints.json').open('r') as f:
+                    self.endpoints = json.load(f)
+            except FileNotFoundError:
+                logger.critical("The file 'endpoints.json' was not found.")
+                exit(1)
+            except json.JSONDecodeError:
+                logger.critical('Invalid JSON format in endpoints.json.')
+                exit(1)
+            except Exception as e:
+                logger.critical(
+                    f'An unexpected error occurred when load and parse endpoints.json file. {e}')
+                exit(1)
 
         # define User Agent list
         self._ua_list = [
@@ -502,6 +525,199 @@ class Service:
                 vv=response['data']['stat'].get('vv', None),
             ),
         )
+
+    def get_video_view_trimmed_batch(
+            self, aids: list[int], headers: Optional[dict] = None,
+            mode: Optional[RequestMode] = None
+    ) -> list[VideoViewTrimmedBatchItem]:
+        """
+        aids: aid ints, already de-duplicated by the caller (the batch worker
+              forwards duplicate tokens as-is per its contract)
+        mode: 'worker' only
+
+        Batched counterpart of get_video_view_trimmed against the batch worker
+        (service/workers/video_view/aws_lambda_batch.mjs, contract v1): one GET
+        with ?aids=a,b,c returns per-item envelopes, same order as the input.
+
+        Error model, three tiers. A top-level HTTP 200 does NOT mean the items
+        succeeded -- every item is judged on its own status + kind + body.code:
+
+        - returns list[VideoViewTrimmedBatchItem], same length/order as aids.
+          An item is trusted (view set) only when kind == 'json' AND upstream
+          status == 200 AND body.code == 0 AND the full single-path format
+          check set AND the identity checks all pass. kind == 'json' with
+          status == 200 and code != 0 carries a CodeError (identical routing
+          to the single path). Everything transient (item_timeout, fetch_error,
+          non_json, or ANY non-200 upstream status -- the single path never
+          parses non-200 bodies, so a code==0 body on a 500 is NOT trusted)
+          carries a ResponseError: retry this item only.
+        - raises ResponseError: whole-batch transport failure -- HTTP != 200 /
+          unparsable top level (includes the worker's own 400/500 envelopes),
+          or no batch worker endpoint configured. The caller owns the retry
+          and counts one attempt for every aid in the batch.
+        - raises MisalignmentError: top level parsed but violates the batch
+          contract (v != 1, requested/results length mismatch) or an item
+          fails an identity/format check (aid echo, body.data.aid, bvid,
+          stat.aid, missing keys). The whole batch result is untrustworthy:
+          the caller must discard it entirely and trip its kill-switch.
+
+        No internal retry (retry=1 below): whole-batch retries belong to the
+        caller's per-aid attempt accounting; stacking Service-level retries
+        under them would multiply Lambda invocations invisibly.
+
+        A missing/empty endpoints entry raises ResponseError instead of the
+        sibling methods' critical+exit: the batch path has a designed fallback
+        (kill-switch -> single path), so config drift here must degrade the
+        run, never kill it.
+        """
+        # config mode
+        mode = mode if mode is not None else self._mode
+
+        # validate params
+        if mode != 'worker':
+            logger.critical(f'Endpoint "get_video_view_trimmed_batch" is worker-only '
+                            f'(no direct API serves the batch contract), got mode: {mode}.')
+            exit(1)
+
+        params = {'aids': ','.join(str(aid) for aid in aids)}
+
+        # get endpoint url (worker-only). Unlike the siblings, missing config
+        # is a loud *recoverable* failure -- see docstring.
+        try:
+            url = random.choice(
+                self.endpoints['get_video_view_trimmed_batch']['workers'])
+        except (KeyError, IndexError):
+            logger.error('Endpoint "get_video_view_trimmed_batch" not found or has no '
+                         'worker configured; treating as whole-batch failure.')
+            raise ResponseError('video_view_trimmed_batch', params)
+
+        # get response (batch-specific timeout/deadline; single whole-batch
+        # trial, see docstring)
+        response = self._get(url, params=params, headers=headers,
+                             retry=1, timeout=BATCH_READ_TIMEOUT_S,
+                             deadline=BATCH_DEADLINE_S)
+        if response is None:
+            raise ResponseError('video_view_trimmed_batch', params)
+
+        def misaligned(message: str):
+            return MisalignmentError('video_view_trimmed_batch', params, response, message)
+
+        # validate the batch envelope. The v check is the double insurance
+        # against a config error pointing this path at a non-batch endpoint
+        # (e.g. the single-aid worker answers ?aids= with an upstream -400
+        # passthrough -- valid JSON, no v).
+        if not isinstance(response, dict) or response.get('v') != BATCH_PROTOCOL_VERSION:
+            raise misaligned(f'Response is not a batch protocol v{BATCH_PROTOCOL_VERSION} envelope.')
+        if response.get('requested') != len(aids):
+            raise misaligned(f'Response requested {response.get("requested")} != {len(aids)} aids sent.')
+        results = response.get('results')
+        if not isinstance(results, list) or len(results) != len(aids):
+            raise misaligned(f'Response results is not a list of length {len(aids)}.')
+
+        # validate items: same order as the input, each judged independently
+        items: list[VideoViewTrimmedBatchItem] = []
+        for index, (aid, item) in enumerate(zip(aids, results)):
+            item_params = {'aid': aid}
+            if not isinstance(item, dict):
+                raise misaligned(f'Result {index} is not a dict.')
+            # aid echo: the worker echoes the raw token, and we sent str(aid)
+            if item.get('aid') != str(aid):
+                raise misaligned(
+                    f'Result {index} echoes aid {item.get("aid")!r}, expected {str(aid)!r}.')
+            kind = item.get('kind')
+
+            if kind in ('item_timeout', 'fetch_error', 'non_json'):
+                # transient, this item only. non_json matches the single path,
+                # where an unparsable body is retried then given up on.
+                items.append(VideoViewTrimmedBatchItem(
+                    aid=aid, view=None,
+                    error=ResponseError('video_view_trimmed_batch_item',
+                                        {**item_params, 'kind': kind})))
+                continue
+
+            if kind != 'json':
+                raise misaligned(f'Result {index} has unknown kind {kind!r}.')
+
+            body = item.get('body')
+            if not isinstance(body, dict):
+                raise misaligned(f'Result {index} kind json has no dict body.')
+
+            # non-200 upstream: NEVER trust the body, code == 0 included --
+            # the single path retries non-200 without parsing (see _get), so
+            # trusting it here would be a semantic change, not a batch detail
+            if item.get('status') != 200:
+                items.append(VideoViewTrimmedBatchItem(
+                    aid=aid, view=None,
+                    error=ResponseError('video_view_trimmed_batch_item',
+                                        {**item_params, 'kind': kind,
+                                         'status': item.get('status')})))
+                continue
+
+            # from here on: same check set as get_video_view_trimmed, except
+            # any violation is a misalignment (the batch worker BUILT this
+            # envelope; a malformed one means the path is broken, not that one
+            # video is odd), plus the identity checks
+            for key in ['code', 'message', 'ttl']:
+                if key not in body.keys():
+                    raise misaligned(f'Result {index} body should contain key {key}.')
+
+            if body['code'] != 0:
+                # upstream said no -- identical semantics to the single-path
+                # CodeError (same target so downstream logging matches)
+                items.append(VideoViewTrimmedBatchItem(
+                    aid=aid, view=None,
+                    error=CodeError('video_view_trimmed', item_params, body, body['code'])))
+                continue
+
+            if type(body.get('data')) != dict:
+                raise misaligned(f'Result {index} body data should be a dict.')
+            data = body['data']
+            for key in ['bvid', 'aid', 'stat']:
+                if key not in data.keys():
+                    raise misaligned(f'Result {index} body data should contain key {key}.')
+            if type(data['stat']) != dict:
+                raise misaligned(f'Result {index} body data stat should be a dict.')
+            stat = data['stat']
+            for key in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share',
+                        'now_rank', 'his_rank', 'like', 'dislike']:
+                if key not in stat.keys():
+                    raise misaligned(f'Result {index} body data stat should contain key {key}.')
+
+            # identity checks: strong misrouting/misalignment detectors. bvid
+            # is independently computable from aid, so a payload from another
+            # video (or another endpoint) cannot satisfy both.
+            if data['aid'] != aid:
+                raise misaligned(f'Result {index} body data aid {data["aid"]!r} != {aid}.')
+            if data['bvid'] != 'BV' + a2b(aid):
+                raise misaligned(
+                    f'Result {index} body data bvid {data["bvid"]!r} != computed for aid {aid}.')
+            if stat['aid'] not in (aid, 0):  # 0 has upstream precedent (see task.py)
+                raise misaligned(f'Result {index} body data stat aid {stat["aid"]!r} != {aid} or 0.')
+
+            items.append(VideoViewTrimmedBatchItem(
+                aid=aid,
+                view=VideoViewTrimmed(
+                    bvid=data['bvid'],
+                    aid=data['aid'],
+                    stat=VideoViewStat(
+                        aid=stat['aid'],
+                        view=stat['view'],
+                        danmaku=stat['danmaku'],
+                        reply=stat['reply'],
+                        favorite=stat['favorite'],
+                        coin=stat['coin'],
+                        share=stat['share'],
+                        now_rank=stat['now_rank'],
+                        his_rank=stat['his_rank'],
+                        like=stat['like'],
+                        dislike=stat['dislike'],
+                        vt=stat.get('vt', None),
+                        vv=stat.get('vv', None),
+                    ),
+                ),
+                error=None))
+
+        return items
 
     def get_video_tags(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,

--- a/service/Service.py
+++ b/service/Service.py
@@ -22,7 +22,9 @@ logger = logging.getLogger('Service')
 RequestMode = Literal['direct', 'worker']
 
 __all__ = ['Service', 'RequestMode',
-           'BATCH_PROTOCOL_VERSION', 'BATCH_READ_TIMEOUT_S', 'BATCH_DEADLINE_S']
+           'VIDEO_VIEW_TRIMMED_BATCH_PROTOCOL_VERSION',
+           'VIDEO_VIEW_TRIMMED_BATCH_READ_TIMEOUT_S',
+           'VIDEO_VIEW_TRIMMED_BATCH_DEADLINE_S']
 
 # --- trimmed video_view batch path tunables ---------------------------------
 # INITIAL HYPOTHESES pending load-test calibration against the deployed batch
@@ -36,9 +38,9 @@ __all__ = ['Service', 'RequestMode',
 # of headroom per step -- the single-path incident where client timeout ==
 # function timeout (5s == 5s) turned worker-side timeouts into opaque
 # client-side ones, and this chain is how that stays fixed.
-BATCH_PROTOCOL_VERSION = 1
-BATCH_READ_TIMEOUT_S = 8.0
-BATCH_DEADLINE_S = 12.0
+VIDEO_VIEW_TRIMMED_BATCH_PROTOCOL_VERSION = 1
+VIDEO_VIEW_TRIMMED_BATCH_READ_TIMEOUT_S = 8.0
+VIDEO_VIEW_TRIMMED_BATCH_DEADLINE_S = 12.0
 
 
 class Service:
@@ -594,8 +596,8 @@ class Service:
         # get response (batch-specific timeout/deadline; single whole-batch
         # trial, see docstring)
         response = self._get(url, params=params, headers=headers,
-                             retry=1, timeout=BATCH_READ_TIMEOUT_S,
-                             deadline=BATCH_DEADLINE_S)
+                             retry=1, timeout=VIDEO_VIEW_TRIMMED_BATCH_READ_TIMEOUT_S,
+                             deadline=VIDEO_VIEW_TRIMMED_BATCH_DEADLINE_S)
         if response is None:
             raise ResponseError('video_view_trimmed_batch', params)
 
@@ -605,11 +607,16 @@ class Service:
         # validate the batch envelope. The v check is the double insurance
         # against a config error pointing this path at a non-batch endpoint
         # (e.g. the single-aid worker answers ?aids= with an upstream -400
-        # passthrough -- valid JSON, no v).
-        if not isinstance(response, dict) or response.get('v') != BATCH_PROTOCOL_VERSION:
-            raise misaligned(f'Response is not a batch protocol v{BATCH_PROTOCOL_VERSION} envelope.')
-        if response.get('requested') != len(aids):
-            raise misaligned(f'Response requested {response.get("requested")} != {len(aids)} aids sent.')
+        # passthrough -- valid JSON, no v). Protocol fields are checked
+        # strictly by TYPE as well as value: bool == int in Python, so
+        # without `type(x) is int` a JSON `true` would pass a `== 1` check.
+        version = response.get('v') if isinstance(response, dict) else None
+        if type(version) is not int or version != VIDEO_VIEW_TRIMMED_BATCH_PROTOCOL_VERSION:
+            raise misaligned(f'Response is not a batch protocol '
+                             f'v{VIDEO_VIEW_TRIMMED_BATCH_PROTOCOL_VERSION} envelope.')
+        requested = response.get('requested')
+        if type(requested) is not int or requested != len(aids):
+            raise misaligned(f'Response requested {requested!r} != {len(aids)} aids sent.')
         results = response.get('results')
         if not isinstance(results, list) or len(results) != len(aids):
             raise misaligned(f'Response results is not a list of length {len(aids)}.')
@@ -642,15 +649,22 @@ class Service:
             if not isinstance(body, dict):
                 raise misaligned(f'Result {index} kind json has no dict body.')
 
+            # the worker always sets an integer upstream status on json items;
+            # a missing or non-int one (bool included) is a contract violation,
+            # not an upstream hiccup to retry
+            status = item.get('status')
+            if type(status) is not int:
+                raise misaligned(f'Result {index} kind json has non-int status {status!r}.')
+
             # non-200 upstream: NEVER trust the body, code == 0 included --
             # the single path retries non-200 without parsing (see _get), so
             # trusting it here would be a semantic change, not a batch detail
-            if item.get('status') != 200:
+            if status != 200:
                 items.append(VideoViewTrimmedBatchItem(
                     aid=aid, view=None,
                     error=ResponseError('video_view_trimmed_batch_item',
                                         {**item_params, 'kind': kind,
-                                         'status': item.get('status')})))
+                                         'status': status})))
                 continue
 
             # from here on: same check set as get_video_view_trimmed, except

--- a/service/endpoints.json.example
+++ b/service/endpoints.json.example
@@ -9,6 +9,11 @@
     "workers": [
     ]
   },
+  "get_video_view_trimmed_batch": {
+    "direct": "invalid://api.bilibili.com/x/web-interface/view",
+    "workers": [
+    ]
+  },
   "get_video_tags": {
     "direct": "http://api.bilibili.com/x/tag/archive/tags",
     "workers": [

--- a/service/error.py
+++ b/service/error.py
@@ -1,6 +1,7 @@
 from core import TddError
 
-__all__ = ['ServiceError', 'ResponseError', 'ValidationError', 'FormatError', 'CodeError']
+__all__ = ['ServiceError', 'ResponseError', 'ValidationError', 'FormatError', 'CodeError',
+           'MisalignmentError']
 
 
 class ServiceError(TddError):
@@ -48,3 +49,24 @@ class CodeError(ValidationError):
 
     def __str__(self):
         return f'<CodeError(target={self.target},params={self.params},response={self.response},code={self.code})>'
+
+
+class MisalignmentError(ValidationError):
+    """
+    A batch response is structurally 200-OK JSON but violates the batch
+    contract or an item's identity checks (protocol version, results
+    order/length, aid echo, body.data.aid, bvid, stat.aid). Unlike FormatError
+    (one bad payload) this means the whole batch PATH cannot be trusted --
+    wrong endpoint, protocol break, or misrouted data -- so callers must
+    discard the entire batch result and trip their kill-switch, not skip the
+    offending item.
+    """
+
+    def __init__(self, target: str, params: dict, response: dict, message: str):
+        super().__init__(target, params, response)
+        self.message = message
+
+    def __str__(self):
+        # no self.response here: a full batch body can run to ~100KB (50 items
+        # x 2KB snippets) and this string lands in critical log lines
+        return f'<MisalignmentError(target={self.target},params={self.params},message={self.message})>'

--- a/service/response.py
+++ b/service/response.py
@@ -2,6 +2,7 @@ from typing import Optional, NamedTuple
 
 __all__ = [
     'VideoViewOwner', 'VideoViewStat', 'VideoViewStaffItem', 'VideoView', 'VideoViewTrimmed',
+    'VideoViewTrimmedBatchItem',
     'VideoTag', 'VideoTags',
     'MemberCard',
     'MemberRelation',
@@ -67,6 +68,24 @@ class VideoViewTrimmed(NamedTuple):
     bvid: str
     aid: int
     stat: VideoViewStat
+
+
+# per-aid outcome of Service.get_video_view_trimmed_batch. Exactly one of
+# view/error is set:
+# - view:  the item passed every check -- usable exactly like a single
+#          get_video_view_trimmed result
+# - error: CodeError     -> upstream said no (deleted/hidden/-403); route it
+#                           the same way as a single-path CodeError
+#          ResponseError -> transient per-item failure (item timeout, fetch
+#                           error, non-JSON upstream, non-200 upstream status);
+#                           the caller owns the retry, this item only
+# Failures that invalidate the WHOLE batch (transport failure, contract or
+# identity violation) never appear here -- get_video_view_trimmed_batch raises
+# for those instead of returning items.
+class VideoViewTrimmedBatchItem(NamedTuple):
+    aid: int
+    view: Optional[VideoViewTrimmed]
+    error: Optional[Exception]
 
 
 class VideoTag(NamedTuple):

--- a/task/task.py
+++ b/task/task.py
@@ -13,6 +13,7 @@ logger = logging.getLogger('task')
 
 __all__ = ['add_video_record_via_video_view',
            'fetch_video_record_via_video_view',
+           'build_video_record_via_video_view',
            'commit_video_records_batch',
            'commit_video_record_via_video_view',
            'commit_video_record_via_newlist_archive_stat',
@@ -21,6 +22,32 @@ __all__ = ['add_video_record_via_video_view',
            'add_member', 'update_member', 'commit_staff', 'add_member_follower_record',
            'fetch_member_follower_record', 'commit_member_follower_records_batch',
            'get_video_tags_str']
+
+
+def build_video_record_via_video_view(aid: int, video_view) -> RecordNew:
+    # Pure mapping: an already-fetched (and validated) trimmed video view ->
+    # RecordNew. Shared by the single-aid fetch below and the batch fetch path
+    # so quirks like the '--' hidden view count live in exactly one place.
+    added = get_ts_s()
+    view = -1 if video_view.stat.view == '--' else video_view.stat.view
+
+    return RecordNew(
+        added=added,
+        aid=aid,
+        bvid=video_view.bvid.lstrip('BV'),
+        view=view,
+        danmaku=video_view.stat.danmaku,
+        reply=video_view.stat.reply,
+        favorite=video_view.stat.favorite,
+        coin=video_view.stat.coin,
+        share=video_view.stat.share,
+        like=video_view.stat.like,
+        dislike=video_view.stat.dislike,
+        now_rank=video_view.stat.now_rank,
+        his_rank=video_view.stat.his_rank,
+        vt=video_view.stat.vt,
+        vv=video_view.stat.vv,
+    )
 
 
 def fetch_video_record_via_video_view(aid: int, service: Service,
@@ -42,26 +69,7 @@ def fetch_video_record_via_video_view(aid: int, service: Service,
     if out_stat is not None:
         out_stat['http_ms'] = int((time.perf_counter() - stage_start) * 1000)
 
-    added = get_ts_s()
-    view = -1 if video_view.stat.view == '--' else video_view.stat.view
-
-    return RecordNew(
-        added=added,
-        aid=aid,
-        bvid=video_view.bvid.lstrip('BV'),
-        view=view,
-        danmaku=video_view.stat.danmaku,
-        reply=video_view.stat.reply,
-        favorite=video_view.stat.favorite,
-        coin=video_view.stat.coin,
-        share=video_view.stat.share,
-        like=video_view.stat.like,
-        dislike=video_view.stat.dislike,
-        now_rank=video_view.stat.now_rank,
-        his_rank=video_view.stat.his_rank,
-        vt=video_view.stat.vt,
-        vv=video_view.stat.vv,
-    )
+    return build_video_record_via_video_view(aid, video_view)
 
 
 def add_video_record_via_video_view(aid: int, service: Service, session: Session,

--- a/task/task.py
+++ b/task/task.py
@@ -34,7 +34,10 @@ def build_video_record_via_video_view(aid: int, video_view) -> RecordNew:
     return RecordNew(
         added=added,
         aid=aid,
-        bvid=video_view.bvid.lstrip('BV'),
+        # removeprefix, not lstrip('BV'): lstrip strips any RUN of leading
+        # B/V characters. Identical output for every real bvid (they all
+        # start 'BV1'), but only removeprefix is correct by construction.
+        bvid=video_view.bvid.removeprefix('BV'),
         view=view,
         danmaku=video_view.stat.danmaku,
         reply=video_view.stat.reply,

--- a/tests/test_video_view_trimmed_batch_job.py
+++ b/tests/test_video_view_trimmed_batch_job.py
@@ -1,11 +1,15 @@
 """
-Tests for FetchVideoRecordJob's BATCH mode (batch assembly, per-item retry,
-kill-switch, single-path fallback) and the conf switch behind it.
+Tests for FetchVideoRecordJob's BATCH mode and its pool-shared
+VideoViewTrimmedBatchController: batch assembly, per-item retry, the
+concurrency gate on simultaneous batch invocations, the circuit breaker
+(including the in-flight-response race), single-path fallback, and the conf
+switch behind it all.
 
 The Service is a scripted mock; the DB layer is stubbed out at import time
 (fetch workers never touch the DB anyway -- the stub just satisfies the
-``job`` package's sibling imports). Wall-clock colddown sleeps inside the job
-module are patched to keep the suite fast.
+``job`` package's sibling imports). Synchronous tests drive ``process()``
+directly with the job module's colddown sleeps patched out; the concurrency
+and race tests run REAL job threads against services that block on events.
 
 Run from the repo root:
 
@@ -15,6 +19,8 @@ Run from the repo root:
 import importlib.util
 import os
 import sys
+import threading
+import time
 import types
 import unittest
 import unittest.mock
@@ -30,6 +36,7 @@ if 'db' not in sys.modules:
     _fake_db = types.ModuleType('db')
     _fake_db.__getattr__ = lambda name: type(name, (), {})
     sys.modules['db'] = _fake_db
+
 
 def _load_real_conf_module():
     """
@@ -50,7 +57,7 @@ try:
         ResponseError, CodeError, MisalignmentError,
         VideoViewTrimmed, VideoViewStat, VideoViewTrimmedBatchItem)
     from job import (  # noqa: E402
-        FetchVideoRecordJob, VideoViewTrimmedBatchConfig, VideoViewTrimmedBatchState)
+        FetchVideoRecordJob, VideoViewTrimmedBatchConfig, VideoViewTrimmedBatchController)
     from task import build_video_record_via_video_view  # noqa: E402
     from util import a2b  # noqa: E402
 except ImportError as e:  # pragma: no cover -- e.g. requests not installed
@@ -60,6 +67,8 @@ conf_module = _load_real_conf_module()
 get_video_view_trimmed_batch_conf = conf_module.get_video_view_trimmed_batch_conf
 
 import configparser  # noqa: E402
+
+EVENT_TIMEOUT_S = 10  # generous guard so a broken sync can never hang the suite
 
 
 def make_view(aid, view=100):
@@ -85,6 +94,13 @@ def retryable_item(aid):
         aid=aid, view=None,
         error=ResponseError('video_view_trimmed_batch_item',
                             {'aid': aid, 'kind': 'item_timeout'}))
+
+
+def make_controller(batch_size=2, batch_fraction=1.0, max_concurrent_batches=30,
+                    max_attempts=3):
+    return VideoViewTrimmedBatchController(VideoViewTrimmedBatchConfig(
+        batch_size=batch_size, batch_fraction=batch_fraction,
+        max_concurrent_batches=max_concurrent_batches, max_attempts=max_attempts))
 
 
 class ScriptedService:
@@ -128,40 +144,40 @@ class NoBatchService(ScriptedService):
         raise AssertionError('batch path must not be used')
 
 
-def run_job(service, aids, batch_config, batch_state=None,
-            code_error_queue=True):
-    """Build a job over a prefilled aid queue, run its loop synchronously
-    (no thread), return (job, records, code_error_aids)."""
+def make_job(service, aids, controller, duration_limit_s=None):
+    """Build a job over its own prefilled aid queue (not started)."""
     aid_queue = Queue()
     for aid in aids:
         aid_queue.put(aid)
     record_queue = Queue()
-    code_error_aid_queue = Queue() if code_error_queue else None
+    code_error_aid_queue = Queue()
     job = FetchVideoRecordJob(
         'job_test', aid_queue, record_queue, service,
         code_error_aid_queue=code_error_aid_queue,
-        batch_config=batch_config, batch_state=batch_state)
+        duration_limit_s=duration_limit_s,
+        batch_controller=controller)
     job.logger.disabled = True  # the failure paths log loudly on purpose
+    return job, record_queue, code_error_aid_queue
 
+
+def drain(queue):
+    out = []
+    while not queue.empty():
+        out.append(queue.get())
+    return out
+
+
+def run_job(service, aids, controller):
+    """Run one job's loop synchronously (no thread), colddown sleeps patched
+    out. Returns (job, records, code_error_aids)."""
+    job, record_queue, code_error_aid_queue = make_job(service, aids, controller)
     # keep the retry colddowns out of the test wall clock (time.perf_counter
     # must stay real -- the job measures batch latency with it)
-    import time as real_time
     fake_time = types.SimpleNamespace(
-        sleep=lambda s: None, perf_counter=real_time.perf_counter)
+        sleep=lambda s: None, perf_counter=time.perf_counter)
     with unittest.mock.patch('job.FetchVideoRecordJob.time', fake_time):
         job.process()
-
-    records = []
-    while not record_queue.empty():
-        records.append(record_queue.get())
-    code_error_aids = []
-    if code_error_aid_queue is not None:
-        while not code_error_aid_queue.empty():
-            code_error_aids.append(code_error_aid_queue.get())
-    return job, records, code_error_aids
-
-
-ALWAYS = VideoViewTrimmedBatchConfig(batch_size=2, batch_fraction=1.0)
+    return job, drain(record_queue), drain(code_error_aid_queue)
 
 
 class TestBatchHappyPath(unittest.TestCase):
@@ -169,7 +185,7 @@ class TestBatchHappyPath(unittest.TestCase):
     def test_records_flow_through_batches(self):
         service = ScriptedService()
         aids = [101, 102, 103, 104]
-        job, records, _ = run_job(service, aids, ALWAYS, VideoViewTrimmedBatchState())
+        job, records, _ = run_job(service, aids, make_controller())
 
         self.assertEqual(service.batch_calls, [[101, 102], [103, 104]])
         self.assertEqual(service.single_calls, [])
@@ -182,8 +198,7 @@ class TestBatchHappyPath(unittest.TestCase):
 
     def test_partial_batch_flushes_when_queue_drains(self):
         service = ScriptedService()
-        job, records, _ = run_job(
-            service, [101, 102, 103], ALWAYS, VideoViewTrimmedBatchState())
+        job, records, _ = run_job(service, [101, 102, 103], make_controller())
 
         self.assertEqual(service.batch_calls, [[101, 102], [103]])
         self.assertEqual(len(records), 3)
@@ -191,8 +206,7 @@ class TestBatchHappyPath(unittest.TestCase):
     def test_code_error_routes_to_update_queue(self):
         service = ScriptedService(batch_script=[
             lambda aids: [ok_item(aids[0]), code_error_item(aids[1])]])
-        job, records, code_error_aids = run_job(
-            service, [101, 102], ALWAYS, VideoViewTrimmedBatchState())
+        job, records, code_error_aids = run_job(service, [101, 102], make_controller())
 
         self.assertEqual([r.aid for r in records], [101])
         self.assertEqual(code_error_aids, [102])
@@ -202,8 +216,7 @@ class TestBatchHappyPath(unittest.TestCase):
 
     def test_duplicate_aid_in_buffer_takes_single_path(self):
         service = ScriptedService()
-        job, records, _ = run_job(
-            service, [101, 101, 102], ALWAYS, VideoViewTrimmedBatchState())
+        job, records, _ = run_job(service, [101, 101, 102], make_controller())
 
         # never the same token twice in one batch: the second 101 goes single
         self.assertEqual(service.batch_calls, [[101, 102]])
@@ -217,8 +230,7 @@ class TestPerItemRetry(unittest.TestCase):
     def test_only_failed_items_are_retried(self):
         service = ScriptedService(batch_script=[
             lambda aids: [ok_item(aids[0]), retryable_item(aids[1])]])
-        job, records, _ = run_job(
-            service, [101, 102], ALWAYS, VideoViewTrimmedBatchState())
+        job, records, _ = run_job(service, [101, 102], make_controller())
 
         # retry batch contains ONLY the failed item
         self.assertEqual(service.batch_calls, [[101, 102], [102]])
@@ -229,8 +241,7 @@ class TestPerItemRetry(unittest.TestCase):
     def test_attempts_exhausted_becomes_other_exception(self):
         service = ScriptedService(batch_script=[
             lambda aids: [retryable_item(aids[0])]] * 3)
-        job, records, _ = run_job(
-            service, [101], ALWAYS, VideoViewTrimmedBatchState())
+        job, records, _ = run_job(service, [101], make_controller())
 
         # max_attempts=3 total tries, aligned with the single path's retry=3
         self.assertEqual(service.batch_calls, [[101], [101], [101]])
@@ -240,82 +251,233 @@ class TestPerItemRetry(unittest.TestCase):
         self.assertEqual(job.stat.total_count, 1)
 
 
-class TestWholeBatchFailureAndKillSwitch(unittest.TestCase):
+class TestWholeBatchFailureAndBreaker(unittest.TestCase):
 
     def test_whole_batch_failure_charges_every_aid_one_attempt(self):
         service = ScriptedService(batch_script=[
             ResponseError('video_view_trimmed_batch', {})])
-        state = VideoViewTrimmedBatchState()
-        job, records, _ = run_job(service, [101, 102], ALWAYS, state)
+        controller = make_controller()
+        job, records, _ = run_job(service, [101, 102], controller)
 
         # failure, then a successful retry batch with BOTH aids
         self.assertEqual(service.batch_calls, [[101, 102], [101, 102]])
         self.assertEqual(sorted(r.aid for r in records), [101, 102])
         self.assertEqual(job.stat.condition['batch_whole_failure'], 1)
-        self.assertTrue(state.is_enabled())  # one failure does not trip
-
-    def test_three_consecutive_whole_batch_failures_trip_the_kill_switch(self):
-        service = ScriptedService(batch_script=[
-            ResponseError('video_view_trimmed_batch', {})] * 3)
-        state = VideoViewTrimmedBatchState()
-        job, records, _ = run_job(service, [101, 102], ALWAYS, state)
-
-        self.assertEqual(job.stat.condition['batch_whole_failure'], 3)
-        self.assertFalse(state.is_enabled())
-        # the batch's aids came back over the single path -- no data lost
-        self.assertEqual(sorted(service.single_calls), [101, 102])
-        self.assertEqual(sorted(r.aid for r in records), [101, 102])
-        self.assertEqual(job.stat.condition['batch_fallback_single'], 2)
+        self.assertTrue(controller.is_enabled())  # one failure does not trip
 
     def test_unexpected_exception_is_a_whole_batch_failure_not_a_dead_thread(self):
         # a bug-shaped exception must degrade like a transport failure, never
         # kill the worker thread mid-run
         service = ScriptedService(batch_script=[ValueError('boom')])
-        state = VideoViewTrimmedBatchState()
-        job, records, _ = run_job(service, [101, 102], ALWAYS, state)
+        job, records, _ = run_job(service, [101, 102], make_controller())
 
         self.assertEqual(job.stat.condition['batch_whole_failure'], 1)
         self.assertEqual(sorted(r.aid for r in records), [101, 102])
 
-    def test_batch_success_resets_the_consecutive_counter(self):
-        state = VideoViewTrimmedBatchState()
-        state.record_whole_batch_failure()
-        state.record_whole_batch_failure()
-        state.record_batch_success()
-        self.assertFalse(state.record_whole_batch_failure())  # back to 1
-        self.assertTrue(state.is_enabled())
+    def test_three_consecutive_whole_batch_failures_trip_the_breaker(self):
+        service = ScriptedService(batch_script=[
+            ResponseError('video_view_trimmed_batch', {})] * 3)
+        controller = make_controller()
+        job, records, _ = run_job(service, [101, 102], controller)
+
+        self.assertEqual(job.stat.condition['batch_whole_failure'], 3)
+        self.assertFalse(controller.is_enabled())
+        # the batch's aids came back over the single path -- no data lost
+        self.assertEqual(sorted(service.single_calls), [101, 102])
+        self.assertEqual(sorted(r.aid for r in records), [101, 102])
+        self.assertEqual(job.stat.condition['batch_fallback_single'], 2)
+
+    def test_breaker_counts_in_completion_order_and_success_resets(self):
+        # the documented definition: N failures recorded with no validated
+        # success recorded between them, in COMPLETION order -- interleaved
+        # successes (e.g. from other in-flight batches) reset the streak
+        controller = make_controller()
+        self.assertFalse(controller.record_whole_batch_failure())  # 1
+        self.assertFalse(controller.record_whole_batch_failure())  # 2
+        controller.record_batch_success()                          # reset
+        self.assertFalse(controller.record_whole_batch_failure())  # 1
+        self.assertFalse(controller.record_whole_batch_failure())  # 2
+        self.assertTrue(controller.is_enabled())
+        self.assertTrue(controller.record_whole_batch_failure())   # 3 -> trip
+        self.assertFalse(controller.is_enabled())
 
     def test_misalignment_trips_immediately_and_falls_back(self):
         service = ScriptedService(batch_script=[
             MisalignmentError('video_view_trimmed_batch', {}, {}, 'aid echo mismatch')])
-        state = VideoViewTrimmedBatchState()
-        job, records, _ = run_job(service, [101, 102, 103, 104], ALWAYS, state)
+        controller = make_controller()
+        job, records, _ = run_job(service, [101, 102, 103, 104], controller)
 
         # exactly ONE batch call; its aids and every later aid go single path
         self.assertEqual(service.batch_calls, [[101, 102]])
-        self.assertFalse(state.is_enabled())
+        self.assertFalse(controller.is_enabled())
         self.assertEqual(sorted(service.single_calls), [101, 102, 103, 104])
         self.assertEqual(sorted(r.aid for r in records), [101, 102, 103, 104])
         self.assertEqual(job.stat.condition['batch_misalignment'], 1)
         self.assertEqual(job.stat.condition['batch_fallback_single'], 2)
 
-    def test_kill_switch_is_shared_across_jobs(self):
-        # a state tripped by one job disables the path for its siblings
-        state = VideoViewTrimmedBatchState()
-        self.assertTrue(state.trip('misalignment seen by job_0'))
-        self.assertFalse(state.trip('job_1 saw it too'))  # only first trips
+    def test_breaker_is_shared_across_jobs(self):
+        # a controller tripped by one job disables the path for its siblings
+        controller = make_controller()
+        self.assertTrue(controller.trip('misalignment seen by job_0'))
+        self.assertFalse(controller.trip('job_1 saw it too'))  # only first trips
 
         service = NoBatchService()
-        job, records, _ = run_job(service, [101, 102], ALWAYS, state)
+        job, records, _ = run_job(service, [101, 102], controller)
         self.assertEqual(sorted(r.aid for r in records), [101, 102])
         self.assertEqual(service.single_calls, [101, 102])
 
 
+class BlockingBatchService(ScriptedService):
+    """Batch calls track in-flight concurrency and block until released."""
+
+    def __init__(self, hold_s=0.0, release_event=None):
+        super().__init__()
+        self._lock = threading.Lock()
+        self._in_flight = 0
+        self.max_in_flight = 0
+        self.hold_s = hold_s
+        self.release_event = release_event
+        self.entered = threading.Event()  # set when any batch call is in flight
+
+    def get_video_view_trimmed_batch(self, aids, **kwargs):
+        with self._lock:
+            self.batch_calls.append(list(aids))
+            self._in_flight += 1
+            self.max_in_flight = max(self.max_in_flight, self._in_flight)
+        self.entered.set()
+        try:
+            if self.release_event is not None:
+                assert self.release_event.wait(EVENT_TIMEOUT_S), 'release never came'
+            elif self.hold_s:
+                time.sleep(self.hold_s)
+            return [ok_item(aid) for aid in aids]
+        finally:
+            with self._lock:
+                self._in_flight -= 1
+
+
+class TestConcurrencyGate(unittest.TestCase):
+    """Real threads: the gate must bound SIMULTANEOUS batch invocations."""
+
+    def test_in_flight_batches_never_exceed_the_cap(self):
+        cap = 2
+        controller = make_controller(batch_size=2, max_concurrent_batches=cap)
+        service = BlockingBatchService(hold_s=0.02)
+        aid_queue = Queue()
+        for aid in range(1, 49):  # 48 aids -> 24 batches
+            aid_queue.put(aid)
+        record_queue = Queue()
+        jobs = []
+        for i in range(6):  # 6 threads contending for 2 slots
+            job = FetchVideoRecordJob(
+                f'job_{i}', aid_queue, record_queue, service,
+                code_error_aid_queue=Queue(), batch_controller=controller)
+            job.logger.disabled = True
+            jobs.append(job)
+        for job in jobs:
+            job.start()
+        for job in jobs:
+            job.join(EVENT_TIMEOUT_S)
+            self.assertFalse(job.is_alive(), 'job did not finish')
+
+        self.assertLessEqual(service.max_in_flight, cap)
+        self.assertEqual(len(drain(record_queue)), 48)  # nothing lost to the gate
+        # observability: with 24 batches over 2 slots the gate must have bitten
+        throttled = sum(j.stat.condition['batch_concurrency_throttled'] for j in jobs)
+        self.assertGreaterEqual(throttled, 1)
+
+    def test_deadline_while_waiting_for_a_slot_exits_cleanly(self):
+        # job A holds the only slot with its batch blocked in flight; job B
+        # must give up at its run deadline instead of waiting forever
+        release = threading.Event()
+        controller = make_controller(batch_size=1, max_concurrent_batches=1)
+        service = BlockingBatchService(release_event=release)
+
+        job_a, records_a, _ = make_job(service, [301], controller)
+        job_b, records_b, _ = make_job(service, [302], controller,
+                                       duration_limit_s=1)
+        job_a.start()
+        self.assertTrue(service.entered.wait(EVENT_TIMEOUT_S))  # A holds the slot
+        job_b.start()
+        job_b.join(EVENT_TIMEOUT_S)
+        self.assertFalse(job_b.is_alive(), 'job B hung waiting for a slot')
+        release.set()
+        job_a.join(EVENT_TIMEOUT_S)
+        self.assertFalse(job_a.is_alive())
+
+        self.assertEqual(job_b.stat.condition['duration_limit_reached'], 1)
+        self.assertEqual(job_b.stat.condition['batch_concurrency_throttled'], 1)
+        self.assertEqual(drain(records_b), [])  # 302 dropped at the deadline
+        self.assertEqual([r.aid for r in drain(records_a)], [301])
+
+
+class RaceBatchService(ScriptedService):
+    """
+    Orchestrates the breaker/in-flight race: job B's batch (aids starting at
+    201) blocks in flight; job A's batch (101...) waits until B is in flight,
+    then fails with a misalignment, tripping the breaker. B's response then
+    returns AFTER the trip and must be discarded by the job.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._lock = threading.Lock()
+        self.b_in_flight = threading.Event()
+        self.b_release = threading.Event()
+
+    def get_video_view_trimmed_batch(self, aids, **kwargs):
+        with self._lock:
+            self.batch_calls.append(list(aids))
+        if aids[0] == 201:  # job B
+            self.b_in_flight.set()
+            assert self.b_release.wait(EVENT_TIMEOUT_S), 'b_release never came'
+            return [ok_item(aid) for aid in aids]
+        # job A: only misalign once B is provably in flight
+        assert self.b_in_flight.wait(EVENT_TIMEOUT_S), 'B never got in flight'
+        raise MisalignmentError('video_view_trimmed_batch', {}, {}, 'aid echo mismatch')
+
+    def get_video_view_trimmed(self, params, **kwargs):
+        with self._lock:
+            self.single_calls.append(params['aid'])
+        return make_view(params['aid'])
+
+
+class TestBreakerInFlightRace(unittest.TestCase):
+
+    def test_response_in_flight_during_trip_is_discarded_and_refetched(self):
+        controller = make_controller(batch_size=2, max_concurrent_batches=2)
+        service = RaceBatchService()
+        job_b, records_b, _ = make_job(service, [201, 202], controller)
+        job_a, records_a, _ = make_job(service, [101, 102], controller)
+
+        job_b.start()
+        self.assertTrue(service.b_in_flight.wait(EVENT_TIMEOUT_S))
+        job_a.start()
+        job_a.join(EVENT_TIMEOUT_S)  # A misaligns, trips, falls back, finishes
+        self.assertFalse(job_a.is_alive())
+        self.assertFalse(controller.is_enabled())
+        # only now does B's (healthy-looking) response come back
+        service.b_release.set()
+        job_b.join(EVENT_TIMEOUT_S)
+        self.assertFalse(job_b.is_alive())
+
+        # B re-checked the breaker on return: response discarded wholesale,
+        # its aids refetched over the single path -- nothing lost, nothing
+        # written from the untrusted response, nothing duplicated
+        self.assertEqual(job_b.stat.condition['batch_discarded_after_trip'], 1)
+        self.assertEqual(sorted(service.single_calls), [101, 102, 201, 202])
+        self.assertEqual(sorted(r.aid for r in drain(records_a)), [101, 102])
+        self.assertEqual(sorted(r.aid for r in drain(records_b)), [201, 202])
+        self.assertEqual(job_b.stat.condition['batch_fallback_single'], 2)
+        # exactly one batch call each: neither job retried the dead path
+        self.assertEqual(len(service.batch_calls), 2)
+
+
 class TestBatchPathOff(unittest.TestCase):
 
-    def test_no_config_means_single_path_only(self):
+    def test_no_controller_means_single_path_only(self):
         service = NoBatchService()
-        job, records, _ = run_job(service, [101, 102], None, None)
+        job, records, _ = run_job(service, [101, 102], None)
 
         self.assertEqual(service.single_calls, [101, 102])
         self.assertEqual(sorted(r.aid for r in records), [101, 102])
@@ -325,9 +487,8 @@ class TestBatchPathOff(unittest.TestCase):
 
     def test_fraction_zero_never_batches(self):
         service = NoBatchService()
-        config = VideoViewTrimmedBatchConfig(batch_size=2, batch_fraction=0.0)
         job, records, _ = run_job(
-            service, [101, 102], config, VideoViewTrimmedBatchState())
+            service, [101, 102], make_controller(batch_fraction=0.0))
 
         self.assertEqual(service.single_calls, [101, 102])
         self.assertEqual(len(records), 2)
@@ -339,6 +500,38 @@ class TestRecordMapping(unittest.TestCase):
         record = build_video_record_via_video_view(101, make_view(101, view='--'))
         self.assertEqual(record.view, -1)
         self.assertEqual(record.bvid, a2b(101))  # BV prefix stripped
+
+    def test_every_field_maps_through(self):
+        aid = 456930
+        view = VideoViewTrimmed(
+            bvid='BV' + a2b(aid), aid=aid,
+            stat=VideoViewStat(aid=aid, view=11, danmaku=12, reply=13,
+                               favorite=14, coin=15, share=16, now_rank=17,
+                               his_rank=18, like=19, dislike=20, vt=21, vv=22))
+        record = build_video_record_via_video_view(aid, view)
+
+        self.assertEqual(record.aid, aid)
+        self.assertEqual(record.bvid, a2b(aid))
+        self.assertEqual(record.view, 11)
+        self.assertEqual(record.danmaku, 12)
+        self.assertEqual(record.reply, 13)
+        self.assertEqual(record.favorite, 14)
+        self.assertEqual(record.coin, 15)
+        self.assertEqual(record.share, 16)
+        self.assertEqual(record.now_rank, 17)
+        self.assertEqual(record.his_rank, 18)
+        self.assertEqual(record.like, 19)
+        self.assertEqual(record.dislike, 20)
+        self.assertEqual(record.vt, 21)
+        self.assertEqual(record.vv, 22)
+        self.assertGreater(record.added, 0)
+
+    def test_bvid_prefix_removal_is_removeprefix_not_lstrip(self):
+        # lstrip('BV') would strip any run of leading B/V characters; the
+        # mapping must remove exactly one 'BV' prefix
+        view = make_view(101)._replace(bvid='BVVB1x')
+        self.assertEqual(
+            build_video_record_via_video_view(101, view).bvid, 'VB1x')
 
 
 class TestConf(unittest.TestCase):
@@ -352,40 +545,55 @@ class TestConf(unittest.TestCase):
 
     def test_missing_section_is_disabled(self):
         self._with_config('[db_mysql]\nuser = u\n')
-        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0, 0))
 
     def test_enabled_values_pass_through(self):
         self._with_config(
+            '[video_view_trimmed_batch]\nbatch_size = 10\nbatch_fraction = 0.05\n'
+            'max_concurrent_batches = 20\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (10, 0.05, 20))
+
+    def test_max_concurrent_defaults_when_absent(self):
+        self._with_config(
             '[video_view_trimmed_batch]\nbatch_size = 10\nbatch_fraction = 0.05\n')
-        self.assertEqual(get_video_view_trimmed_batch_conf(), (10, 0.05))
+        self.assertEqual(
+            get_video_view_trimmed_batch_conf(),
+            (10, 0.05, conf_module.VIDEO_VIEW_TRIMMED_BATCH_MAX_CONCURRENT_DEFAULT))
 
     def test_zero_size_or_fraction_is_disabled(self):
         self._with_config(
             '[video_view_trimmed_batch]\nbatch_size = 0\nbatch_fraction = 1\n')
-        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0, 0))
         self._with_config(
             '[video_view_trimmed_batch]\nbatch_size = 10\nbatch_fraction = 0\n')
-        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0, 0))
+
+    def test_nonpositive_concurrency_disables_the_path(self):
+        # a cap <= 0 would deadlock the gate; fail safe to off, never guess
+        self._with_config(
+            '[video_view_trimmed_batch]\nbatch_size = 10\nbatch_fraction = 1\n'
+            'max_concurrent_batches = 0\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0, 0))
 
     def test_negative_values_are_disabled(self):
         self._with_config(
             '[video_view_trimmed_batch]\nbatch_size = -5\nbatch_fraction = 0.5\n')
-        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0, 0))
 
     def test_size_is_capped_at_worker_max(self):
         self._with_config(
             '[video_view_trimmed_batch]\nbatch_size = 100\nbatch_fraction = 1\n')
-        self.assertEqual(get_video_view_trimmed_batch_conf(), (50, 1.0))
+        self.assertEqual(get_video_view_trimmed_batch_conf()[0], 50)
 
     def test_fraction_is_clamped_to_one(self):
         self._with_config(
             '[video_view_trimmed_batch]\nbatch_size = 10\nbatch_fraction = 1.5\n')
-        self.assertEqual(get_video_view_trimmed_batch_conf(), (10, 1.0))
+        self.assertEqual(get_video_view_trimmed_batch_conf()[1], 1.0)
 
     def test_unparsable_values_are_disabled(self):
         self._with_config(
             '[video_view_trimmed_batch]\nbatch_size = lots\nbatch_fraction = 1\n')
-        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0, 0))
 
 
 if __name__ == '__main__':

--- a/tests/test_video_view_trimmed_batch_job.py
+++ b/tests/test_video_view_trimmed_batch_job.py
@@ -384,6 +384,33 @@ class TestConcurrencyGate(unittest.TestCase):
         self.assertEqual(drain(records_b), [])  # 302 dropped at the deadline
         self.assertEqual([r.aid for r in drain(records_a)], [301])
 
+    def test_deadline_during_final_partial_flush_still_counts_duration_limit(self):
+        # queue already EMPTY, job B is flushing its last partial batch (one
+        # aid, batch_size 2) and waits for the slot job A holds; the deadline
+        # passes during that wait. B breaks straight out after the drop -- the
+        # loop top never runs again -- so the drop path itself must record
+        # the duration-limit hit, exactly once.
+        release = threading.Event()
+        controller = make_controller(batch_size=2, max_concurrent_batches=1)
+        service = BlockingBatchService(release_event=release)
+
+        job_a, records_a, _ = make_job(service, [301, 302], controller)
+        job_b, records_b, _ = make_job(service, [303], controller,
+                                       duration_limit_s=1)
+        job_a.start()
+        self.assertTrue(service.entered.wait(EVENT_TIMEOUT_S))  # A holds the slot
+        job_b.start()
+        job_b.join(EVENT_TIMEOUT_S)
+        self.assertFalse(job_b.is_alive(), 'job B hung waiting for a slot')
+        release.set()
+        job_a.join(EVENT_TIMEOUT_S)
+        self.assertFalse(job_a.is_alive())
+
+        self.assertEqual(job_b.stat.condition['batch_dropped_at_deadline'], 1)
+        self.assertEqual(job_b.stat.condition['duration_limit_reached'], 1)
+        self.assertEqual(drain(records_b), [])
+        self.assertEqual(sorted(r.aid for r in drain(records_a)), [301, 302])
+
 
 class RaceBatchService(ScriptedService):
     """

--- a/tests/test_video_view_trimmed_batch_job.py
+++ b/tests/test_video_view_trimmed_batch_job.py
@@ -447,6 +447,126 @@ class TestBreakerInFlightRace(unittest.TestCase):
         self.assertEqual(len(service.batch_calls), 2)
 
 
+class GatedQueue(Queue):
+    """An aid queue whose Nth get_nowait blocks until `gate` is opened -- lets
+    a test freeze a job between two dequeues while another job acts."""
+
+    def __init__(self, gate_before_get_number):
+        super().__init__()
+        self.gate = threading.Event()
+        self._gate_before = gate_before_get_number
+        self._gets = 0
+
+    def get_nowait(self):
+        self._gets += 1
+        if self._gets == self._gate_before:
+            assert self.gate.wait(EVENT_TIMEOUT_S), 'gate never opened'
+        return super().get_nowait()
+
+
+class TestPartialBufferOnTrip(unittest.TestCase):
+
+    def test_job_holding_a_partial_buffer_flushes_it_when_the_breaker_opens(self):
+        # job A buffers 101 (batch_size 3, so no dispatch), then is frozen on
+        # its next dequeue; job B trips the breaker meanwhile. When A resumes
+        # it must resolve its buffered 101 over the single path BEFORE
+        # handling the aid it just dequeued -- not at queue-empty, not at the
+        # deadline.
+        controller = make_controller(batch_size=3, max_concurrent_batches=2)
+        service = RaceBatchService()  # B's 201-batch would block; unused here
+        service.get_video_view_trimmed_batch = lambda aids, **kw: (_ for _ in ()).throw(
+            MisalignmentError('video_view_trimmed_batch', {}, {}, 'aid echo mismatch'))
+
+        aid_queue_a = GatedQueue(gate_before_get_number=2)
+        for aid in (101, 102):
+            aid_queue_a.put(aid)
+        records_a = Queue()
+        job_a = FetchVideoRecordJob('job_a', aid_queue_a, records_a, service,
+                                    code_error_aid_queue=Queue(), batch_controller=controller)
+        job_a.logger.disabled = True
+        job_b, records_b, _ = make_job(service, [201, 202], controller)
+
+        job_a.start()
+        # A is now parked inside its second get_nowait with 101 buffered
+        job_b.start()
+        job_b.join(EVENT_TIMEOUT_S)
+        self.assertFalse(job_b.is_alive())
+        self.assertFalse(controller.is_enabled())  # B tripped it
+        aid_queue_a.gate.set()
+        job_a.join(EVENT_TIMEOUT_S)
+        self.assertFalse(job_a.is_alive())
+
+        # 101 (the buffer) was refetched before 102 (the fresh dequeue)
+        a_singles = [aid for aid in service.single_calls if aid in (101, 102)]
+        self.assertEqual(a_singles, [101, 102])
+        self.assertEqual(job_a.stat.condition['batch_fallback_single'], 1)
+        self.assertNotIn('batch_dropped_at_deadline', job_a.stat.condition)
+        self.assertEqual(sorted(r.aid for r in drain(records_a)), [101, 102])
+        self.assertEqual(sorted(r.aid for r in drain(records_b)), [201, 202])
+
+
+class SlotRaceService(ScriptedService):
+    """
+    Orchestrates the slot/breaker race: job A's batch (301...) holds the only
+    slot and blocks until `trip_now` is set, then fails with a misalignment
+    (tripping the breaker and releasing the slot). Job B, waiting for that
+    slot, then acquires it -- and must NOT send its batch.
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._lock = threading.Lock()
+        self.trip_now = threading.Event()
+
+    def get_video_view_trimmed_batch(self, aids, **kwargs):
+        with self._lock:
+            self.batch_calls.append(list(aids))
+        assert self.trip_now.wait(EVENT_TIMEOUT_S), 'trip_now never came'
+        raise MisalignmentError('video_view_trimmed_batch', {}, {}, 'aid echo mismatch')
+
+    def get_video_view_trimmed(self, params, **kwargs):
+        with self._lock:
+            self.single_calls.append(params['aid'])
+        return make_view(params['aid'])
+
+
+class TestSlotAcquiredAfterTrip(unittest.TestCase):
+
+    def test_waiter_that_gets_the_slot_after_a_trip_releases_it_and_falls_back(self):
+        controller = make_controller(batch_size=2, max_concurrent_batches=1)
+        service = SlotRaceService()
+        job_a, records_a, _ = make_job(service, [301, 302], controller)
+        job_b, records_b, _ = make_job(service, [303, 304], controller)
+
+        job_a.start()
+        deadline = time.time() + EVENT_TIMEOUT_S
+        while len(service.batch_calls) < 1:  # A holds the slot, in flight
+            self.assertLess(time.time(), deadline, 'A never got in flight')
+            time.sleep(0.005)
+        job_b.start()
+        while job_b.stat.condition['batch_concurrency_throttled'] < 1:  # B waits
+            self.assertLess(time.time(), deadline, 'B never waited for the slot')
+            time.sleep(0.005)
+        # another thread (A) trips the breaker and releases the slot while B
+        # is blocked waiting for it
+        service.trip_now.set()
+        job_a.join(EVENT_TIMEOUT_S)
+        job_b.join(EVENT_TIMEOUT_S)
+        self.assertFalse(job_a.is_alive())
+        self.assertFalse(job_b.is_alive())
+
+        self.assertFalse(controller.is_enabled())
+        # B acquired the freed slot but never sent: only A's batch exists
+        self.assertEqual(service.batch_calls, [[301, 302]])
+        self.assertEqual(job_b.stat.condition['batch_request'], 0)
+        self.assertEqual(job_b.stat.condition['batch_fallback_single'], 2)
+        self.assertEqual(sorted(r.aid for r in drain(records_b)), [303, 304])
+        self.assertEqual(sorted(r.aid for r in drain(records_a)), [301, 302])
+        # the slot B abandoned was given back: with cap=1 it is free again
+        self.assertTrue(controller.try_acquire_slot(0))
+        controller.release_slot()
+
+
 class TestBatchPathOff(unittest.TestCase):
 
     def test_no_controller_means_single_path_only(self):

--- a/tests/test_video_view_trimmed_batch_job.py
+++ b/tests/test_video_view_trimmed_batch_job.py
@@ -1,15 +1,15 @@
 """
 Tests for FetchVideoRecordJob's BATCH mode and its pool-shared
-VideoViewTrimmedBatchController: batch assembly, per-item retry, the
-concurrency gate on simultaneous batch invocations, the circuit breaker
-(including the in-flight-response race), single-path fallback, and the conf
-switch behind it all.
+VideoViewTrimmedBatchController: batch assembly, per-item routing with
+single-path fallback for every failure mode, the concurrency gate on
+simultaneous batch invocations, the circuit breaker (including the
+in-flight-response race), and the conf switch behind it all.
 
 The Service is a scripted mock; the DB layer is stubbed out at import time
 (fetch workers never touch the DB anyway -- the stub just satisfies the
 ``job`` package's sibling imports). Synchronous tests drive ``process()``
-directly with the job module's colddown sleeps patched out; the concurrency
-and race tests run REAL job threads against services that block on events.
+directly; the concurrency and race tests run REAL job threads against
+services that block on events.
 
 Run from the repo root:
 
@@ -23,7 +23,6 @@ import threading
 import time
 import types
 import unittest
-import unittest.mock
 from queue import Queue
 
 ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
@@ -89,18 +88,17 @@ def code_error_item(aid, code=-404):
         error=CodeError('video_view_trimmed', {'aid': aid}, {'code': code}, code))
 
 
-def retryable_item(aid):
+def transient_item(aid):
     return VideoViewTrimmedBatchItem(
         aid=aid, view=None,
         error=ResponseError('video_view_trimmed_batch_item',
                             {'aid': aid, 'kind': 'item_timeout'}))
 
 
-def make_controller(batch_size=2, batch_fraction=1.0, max_concurrent_batches=30,
-                    max_attempts=3):
+def make_controller(batch_size=2, batch_fraction=1.0, max_concurrent_batches=30):
     return VideoViewTrimmedBatchController(VideoViewTrimmedBatchConfig(
         batch_size=batch_size, batch_fraction=batch_fraction,
-        max_concurrent_batches=max_concurrent_batches, max_attempts=max_attempts))
+        max_concurrent_batches=max_concurrent_batches))
 
 
 class ScriptedService:
@@ -168,15 +166,10 @@ def drain(queue):
 
 
 def run_job(service, aids, controller):
-    """Run one job's loop synchronously (no thread), colddown sleeps patched
-    out. Returns (job, records, code_error_aids)."""
+    """Run one job's loop synchronously (no thread).
+    Returns (job, records, code_error_aids)."""
     job, record_queue, code_error_aid_queue = make_job(service, aids, controller)
-    # keep the retry colddowns out of the test wall clock (time.perf_counter
-    # must stay real -- the job measures batch latency with it)
-    fake_time = types.SimpleNamespace(
-        sleep=lambda s: None, perf_counter=time.perf_counter)
-    with unittest.mock.patch('job.FetchVideoRecordJob.time', fake_time):
-        job.process()
+    job.process()
     return job, drain(record_queue), drain(code_error_aid_queue)
 
 
@@ -225,81 +218,62 @@ class TestBatchHappyPath(unittest.TestCase):
         self.assertEqual(len(records), 3)
 
 
-class TestPerItemRetry(unittest.TestCase):
+class TestFailureFallback(unittest.TestCase):
+    """Every batch failure mode ends in the single-aid path; nothing is
+    retried inside the batch path and nothing is lost."""
 
-    def test_only_failed_items_are_retried(self):
+    def test_transient_item_falls_back_to_single_path_alone(self):
         service = ScriptedService(batch_script=[
-            lambda aids: [ok_item(aids[0]), retryable_item(aids[1])]])
-        job, records, _ = run_job(service, [101, 102], make_controller())
+            lambda aids: [ok_item(aids[0]), transient_item(aids[1])]])
+        controller = make_controller()
+        job, records, _ = run_job(service, [101, 102, 103, 104], controller)
 
-        # retry batch contains ONLY the failed item
-        self.assertEqual(service.batch_calls, [[101, 102], [102]])
-        self.assertEqual(sorted(r.aid for r in records), [101, 102])
-        self.assertEqual(job.stat.condition['batch_item_retry'], 1)
-        self.assertEqual(job.stat.condition['success'], 2)
+        # only the failed item went single; the batch path stayed in use
+        self.assertEqual(service.batch_calls, [[101, 102], [103, 104]])
+        self.assertEqual(service.single_calls, [102])
+        self.assertTrue(controller.is_enabled())
+        self.assertEqual(sorted(r.aid for r in records), [101, 102, 103, 104])
+        self.assertEqual(job.stat.condition['batch_item_fallback_single'], 1)
+        self.assertEqual(job.stat.condition['success'], 4)
+        self.assertEqual(job.stat.total_count, 4)
 
-    def test_attempts_exhausted_becomes_other_exception(self):
-        service = ScriptedService(batch_script=[
-            lambda aids: [retryable_item(aids[0])]] * 3)
+    def test_transient_item_fallback_reports_the_single_path_outcome(self):
+        # the single path's own retry=3 is the retry policy; if IT gives up,
+        # the aid is a plain other_exception exactly like today
+        service = ScriptedService(
+            batch_script=[lambda aids: [transient_item(aids[0])]],
+            single_error=ResponseError('video_view_trimmed', {'aid': 101}))
         job, records, _ = run_job(service, [101], make_controller())
 
-        # max_attempts=3 total tries, aligned with the single path's retry=3
-        self.assertEqual(service.batch_calls, [[101], [101], [101]])
+        self.assertEqual(service.single_calls, [101])
         self.assertEqual(records, [])
-        self.assertEqual(service.single_calls, [])  # exhausted != fallback
         self.assertEqual(job.stat.condition['other_exception'], 1)
         self.assertEqual(job.stat.total_count, 1)
 
-
-class TestWholeBatchFailureAndBreaker(unittest.TestCase):
-
-    def test_whole_batch_failure_charges_every_aid_one_attempt(self):
+    def test_whole_batch_failure_falls_back_and_disables_the_path(self):
         service = ScriptedService(batch_script=[
             ResponseError('video_view_trimmed_batch', {})])
         controller = make_controller()
-        job, records, _ = run_job(service, [101, 102], controller)
+        job, records, _ = run_job(service, [101, 102, 103, 104], controller)
 
-        # failure, then a successful retry batch with BOTH aids
-        self.assertEqual(service.batch_calls, [[101, 102], [101, 102]])
-        self.assertEqual(sorted(r.aid for r in records), [101, 102])
+        # exactly ONE batch call: its aids and every later aid go single path
+        self.assertEqual(service.batch_calls, [[101, 102]])
+        self.assertFalse(controller.is_enabled())
+        self.assertEqual(sorted(service.single_calls), [101, 102, 103, 104])
+        self.assertEqual(sorted(r.aid for r in records), [101, 102, 103, 104])
         self.assertEqual(job.stat.condition['batch_whole_failure'], 1)
-        self.assertTrue(controller.is_enabled())  # one failure does not trip
+        self.assertEqual(job.stat.condition['batch_fallback_single'], 2)
 
     def test_unexpected_exception_is_a_whole_batch_failure_not_a_dead_thread(self):
         # a bug-shaped exception must degrade like a transport failure, never
         # kill the worker thread mid-run
         service = ScriptedService(batch_script=[ValueError('boom')])
-        job, records, _ = run_job(service, [101, 102], make_controller())
-
-        self.assertEqual(job.stat.condition['batch_whole_failure'], 1)
-        self.assertEqual(sorted(r.aid for r in records), [101, 102])
-
-    def test_three_consecutive_whole_batch_failures_trip_the_breaker(self):
-        service = ScriptedService(batch_script=[
-            ResponseError('video_view_trimmed_batch', {})] * 3)
         controller = make_controller()
         job, records, _ = run_job(service, [101, 102], controller)
 
-        self.assertEqual(job.stat.condition['batch_whole_failure'], 3)
+        self.assertEqual(job.stat.condition['batch_whole_failure'], 1)
         self.assertFalse(controller.is_enabled())
-        # the batch's aids came back over the single path -- no data lost
-        self.assertEqual(sorted(service.single_calls), [101, 102])
         self.assertEqual(sorted(r.aid for r in records), [101, 102])
-        self.assertEqual(job.stat.condition['batch_fallback_single'], 2)
-
-    def test_breaker_counts_in_completion_order_and_success_resets(self):
-        # the documented definition: N failures recorded with no validated
-        # success recorded between them, in COMPLETION order -- interleaved
-        # successes (e.g. from other in-flight batches) reset the streak
-        controller = make_controller()
-        self.assertFalse(controller.record_whole_batch_failure())  # 1
-        self.assertFalse(controller.record_whole_batch_failure())  # 2
-        controller.record_batch_success()                          # reset
-        self.assertFalse(controller.record_whole_batch_failure())  # 1
-        self.assertFalse(controller.record_whole_batch_failure())  # 2
-        self.assertTrue(controller.is_enabled())
-        self.assertTrue(controller.record_whole_batch_failure())   # 3 -> trip
-        self.assertFalse(controller.is_enabled())
 
     def test_misalignment_trips_immediately_and_falls_back(self):
         service = ScriptedService(batch_script=[
@@ -307,7 +281,6 @@ class TestWholeBatchFailureAndBreaker(unittest.TestCase):
         controller = make_controller()
         job, records, _ = run_job(service, [101, 102, 103, 104], controller)
 
-        # exactly ONE batch call; its aids and every later aid go single path
         self.assertEqual(service.batch_calls, [[101, 102]])
         self.assertFalse(controller.is_enabled())
         self.assertEqual(sorted(service.single_calls), [101, 102, 103, 104])
@@ -407,6 +380,7 @@ class TestConcurrencyGate(unittest.TestCase):
 
         self.assertEqual(job_b.stat.condition['duration_limit_reached'], 1)
         self.assertEqual(job_b.stat.condition['batch_concurrency_throttled'], 1)
+        self.assertEqual(job_b.stat.condition['batch_dropped_at_deadline'], 1)
         self.assertEqual(drain(records_b), [])  # 302 dropped at the deadline
         self.assertEqual([r.aid for r in drain(records_a)], [301])
 

--- a/tests/test_video_view_trimmed_batch_job.py
+++ b/tests/test_video_view_trimmed_batch_job.py
@@ -1,0 +1,392 @@
+"""
+Tests for FetchVideoRecordJob's BATCH mode (batch assembly, per-item retry,
+kill-switch, single-path fallback) and the conf switch behind it.
+
+The Service is a scripted mock; the DB layer is stubbed out at import time
+(fetch workers never touch the DB anyway -- the stub just satisfies the
+``job`` package's sibling imports). Wall-clock colddown sleeps inside the job
+module are patched to keep the suite fast.
+
+Run from the repo root:
+
+    python -m unittest discover -s tests
+"""
+
+import importlib.util
+import os
+import sys
+import types
+import unittest
+import unittest.mock
+from queue import Queue
+
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, ROOT)
+
+# the `job` package imports DB-backed siblings (UpdateVideoJob etc.) whose
+# `db` import needs a conf.ini; none of that is exercised here, so satisfy
+# the imports with placeholder attributes when the real db is not loadable
+if 'db' not in sys.modules:
+    _fake_db = types.ModuleType('db')
+    _fake_db.__getattr__ = lambda name: type(name, (), {})
+    sys.modules['db'] = _fake_db
+
+def _load_real_conf_module():
+    """
+    Load conf/conf.py by file path, bypassing sys.modules: other test modules
+    (the run-record script tests) install a stub ``conf`` for the DB-backed
+    imports, and this module must test the REAL getter regardless of import
+    order. conf/conf.py is stdlib-only, so this always works.
+    """
+    spec = importlib.util.spec_from_file_location(
+        'tdd_real_conf_conf', os.path.join(ROOT, 'conf', 'conf.py'))
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+try:
+    from service import (  # noqa: E402
+        ResponseError, CodeError, MisalignmentError,
+        VideoViewTrimmed, VideoViewStat, VideoViewTrimmedBatchItem)
+    from job import (  # noqa: E402
+        FetchVideoRecordJob, VideoViewTrimmedBatchConfig, VideoViewTrimmedBatchState)
+    from task import build_video_record_via_video_view  # noqa: E402
+    from util import a2b  # noqa: E402
+except ImportError as e:  # pragma: no cover -- e.g. requests not installed
+    raise unittest.SkipTest(f'job dependencies unavailable: {e}')
+
+conf_module = _load_real_conf_module()
+get_video_view_trimmed_batch_conf = conf_module.get_video_view_trimmed_batch_conf
+
+import configparser  # noqa: E402
+
+
+def make_view(aid, view=100):
+    return VideoViewTrimmed(
+        bvid='BV' + a2b(aid), aid=aid,
+        stat=VideoViewStat(aid=aid, view=view, danmaku=1, reply=2, favorite=3,
+                           coin=4, share=5, now_rank=0, his_rank=0, like=6,
+                           dislike=None, vt=None, vv=None))
+
+
+def ok_item(aid):
+    return VideoViewTrimmedBatchItem(aid=aid, view=make_view(aid), error=None)
+
+
+def code_error_item(aid, code=-404):
+    return VideoViewTrimmedBatchItem(
+        aid=aid, view=None,
+        error=CodeError('video_view_trimmed', {'aid': aid}, {'code': code}, code))
+
+
+def retryable_item(aid):
+    return VideoViewTrimmedBatchItem(
+        aid=aid, view=None,
+        error=ResponseError('video_view_trimmed_batch_item',
+                            {'aid': aid, 'kind': 'item_timeout'}))
+
+
+class ScriptedService:
+    """
+    Scripted stand-in for Service. `batch_script` entries are consumed one per
+    get_video_view_trimmed_batch call: an Exception instance is raised, a
+    callable is called with the aids, anything else is returned as-is. When
+    the script runs dry, every item comes back ok. The single path
+    (get_video_view_trimmed) always succeeds unless `single_error` is set.
+    """
+
+    def __init__(self, batch_script=None, single_error=None):
+        self.batch_script = list(batch_script or [])
+        self.single_error = single_error
+        self.batch_calls = []
+        self.single_calls = []
+
+    def get_video_view_trimmed_batch(self, aids, **kwargs):
+        self.batch_calls.append(list(aids))
+        if self.batch_script:
+            entry = self.batch_script.pop(0)
+            if isinstance(entry, Exception):
+                raise entry
+            if callable(entry):
+                return entry(aids)
+            return entry
+        return [ok_item(aid) for aid in aids]
+
+    def get_video_view_trimmed(self, params, **kwargs):
+        aid = params['aid']
+        self.single_calls.append(aid)
+        if self.single_error is not None:
+            raise self.single_error
+        return make_view(aid)
+
+
+class NoBatchService(ScriptedService):
+    """A service on which any batch call is a test failure."""
+
+    def get_video_view_trimmed_batch(self, aids, **kwargs):
+        raise AssertionError('batch path must not be used')
+
+
+def run_job(service, aids, batch_config, batch_state=None,
+            code_error_queue=True):
+    """Build a job over a prefilled aid queue, run its loop synchronously
+    (no thread), return (job, records, code_error_aids)."""
+    aid_queue = Queue()
+    for aid in aids:
+        aid_queue.put(aid)
+    record_queue = Queue()
+    code_error_aid_queue = Queue() if code_error_queue else None
+    job = FetchVideoRecordJob(
+        'job_test', aid_queue, record_queue, service,
+        code_error_aid_queue=code_error_aid_queue,
+        batch_config=batch_config, batch_state=batch_state)
+    job.logger.disabled = True  # the failure paths log loudly on purpose
+
+    # keep the retry colddowns out of the test wall clock (time.perf_counter
+    # must stay real -- the job measures batch latency with it)
+    import time as real_time
+    fake_time = types.SimpleNamespace(
+        sleep=lambda s: None, perf_counter=real_time.perf_counter)
+    with unittest.mock.patch('job.FetchVideoRecordJob.time', fake_time):
+        job.process()
+
+    records = []
+    while not record_queue.empty():
+        records.append(record_queue.get())
+    code_error_aids = []
+    if code_error_aid_queue is not None:
+        while not code_error_aid_queue.empty():
+            code_error_aids.append(code_error_aid_queue.get())
+    return job, records, code_error_aids
+
+
+ALWAYS = VideoViewTrimmedBatchConfig(batch_size=2, batch_fraction=1.0)
+
+
+class TestBatchHappyPath(unittest.TestCase):
+
+    def test_records_flow_through_batches(self):
+        service = ScriptedService()
+        aids = [101, 102, 103, 104]
+        job, records, _ = run_job(service, aids, ALWAYS, VideoViewTrimmedBatchState())
+
+        self.assertEqual(service.batch_calls, [[101, 102], [103, 104]])
+        self.assertEqual(service.single_calls, [])
+        self.assertEqual(sorted(r.aid for r in records), aids)
+        # RecordNew comes out of the SAME mapping as the single path
+        self.assertEqual(records[0].bvid, a2b(records[0].aid))
+        self.assertEqual(job.stat.condition['success'], 4)
+        self.assertEqual(job.stat.condition['batch_request'], 2)
+        self.assertEqual(job.stat.total_count, 4)
+
+    def test_partial_batch_flushes_when_queue_drains(self):
+        service = ScriptedService()
+        job, records, _ = run_job(
+            service, [101, 102, 103], ALWAYS, VideoViewTrimmedBatchState())
+
+        self.assertEqual(service.batch_calls, [[101, 102], [103]])
+        self.assertEqual(len(records), 3)
+
+    def test_code_error_routes_to_update_queue(self):
+        service = ScriptedService(batch_script=[
+            lambda aids: [ok_item(aids[0]), code_error_item(aids[1])]])
+        job, records, code_error_aids = run_job(
+            service, [101, 102], ALWAYS, VideoViewTrimmedBatchState())
+
+        self.assertEqual([r.aid for r in records], [101])
+        self.assertEqual(code_error_aids, [102])
+        self.assertEqual(job.stat.condition['code_error'], 1)
+        self.assertEqual(job.stat.condition['success'], 1)
+        self.assertEqual(job.stat.total_count, 2)
+
+    def test_duplicate_aid_in_buffer_takes_single_path(self):
+        service = ScriptedService()
+        job, records, _ = run_job(
+            service, [101, 101, 102], ALWAYS, VideoViewTrimmedBatchState())
+
+        # never the same token twice in one batch: the second 101 goes single
+        self.assertEqual(service.batch_calls, [[101, 102]])
+        self.assertEqual(service.single_calls, [101])
+        self.assertEqual(job.stat.condition['batch_duplicate_single_path'], 1)
+        self.assertEqual(len(records), 3)
+
+
+class TestPerItemRetry(unittest.TestCase):
+
+    def test_only_failed_items_are_retried(self):
+        service = ScriptedService(batch_script=[
+            lambda aids: [ok_item(aids[0]), retryable_item(aids[1])]])
+        job, records, _ = run_job(
+            service, [101, 102], ALWAYS, VideoViewTrimmedBatchState())
+
+        # retry batch contains ONLY the failed item
+        self.assertEqual(service.batch_calls, [[101, 102], [102]])
+        self.assertEqual(sorted(r.aid for r in records), [101, 102])
+        self.assertEqual(job.stat.condition['batch_item_retry'], 1)
+        self.assertEqual(job.stat.condition['success'], 2)
+
+    def test_attempts_exhausted_becomes_other_exception(self):
+        service = ScriptedService(batch_script=[
+            lambda aids: [retryable_item(aids[0])]] * 3)
+        job, records, _ = run_job(
+            service, [101], ALWAYS, VideoViewTrimmedBatchState())
+
+        # max_attempts=3 total tries, aligned with the single path's retry=3
+        self.assertEqual(service.batch_calls, [[101], [101], [101]])
+        self.assertEqual(records, [])
+        self.assertEqual(service.single_calls, [])  # exhausted != fallback
+        self.assertEqual(job.stat.condition['other_exception'], 1)
+        self.assertEqual(job.stat.total_count, 1)
+
+
+class TestWholeBatchFailureAndKillSwitch(unittest.TestCase):
+
+    def test_whole_batch_failure_charges_every_aid_one_attempt(self):
+        service = ScriptedService(batch_script=[
+            ResponseError('video_view_trimmed_batch', {})])
+        state = VideoViewTrimmedBatchState()
+        job, records, _ = run_job(service, [101, 102], ALWAYS, state)
+
+        # failure, then a successful retry batch with BOTH aids
+        self.assertEqual(service.batch_calls, [[101, 102], [101, 102]])
+        self.assertEqual(sorted(r.aid for r in records), [101, 102])
+        self.assertEqual(job.stat.condition['batch_whole_failure'], 1)
+        self.assertTrue(state.is_enabled())  # one failure does not trip
+
+    def test_three_consecutive_whole_batch_failures_trip_the_kill_switch(self):
+        service = ScriptedService(batch_script=[
+            ResponseError('video_view_trimmed_batch', {})] * 3)
+        state = VideoViewTrimmedBatchState()
+        job, records, _ = run_job(service, [101, 102], ALWAYS, state)
+
+        self.assertEqual(job.stat.condition['batch_whole_failure'], 3)
+        self.assertFalse(state.is_enabled())
+        # the batch's aids came back over the single path -- no data lost
+        self.assertEqual(sorted(service.single_calls), [101, 102])
+        self.assertEqual(sorted(r.aid for r in records), [101, 102])
+        self.assertEqual(job.stat.condition['batch_fallback_single'], 2)
+
+    def test_unexpected_exception_is_a_whole_batch_failure_not_a_dead_thread(self):
+        # a bug-shaped exception must degrade like a transport failure, never
+        # kill the worker thread mid-run
+        service = ScriptedService(batch_script=[ValueError('boom')])
+        state = VideoViewTrimmedBatchState()
+        job, records, _ = run_job(service, [101, 102], ALWAYS, state)
+
+        self.assertEqual(job.stat.condition['batch_whole_failure'], 1)
+        self.assertEqual(sorted(r.aid for r in records), [101, 102])
+
+    def test_batch_success_resets_the_consecutive_counter(self):
+        state = VideoViewTrimmedBatchState()
+        state.record_whole_batch_failure()
+        state.record_whole_batch_failure()
+        state.record_batch_success()
+        self.assertFalse(state.record_whole_batch_failure())  # back to 1
+        self.assertTrue(state.is_enabled())
+
+    def test_misalignment_trips_immediately_and_falls_back(self):
+        service = ScriptedService(batch_script=[
+            MisalignmentError('video_view_trimmed_batch', {}, {}, 'aid echo mismatch')])
+        state = VideoViewTrimmedBatchState()
+        job, records, _ = run_job(service, [101, 102, 103, 104], ALWAYS, state)
+
+        # exactly ONE batch call; its aids and every later aid go single path
+        self.assertEqual(service.batch_calls, [[101, 102]])
+        self.assertFalse(state.is_enabled())
+        self.assertEqual(sorted(service.single_calls), [101, 102, 103, 104])
+        self.assertEqual(sorted(r.aid for r in records), [101, 102, 103, 104])
+        self.assertEqual(job.stat.condition['batch_misalignment'], 1)
+        self.assertEqual(job.stat.condition['batch_fallback_single'], 2)
+
+    def test_kill_switch_is_shared_across_jobs(self):
+        # a state tripped by one job disables the path for its siblings
+        state = VideoViewTrimmedBatchState()
+        self.assertTrue(state.trip('misalignment seen by job_0'))
+        self.assertFalse(state.trip('job_1 saw it too'))  # only first trips
+
+        service = NoBatchService()
+        job, records, _ = run_job(service, [101, 102], ALWAYS, state)
+        self.assertEqual(sorted(r.aid for r in records), [101, 102])
+        self.assertEqual(service.single_calls, [101, 102])
+
+
+class TestBatchPathOff(unittest.TestCase):
+
+    def test_no_config_means_single_path_only(self):
+        service = NoBatchService()
+        job, records, _ = run_job(service, [101, 102], None, None)
+
+        self.assertEqual(service.single_calls, [101, 102])
+        self.assertEqual(sorted(r.aid for r in records), [101, 102])
+        self.assertEqual(job.stat.condition['success'], 2)
+        # no batch counters ever appear when the path is off
+        self.assertNotIn('batch_request', job.stat.condition)
+
+    def test_fraction_zero_never_batches(self):
+        service = NoBatchService()
+        config = VideoViewTrimmedBatchConfig(batch_size=2, batch_fraction=0.0)
+        job, records, _ = run_job(
+            service, [101, 102], config, VideoViewTrimmedBatchState())
+
+        self.assertEqual(service.single_calls, [101, 102])
+        self.assertEqual(len(records), 2)
+
+
+class TestRecordMapping(unittest.TestCase):
+
+    def test_hidden_view_count_maps_to_minus_one(self):
+        record = build_video_record_via_video_view(101, make_view(101, view='--'))
+        self.assertEqual(record.view, -1)
+        self.assertEqual(record.bvid, a2b(101))  # BV prefix stripped
+
+
+class TestConf(unittest.TestCase):
+
+    def _with_config(self, ini_text):
+        parser = configparser.ConfigParser()
+        parser.read_string(ini_text)
+        original = conf_module.CONFIG
+        conf_module.CONFIG = parser
+        self.addCleanup(lambda: setattr(conf_module, 'CONFIG', original))
+
+    def test_missing_section_is_disabled(self):
+        self._with_config('[db_mysql]\nuser = u\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+
+    def test_enabled_values_pass_through(self):
+        self._with_config(
+            '[video_view_trimmed_batch]\nbatch_size = 10\nbatch_fraction = 0.05\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (10, 0.05))
+
+    def test_zero_size_or_fraction_is_disabled(self):
+        self._with_config(
+            '[video_view_trimmed_batch]\nbatch_size = 0\nbatch_fraction = 1\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+        self._with_config(
+            '[video_view_trimmed_batch]\nbatch_size = 10\nbatch_fraction = 0\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+
+    def test_negative_values_are_disabled(self):
+        self._with_config(
+            '[video_view_trimmed_batch]\nbatch_size = -5\nbatch_fraction = 0.5\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+
+    def test_size_is_capped_at_worker_max(self):
+        self._with_config(
+            '[video_view_trimmed_batch]\nbatch_size = 100\nbatch_fraction = 1\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (50, 1.0))
+
+    def test_fraction_is_clamped_to_one(self):
+        self._with_config(
+            '[video_view_trimmed_batch]\nbatch_size = 10\nbatch_fraction = 1.5\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (10, 1.0))
+
+    def test_unparsable_values_are_disabled(self):
+        self._with_config(
+            '[video_view_trimmed_batch]\nbatch_size = lots\nbatch_fraction = 1\n')
+        self.assertEqual(get_video_view_trimmed_batch_conf(), (0, 0.0))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_video_view_trimmed_batch_service.py
+++ b/tests/test_video_view_trimmed_batch_service.py
@@ -28,7 +28,8 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
     from service import Service, ResponseError, CodeError, MisalignmentError  # noqa: E402
-    from service.Service import BATCH_READ_TIMEOUT_S, BATCH_DEADLINE_S  # noqa: E402
+    from service.Service import \
+        VIDEO_VIEW_TRIMMED_BATCH_READ_TIMEOUT_S, VIDEO_VIEW_TRIMMED_BATCH_DEADLINE_S  # noqa: E402
     from util import a2b  # noqa: E402
 except ImportError as e:  # pragma: no cover -- e.g. requests not installed
     raise unittest.SkipTest(f'service dependencies unavailable: {e}')
@@ -112,8 +113,8 @@ class TestBatchHappyPath(unittest.TestCase):
         # single whole-batch trial: retries are the CALLER's per-aid attempts
         self.assertEqual(call['retry'], 1)
         # batch-specific timeout chain, not the 5s/10s single-path defaults
-        self.assertEqual(call['timeout'], BATCH_READ_TIMEOUT_S)
-        self.assertEqual(call['deadline'], BATCH_DEADLINE_S)
+        self.assertEqual(call['timeout'], VIDEO_VIEW_TRIMMED_BATCH_READ_TIMEOUT_S)
+        self.assertEqual(call['deadline'], VIDEO_VIEW_TRIMMED_BATCH_DEADLINE_S)
 
     def test_vt_vv_missing_from_stat_default_to_none(self):
         # the worker backfills vt/vv with null, but the client must not rely
@@ -275,10 +276,35 @@ class TestMisalignment(unittest.TestCase):
         self._assert_misaligned(
             aids, envelope(aids, [json_item(1)], v=2))
 
+    def test_boolean_protocol_version_is_misaligned(self):
+        # True == 1 in Python; the protocol field must be a real int
+        aids = [1]
+        self._assert_misaligned(
+            aids, envelope(aids, [json_item(1)], v=True))
+
     def test_requested_count_mismatch(self):
         aids = [1, 2]
         self._assert_misaligned(
             aids, envelope(aids, [json_item(1), json_item(2)], requested=3))
+
+    def test_boolean_requested_is_misaligned(self):
+        # True == 1 would otherwise slip through a one-aid batch
+        aids = [1]
+        self._assert_misaligned(
+            aids, envelope(aids, [json_item(1)], requested=True))
+
+    def test_json_item_with_missing_or_non_int_status_is_misaligned(self):
+        # the worker always sets an integer status on json items: a missing,
+        # string, or boolean one is a contract violation, not a retryable
+        # upstream hiccup
+        for bad_status in (None, '200', True):
+            aid = 170001
+            item = json_item(aid)
+            if bad_status is None:
+                del item['status']
+            else:
+                item['status'] = bad_status
+            self._assert_misaligned([aid], envelope([aid], [item]))
 
     def test_results_length_mismatch(self):
         aids = [1, 2]

--- a/tests/test_video_view_trimmed_batch_service.py
+++ b/tests/test_video_view_trimmed_batch_service.py
@@ -1,0 +1,351 @@
+"""
+Tests for ``Service.get_video_view_trimmed_batch`` -- the client side of the
+batch worker contract (service/workers/video_view/aws_lambda_batch.mjs, v1).
+
+The HTTP layer (``Service._get``) is stubbed; every test feeds a canned
+top-level response and asserts the three-tier error model:
+
+- per-item outcomes (ok / CodeError / retryable ResponseError), including the
+  rule that a top-level HTTP 200 proves nothing about the items and an item is
+  only trusted when kind == json AND status == 200 AND body.code == 0 AND the
+  identity checks pass -- notably, an upstream non-2xx carrying a code == 0
+  JSON body must NOT produce a record;
+- whole-batch failures (transport / unconfigured endpoint) raising
+  ResponseError;
+- contract/identity violations raising MisalignmentError (kill-switch food).
+
+Run from the repo root:
+
+    python -m unittest discover -s tests
+"""
+
+import logging
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+try:
+    from service import Service, ResponseError, CodeError, MisalignmentError  # noqa: E402
+    from service.Service import BATCH_READ_TIMEOUT_S, BATCH_DEADLINE_S  # noqa: E402
+    from util import a2b  # noqa: E402
+except ImportError as e:  # pragma: no cover -- e.g. requests not installed
+    raise unittest.SkipTest(f'service dependencies unavailable: {e}')
+
+BATCH_ENDPOINTS = {
+    'get_video_view_trimmed_batch': {'workers': ['http://batch-worker.invalid/']},
+}
+
+
+def make_service(endpoints=None):
+    return Service(mode='worker',
+                   endpoints=BATCH_ENDPOINTS if endpoints is None else endpoints)
+
+
+def stub_get(service, response):
+    """Replace service._get with a stub returning `response`, recording calls."""
+    calls = []
+
+    def _get(url, params=None, headers=None, **kwargs):
+        calls.append({'url': url, 'params': params, 'headers': headers, **kwargs})
+        return response
+
+    service._get = _get
+    return calls
+
+
+def trimmed_body(aid, **overrides):
+    """The exact envelope the batch worker builds for a healthy view."""
+    stat = {
+        'aid': aid, 'view': 100, 'danmaku': 1, 'reply': 2, 'favorite': 3,
+        'coin': 4, 'share': 5, 'now_rank': 0, 'his_rank': 0, 'like': 6,
+        'dislike': None, 'vt': None, 'vv': None,
+    }
+    stat.update(overrides.pop('stat', {}))
+    body = {
+        'code': 0, 'message': '0', 'ttl': 1,
+        'data': {'bvid': 'BV' + a2b(aid), 'aid': aid, 'stat': stat},
+    }
+    body.update(overrides)
+    return body
+
+
+def json_item(aid, status=200, body=None, echo=None):
+    return {'aid': str(aid) if echo is None else echo, 'ms': 5, 'kind': 'json',
+            'status': status, 'body': trimmed_body(aid) if body is None else body}
+
+
+def envelope(aids, results, **overrides):
+    e = {'v': 1, 'requested': len(aids), 'results': results}
+    e.update(overrides)
+    return e
+
+
+class TestBatchHappyPath(unittest.TestCase):
+
+    def test_two_ok_items(self):
+        service = make_service()
+        aids = [170001, 170002]
+        calls = stub_get(service, envelope(aids, [json_item(a) for a in aids]))
+
+        items = service.get_video_view_trimmed_batch(aids)
+
+        self.assertEqual([i.aid for i in items], aids)
+        for aid, item in zip(aids, items):
+            self.assertIsNone(item.error)
+            self.assertEqual(item.view.aid, aid)
+            self.assertEqual(item.view.bvid, 'BV' + a2b(aid))
+            self.assertEqual(item.view.stat.view, 100)
+            self.assertIsNone(item.view.stat.vt)
+        self.assertEqual(len(calls), 1)
+
+    def test_request_shape_and_batch_tunables(self):
+        service = make_service()
+        aids = [1, 2, 3]
+        calls = stub_get(service, envelope(aids, [json_item(a) for a in aids]))
+
+        service.get_video_view_trimmed_batch(aids)
+
+        call = calls[0]
+        self.assertEqual(call['params'], {'aids': '1,2,3'})
+        # single whole-batch trial: retries are the CALLER's per-aid attempts
+        self.assertEqual(call['retry'], 1)
+        # batch-specific timeout chain, not the 5s/10s single-path defaults
+        self.assertEqual(call['timeout'], BATCH_READ_TIMEOUT_S)
+        self.assertEqual(call['deadline'], BATCH_DEADLINE_S)
+
+    def test_vt_vv_missing_from_stat_default_to_none(self):
+        # the worker backfills vt/vv with null, but the client must not rely
+        # on it (same .get(None) leniency as the single path)
+        aid = 170001
+        body = trimmed_body(aid)
+        del body['data']['stat']['vt']
+        del body['data']['stat']['vv']
+        service = make_service()
+        stub_get(service, envelope([aid], [json_item(aid, body=body)]))
+
+        item = service.get_video_view_trimmed_batch([aid])[0]
+
+        self.assertIsNone(item.view.stat.vt)
+        self.assertIsNone(item.view.stat.vv)
+
+    def test_stat_aid_zero_is_accepted(self):
+        # upstream precedent: stat.aid is sometimes 0 (see task.py's
+        # commit_video_record_via_newlist_archive_stat)
+        aid = 170001
+        service = make_service()
+        stub_get(service, envelope(
+            [aid], [json_item(aid, body=trimmed_body(aid, stat={'aid': 0}))]))
+
+        item = service.get_video_view_trimmed_batch([aid])[0]
+
+        self.assertIsNone(item.error)
+        self.assertEqual(item.view.stat.aid, 0)
+
+    def test_hidden_view_count_passes_through_as_string(self):
+        # '--' handling belongs to the RecordNew mapping, not here
+        aid = 170001
+        service = make_service()
+        stub_get(service, envelope(
+            [aid], [json_item(aid, body=trimmed_body(aid, stat={'view': '--'}))]))
+
+        item = service.get_video_view_trimmed_batch([aid])[0]
+
+        self.assertEqual(item.view.stat.view, '--')
+
+
+class TestPerItemFailures(unittest.TestCase):
+
+    def test_code_error_item(self):
+        aids = [170001, 170002]
+        service = make_service()
+        stub_get(service, envelope(aids, [
+            json_item(aids[0]),
+            json_item(aids[1], body={'code': -404, 'message': 'not found', 'ttl': 1}),
+        ]))
+
+        items = service.get_video_view_trimmed_batch(aids)
+
+        self.assertIsNone(items[0].error)
+        error = items[1].error
+        self.assertIsInstance(error, CodeError)
+        self.assertEqual(error.code, -404)
+        # same target as the single path so downstream logging matches
+        self.assertEqual(error.target, 'video_view_trimmed')
+        self.assertEqual(error.params, {'aid': aids[1]})
+        self.assertIsNone(items[1].view)
+
+    def test_transient_kinds_are_retryable(self):
+        aids = [1, 2, 3]
+        service = make_service()
+        stub_get(service, envelope(aids, [
+            {'aid': '1', 'ms': 4500, 'kind': 'item_timeout', 'timeout_ms': 4500},
+            {'aid': '2', 'ms': 10, 'kind': 'fetch_error', 'detail': 'connect ECONNREFUSED'},
+            {'aid': '3', 'ms': 20, 'kind': 'non_json', 'status': 404,
+             'body_snippet': '<!DOCTYPE html>'},
+        ]))
+
+        items = service.get_video_view_trimmed_batch(aids)
+
+        for item in items:
+            self.assertIsNone(item.view)
+            self.assertIsInstance(item.error, ResponseError)
+            self.assertNotIsInstance(item.error, CodeError)
+
+    def test_non_200_upstream_with_code_zero_body_is_not_trusted(self):
+        # THE trap case: top-level 200, kind json, body.code == 0 -- but the
+        # upstream status was 500. The single path never parses non-200
+        # bodies, so this must be a retryable failure, never a record.
+        aid = 170001
+        service = make_service()
+        stub_get(service, envelope(
+            [aid], [json_item(aid, status=500)]))
+
+        item = service.get_video_view_trimmed_batch([aid])[0]
+
+        self.assertIsNone(item.view)
+        self.assertIsInstance(item.error, ResponseError)
+
+    def test_non_200_upstream_with_error_code_body_is_retryable_not_code_error(self):
+        # e.g. a -412 rate-limit page served with HTTP 412: the single path
+        # would retry it (non-200), not route it to the code-error queue
+        aid = 170001
+        service = make_service()
+        stub_get(service, envelope(
+            [aid],
+            [json_item(aid, status=412,
+                       body={'code': -412, 'message': 'rejected', 'ttl': 1})]))
+
+        item = service.get_video_view_trimmed_batch([aid])[0]
+
+        self.assertIsNone(item.view)
+        self.assertIsInstance(item.error, ResponseError)
+        self.assertNotIsInstance(item.error, CodeError)
+
+
+class TestWholeBatchFailures(unittest.TestCase):
+
+    def setUp(self):
+        # these paths log loudly on purpose; keep the test run output clean
+        logging.getLogger('Service').disabled = True
+        self.addCleanup(
+            lambda: setattr(logging.getLogger('Service'), 'disabled', False))
+
+    def test_transport_failure_raises_response_error(self):
+        # _get returns None on HTTP != 200 / unparsable body / network failure
+        # (this includes the batch worker's own 400/500 error envelopes)
+        service = make_service()
+        stub_get(service, None)
+
+        with self.assertRaises(ResponseError):
+            service.get_video_view_trimmed_batch([1, 2])
+
+    def test_missing_endpoint_raises_response_error_not_exit(self):
+        # unlike the sibling methods (critical + exit), the batch path has a
+        # designed fallback -- config drift degrades the run, never kills it
+        for endpoints in ({}, {'get_video_view_trimmed_batch': {'workers': []}}):
+            service = make_service(endpoints=endpoints)
+            with self.assertRaises(ResponseError):
+                service.get_video_view_trimmed_batch([1])
+
+    def test_direct_mode_is_a_programming_error(self):
+        service = Service(mode='direct', endpoints=BATCH_ENDPOINTS)
+        with self.assertRaises(SystemExit):
+            service.get_video_view_trimmed_batch([1])
+
+
+class TestMisalignment(unittest.TestCase):
+
+    def _assert_misaligned(self, aids, response):
+        service = make_service()
+        stub_get(service, response)
+        with self.assertRaises(MisalignmentError):
+            service.get_video_view_trimmed_batch(aids)
+
+    def test_old_single_worker_answer_is_misaligned(self):
+        # a config error pointing the batch key at the single-aid worker:
+        # upstream answers ?aids= with a -400 passthrough -- valid JSON, no v.
+        # The v check is the double insurance that kills the path immediately
+        # instead of poisoning anything.
+        self._assert_misaligned([1, 2], {'code': -400, 'message': '请求错误', 'ttl': 1})
+
+    def test_wrong_protocol_version(self):
+        aids = [1]
+        self._assert_misaligned(
+            aids, envelope(aids, [json_item(1)], v=2))
+
+    def test_requested_count_mismatch(self):
+        aids = [1, 2]
+        self._assert_misaligned(
+            aids, envelope(aids, [json_item(1), json_item(2)], requested=3))
+
+    def test_results_length_mismatch(self):
+        aids = [1, 2]
+        self._assert_misaligned(aids, envelope(aids, [json_item(1)], requested=2))
+
+    def test_aid_echo_mismatch(self):
+        aids = [1, 2]
+        self._assert_misaligned(
+            aids, envelope(aids, [json_item(1), json_item(2, echo='999')]))
+
+    def test_aid_echo_wrong_type(self):
+        # the worker echoes the raw token, which we sent as a decimal string;
+        # an int echo means we are NOT talking to the contract we think
+        aids = [1]
+        self._assert_misaligned(aids, envelope(aids, [json_item(1, echo=1)]))
+
+    def test_unknown_kind(self):
+        aids = [1]
+        self._assert_misaligned(
+            aids, envelope(aids, [{'aid': '1', 'ms': 1, 'kind': 'surprise'}]))
+
+    def test_json_kind_without_dict_body(self):
+        aids = [1]
+        self._assert_misaligned(
+            aids, envelope(aids, [{'aid': '1', 'ms': 1, 'kind': 'json',
+                                   'status': 200, 'body': '{"code":0}'}]))
+
+    def test_missing_top_level_body_key(self):
+        aid = 170001
+        body = trimmed_body(aid)
+        del body['ttl']
+        self._assert_misaligned([aid], envelope([aid], [json_item(aid, body=body)]))
+
+    def test_missing_stat_key(self):
+        aid = 170001
+        body = trimmed_body(aid)
+        del body['data']['stat']['dislike']
+        self._assert_misaligned([aid], envelope([aid], [json_item(aid, body=body)]))
+
+    def test_body_data_aid_mismatch(self):
+        aid = 170001
+        other = 170002
+        # a payload wholesale from ANOTHER video: internally consistent
+        # (aid+bvid+stat all match each other) but not the requested aid
+        body = trimmed_body(other)
+        self._assert_misaligned([aid], envelope([aid], [json_item(aid, body=body)]))
+
+    def test_bvid_mismatch(self):
+        aid = 170001
+        body = trimmed_body(aid)
+        body['data']['bvid'] = 'BV' + a2b(aid + 1)
+        self._assert_misaligned([aid], envelope([aid], [json_item(aid, body=body)]))
+
+    def test_stat_aid_mismatch(self):
+        aid = 170001
+        body = trimmed_body(aid, stat={'aid': 999})
+        self._assert_misaligned([aid], envelope([aid], [json_item(aid, body=body)]))
+
+    def test_misalignment_discards_healthy_siblings(self):
+        # one bad item poisons the whole batch by design ("the path is
+        # untrustworthy", not "skip the item"): no partial result comes back
+        aids = [1, 2]
+        service = make_service()
+        stub_get(service, envelope(aids, [json_item(1), json_item(2, echo='42')]))
+        with self.assertRaises(MisalignmentError):
+            service.get_video_view_trimmed_batch(aids)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Client side of the batched trimmed video_view worker merged in #60 (contract v1). **Default OFF**: without the new conf section, the 51_ fetch pipeline behaves byte-identically to today — this PR deploys no worker, changes no endpoints, and shifts no traffic.

## Service layer — `get_video_view_trimmed_batch`

One `GET ?aids=a,b,c` per batch, with a three-tier error model. A top-level HTTP 200 proves nothing about the items; each item is judged on its own `status` + `kind` + `body.code`:

- **Trusted item** (produces a record): `kind == json` **and** upstream `status == 200` **and** `body.code == 0` **and** the full single-path format check set **and** the identity checks — `item.aid` echoes the sent token, `body.data.aid == aid`, `body.data.bvid` equals the bvid computed from aid (strong misrouting detector), `stat.aid ∈ {aid, 0}`.
- **Per-item CodeError**: `status == 200` with `code != 0` — identical semantics and routing to the single path (video-update queue).
- **Per-item retryable**: `item_timeout` / `fetch_error` / `non_json`, and any **non-200 upstream status even when the body says `code: 0`** — the single path never parses non-200 bodies, so trusting such a payload would be a semantic change, not a batching detail.
- **Whole-batch failure** (`ResponseError`): transport failure, unparsable top level, worker 400/500 envelopes, or unconfigured endpoint (deliberately *not* the siblings' critical+exit — this path has a designed fallback and config drift must degrade the run, never kill it).
- **`MisalignmentError`** (new): top level parses but violates the contract (`v != 1`, requested/results length mismatch) or any item fails an identity/format check. The whole batch result is discarded — this is kill-switch food, never "skip the item". The `v` check is the double insurance that a batch key mispointed at the old single-aid worker fails loudly with zero dirty data.

The batch call runs a **single whole-batch trial** (`retry=1`): retries belong to the caller's per-aid attempt accounting, so Service-level retries can't invisibly multiply invocations. Batch read timeout 8s / deadline 12s are named constants documented as initial hypotheses pending load-test calibration, preserving the invariant `deadline > client timeout > fn timeout > per-item timeout` with ≥2s headroom per step.

## Job layer — `FetchVideoRecordJob` batch mode

- Routes a `batch_fraction` share of aids into batches of `batch_size`; everything else (and everything after a kill-switch trip) takes the untouched single-aid path.
- **Only failed items are retried** (3 attempts per aid, aligned with the single path's `retry=3`), mixed into later batches; a whole-batch failure charges every aid in it one attempt. Duplicate tokens never share a batch (contract puts de-dup on the caller); the duplicate occurrence takes the single path.
- **Kill-switch**, shared across the whole fetch pool: any misalignment trips it immediately; 3 consecutive whole-batch failures (self-healing when the worker is dead/deleted) trip it too. Tripping logs one critical line, the discarded batch's aids are refetched over the single path, and the batch path stays off for the rest of the run. Unexpected exceptions degrade like whole-batch failures instead of killing a worker thread.
- Success/code_error/other_exception counters keep their existing meanings; new `batch_*` counters (and their ensure-keys) appear only when the path is enabled, so the off-state log output is unchanged.

## Config

`conf.ini` gains `[video_view_trimmed_batch]` with `batch_size` (0 = off) and `batch_fraction` (0–1). Parsing is fail-safe: missing file/section/option or invalid values resolve to disabled; size is capped at the worker's `MAX_AIDS` default (50); fraction clamps to [0, 1]. `endpoints.json.example` gains the `get_video_view_trimmed_batch` key. `Service.__init__` accepts an injectable `endpoints` dict (tests only; the production file-loading path is unchanged).

## Tests

- 48 new stdlib-unittest cases: service tiers (happy path, CodeError, every retryable kind, **the non-2xx-with-code-0 trap**, transport failures, 15 misalignment variants including the old-worker answer), job behavior (assembly, partial flush, retry-only-failed, attempt exhaustion, both kill-switch triggers, shared-state trip, fallback completeness, duplicates, off-state), and conf parsing/clamping.
- Full suite: 168 Python tests + 10 node worker tests green. Off-state parity: the single-aid loop body was extracted verbatim into helpers and all pre-existing tests pass unchanged.

Review focus: per-item validation set, retry/attempt accounting, kill-switch and fallback behavior. Deployment and traffic ramp-up are explicitly out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Review round 1 (2aeb482)

Supersedes the description above where they differ — the shared batch state is now a **controller** owning two cross-job concerns:

**Concurrency gate.** New `job/VideoViewTrimmedBatchController.py`: one pool-shared instance holds a semaphore of `max_concurrent_batches` slots (conf-driven, default 30 — an initial safe assumption for calibration, **not** a chosen concurrency). Jobs hold a slot around the batch HTTP call only, so simultaneous batch invocations are bounded pool-wide regardless of the fetch thread count: upstream in-flight from the batch path ≤ `batch_size × max_concurrent_batches` (≤ today's ~300 for batch_size ≤ 10 at the default). The single-aid path — kill-switch fallback included — is never throttled. Slot waits run in 1s slices re-checking the run deadline and the breaker; `batch_concurrency_throttled` counts dispatches that had to wait.

**Breaker, precise definition + race fix.** Failures and validated successes are recorded in **completion order** (the order jobs report outcomes, not dispatch order); 3 consecutive failures with no validated success recorded between them trip the breaker, misalignment trips it immediately, and tripping is one-way per run — a spurious trip only costs falling back to the always-correct single path. The race is closed on the return side: every job **re-checks the breaker when its batch response comes back, before interpreting it**. A response that was in flight when another job tripped is discarded wholesale (`batch_discarded_after_trip`) and its aids refetched over the single path; a whole-batch failure landing after a trip goes straight to fallback instead of burning attempts. (A trip landing mid-interpretation remains a documented residual window — every item written there has already passed its own full identity validation; the recheck is defense in depth.)

**Auditability.** `process()` now dispatches once to either `_run_single_path_loop()` — the pre-batch loop kept verbatim, trivially diffable against the original — or `_run_batch_path_loop()`, which only moves aids; failure policy lives in `_dispatch_batch` / `_on_misalignment` / `_on_whole_batch_failure`, and dispatch outcomes are named types (`BatchEntry`, `BatchDispatchResult`) instead of anonymous tuples and `None` returns.

**Protocol strictness.** `v` and `requested` must be real ints (`bool` rejected — `True == 1` in Python); a json item's `status` must be an int, and a missing/non-int one is a contract violation (misalignment), not a retryable non-200. Batch constants renamed with the `VIDEO_VIEW_TRIMMED_BATCH_` prefix.

**Mapping hardening.** `build_video_record_via_video_view` uses `removeprefix('BV')` instead of `lstrip('BV')` (identical output for every real bvid; strict by construction), with a regression test plus a full field-by-field mapping test.

**Tests** (178 Python + 10 node green): real-thread concurrency-cap test (in-flight never exceeds the cap, nothing lost, throttling observed), real-thread breaker race test (in-flight response returned after the trip is discarded and its aids refetched exactly once), deadline-while-waiting-for-a-slot, completion-order breaker accounting, `max_concurrent_batches` conf handling. Off-state tests still prove the single-path behavior unchanged.

---

## Review round 2 (503ca7e) — reliability-first simplification

Supersedes the retry/breaker descriptions above. The batch path is now an optimisation layered on the single path, never a second retry machine:

| batch outcome | what happens |
|---|---|
| item ok | record, exactly as the single path would |
| item `CodeError` | `code_error_aid_queue` → `UpdateVideoJob`, unchanged |
| item transient (timeout / fetch error / non-JSON / non-200) | **that aid alone** is refetched over the single path right away; Service's existing `retry=3` is the only retry policy |
| whole-batch failure (transport, worker 4xx/5xx envelope, unconfigured endpoint, unexpected exception) | every aid of the batch refetched over the single path **and the breaker trips** — the path is unavailable, stop using it this run |
| misalignment | same fallback, breaker trips — the path's data cannot be trusted |

**Removed:** `BatchEntry` / `BatchDispatchResult`, per-aid `attempts_spent` / `max_attempts`, the retry buffer and mixing of failed items into later batches, the batch-level colddown/backoff, and the pool-wide consecutive-failure counter. The controller now holds only the concurrency gate and a one-way `trip()` / `is_enabled()` breaker.

**Kept:** the pre-batch single-aid loop verbatim as the off-state path (`process()` picks one loop once); the pool-wide `max_concurrent_batches` gate (only batch invocations gated, fallback never); the return-side breaker re-check that discards in-flight responses after a trip; Service protocol/identity validation; the shared `RecordNew` mapping; the real-thread concurrency-cap, breaker-race and deadline tests. `_dispatch_batch(aids) -> bool` has the same contract as `_fetch_single` (False = record writer dead, job exits). No aid is ever dropped because of the batch path; the worst case is a few extra single-aid Lambda calls. 176 Python + 10 node tests green.

---

## Review round 3 (b3904ba) — two concurrency edges

- **Partial buffer on trip.** A job that observes the breaker open now resolves its partial batch buffer over the single path immediately — before handling the aid it just dequeued — instead of holding it until the queue drains (where a run deadline could have dropped it). Real-thread test: a job frozen between dequeues with one aid buffered, a sibling trips the breaker, the buffered aid is refetched first.
- **Slot acquired after a trip / deadline.** After a successful slot acquire the job re-checks the breaker and the deadline *before* sending. Abandoning gives the slot back in the same `finally` that covers the HTTP call, so every successful acquire releases exactly once and the fallback/drop work runs unthrottled afterwards. Real-thread test: the slot-holding job trips the breaker and frees the slot while a sibling is blocked waiting for it; the sibling acquires, never sends, falls back, and the slot is verifiably free afterwards.

178 Python + 10 node tests green.

---

## Review round 4 — deadline metric on the final-flush path

When the queue was already empty and the last partial batch was waiting for a slot at the deadline, the drop path returned and the loop broke out without ever reaching the loop-top check, so `batch_dropped_at_deadline` was counted but `duration_limit_reached` was not. The duration-limit hit is now recorded by an idempotent per-job helper shared by the batch loop top and the drop path — every deadline exit lands in the pool summary exactly once per job. The single-aid loop is untouched. Real-thread test added for queue-empty + partial flush + slot wait + deadline. 179 Python + 10 node tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
