### PR TITLE
feat: key-metric metadata and aligned run-metric time series

### DIFF
--- a/runrecord/__init__.py
+++ b/runrecord/__init__.py
@@ -1,8 +1,11 @@
 from . import schema
+from .keymetric import is_key_metric
 from .recorder import (
     RunRecorder, track, display_status,
     RUNNING, SUCCEEDED, FAILED, DEFAULT_DB_PATH,
 )
+from . import series
 
-__all__ = ['RunRecorder', 'track', 'display_status', 'schema',
+__all__ = ['RunRecorder', 'track', 'display_status', 'schema', 'series',
+           'is_key_metric',
            'RUNNING', 'SUCCEEDED', 'FAILED', 'DEFAULT_DB_PATH']

--- a/runrecord/keymetric.py
+++ b/runrecord/keymetric.py
@@ -1,0 +1,38 @@
+"""
+The key-metric convention (Phase 1.5).
+
+A *key metric* is generic display metadata attached to a metric itself: it means
+only "reasonable to surface by default in a cross-script overview". It does not
+express health, a good/bad direction, a threshold or an alert, it never changes
+a run's persisted status, and there is deliberately no per-script key-metric
+config table anywhere.
+
+``is_key_metric(name, is_key)`` resolves the effective flag:
+
+* an explicit, non-``None`` ``is_key`` (persisted in ``run_metric.is_key`` as
+  1 or 0 by a recorder that knows better) wins as-is -- including an explicit
+  ``0`` that suppresses the convention for an otherwise key-looking name;
+* otherwise a name-based convention applies, so rows written before the v2
+  column existed (all ``is_key IS NULL``) still get sensible defaults:
+  - ``total_count`` -- the JobStat row count -- is key;
+  - any name containing ``exception`` / ``error`` / ``fail`` / ``dropped``
+    (case-insensitive substring) is key;
+  - everything else is not key.
+"""
+
+__all__ = ['KEY_NAME_MARKERS', 'is_key_metric']
+
+# error-like counters worth surfacing by default; matched as a case-insensitive
+# substring so `other_exception`, `code_error`, `batch_insert_fail` and
+# `record_dropped_queue_full` are all covered.
+KEY_NAME_MARKERS = ('exception', 'error', 'fail', 'dropped')
+
+
+def is_key_metric(name, is_key=None):
+    """Return whether a metric is a key metric (see the module docstring)."""
+    if is_key is not None:
+        return bool(is_key)
+    lowered = (name or '').lower()
+    if lowered == 'total_count':
+        return True
+    return any(marker in lowered for marker in KEY_NAME_MARKERS)

--- a/runrecord/recorder.py
+++ b/runrecord/recorder.py
@@ -132,14 +132,25 @@ class RunRecorder:
             logger.warning(f'run record: failed to attach log locations ({e!r})')
 
     def add_metric(self, scope: str, name: str, value: float,
-                   unit: Optional[str] = None) -> None:
+                   unit: Optional[str] = None,
+                   key: Optional[bool] = None) -> None:
+        """
+        Persist one metric. ``key`` is optional display metadata:
+        leave it ``None`` to let the name-based convention decide at read time
+        (the default, and what ``add_job_stat_metrics`` does for ``total_count``
+        and the error-like counters), pass ``True`` to mark a genuine output
+        metric as key at its record site, or ``False`` to suppress the
+        convention for an otherwise key-looking name.
+        """
         if not self.enabled:
             return
         try:
             self._conn.execute(
-                'INSERT OR REPLACE INTO run_metric (run_id, scope, name, value, unit) '
-                'VALUES (?, ?, ?, ?, ?)',
-                (self.run_id, scope, name, float(value), unit))
+                'INSERT OR REPLACE INTO run_metric '
+                '(run_id, scope, name, value, unit, is_key) '
+                'VALUES (?, ?, ?, ?, ?, ?)',
+                (self.run_id, scope, name, float(value), unit,
+                 None if key is None else int(bool(key))))
             self._conn.commit()
         except Exception as e:
             logger.warning(f'run record: failed to add metric {scope}/{name} ({e!r})')

--- a/runrecord/schema.py
+++ b/runrecord/schema.py
@@ -14,6 +14,14 @@ free-text ``summary`` (it duplicates the structured fields + metrics), and
 missing migration steps in order and moves ``PRAGMA user_version`` *forward* only.
 A database written by newer code (``user_version`` > ``SCHEMA_VERSION``) is left
 untouched and ``init`` raises -- it never rewrites the version backwards.
+
+v2 adds the nullable ``run_metric.is_key`` column -- generic display metadata
+that marks a metric as "reasonable to show by default in a cross-script
+overview". It carries no health, direction, threshold or alerting meaning and
+never changes a run's status. ``NULL`` (every row written before v2, and every
+row the recorder does not flag explicitly) means "fall back to the name-based
+convention"; see ``runrecord.keymetric``. The migration is a plain additive
+``ALTER TABLE ... ADD COLUMN`` so it preserves every existing row.
 """
 
 __all__ = ['SCHEMA_VERSION', 'SchemaTooNewError', 'init']
@@ -22,7 +30,7 @@ __all__ = ['SCHEMA_VERSION', 'SchemaTooNewError', 'init']
 class SchemaTooNewError(RuntimeError):
     """The database is at a schema version this code does not understand."""
 
-SCHEMA_VERSION = 1
+SCHEMA_VERSION = 2
 
 _DDL_V1 = """
 CREATE TABLE IF NOT EXISTS run (
@@ -56,6 +64,19 @@ CREATE TABLE IF NOT EXISTS run_log (
 """
 
 
+def _apply_v2(conn):
+    """
+    v2: add the nullable ``run_metric.is_key`` column.
+
+    Guarded on the column already being present so a half-applied migration
+    (process died between the ``ALTER`` and the ``PRAGMA user_version`` bump)
+    re-runs cleanly instead of failing with "duplicate column name".
+    """
+    columns = {row[1] for row in conn.execute('PRAGMA table_info(run_metric)')}
+    if 'is_key' not in columns:
+        conn.execute('ALTER TABLE run_metric ADD COLUMN is_key INTEGER')
+
+
 def init(conn):
     """
     Create/upgrade the schema on ``conn``. Idempotent.
@@ -75,7 +96,10 @@ def init(conn):
     if current < 1:
         conn.executescript(_DDL_V1)
 
-    # future: `if current < 2: conn.executescript(_DDL_V2)` ...
+    if current < 2:
+        _apply_v2(conn)
+
+    # future: `if current < 3: _apply_v3(conn)` ...
 
     if current < SCHEMA_VERSION:
         # forward only; PRAGMA does not accept bound parameters

--- a/runrecord/series.py
+++ b/runrecord/series.py
@@ -1,0 +1,197 @@
+"""
+Aligned per-run metric time series over the run-record store (Phase 1.5).
+
+Given one ``script_name`` and a time window, return that script's runs as
+*points* (one per run) carrying run context plus the values of a chosen set of
+metrics, aligned so a single run is one row across every series.
+
+Read-only: only ``SELECT`` / ``PRAGMA``, never migrates. Tolerates a schema-v1
+database (no ``run_metric.is_key`` column) opened read-only -- ``is_key`` then
+reads as NULL and the name convention alone decides ``key``.
+
+Everything is scoped to the runs actually returned by the query (after
+``since`` / ``until`` / ``order`` / ``limit``): metric discovery, ``key``, unit
+and values all reflect those runs. Deliberately minimal -- it organises recorded
+facts. No health classification, rates, ratios, anomaly detection, schedule
+expectations or per-script configuration.
+
+Unit stability is a producer contract: a metric may be written with a NULL unit
+alongside one declared unit, but if a selected ``(scope, name)`` carries more
+than one distinct non-null unit across the queried runs, ``fetch_series`` /
+``available_metrics`` raise ``query.QueryError`` naming the metric and units
+rather than trying to reconcile them.
+"""
+
+from datetime import datetime, timezone
+
+from ._sqlite import sqlite3
+from .keymetric import is_key_metric
+from .query import QueryError, _fetch_runs, _record, _run_query, _FETCH_CAP
+from .recorder import DEFAULT_STALE_AFTER_S
+
+__all__ = ['DURATION_SERIES', 'available_metrics', 'default_key_metrics',
+           'fetch_series']
+
+# the built-in series derived from the run timestamps: selectable alongside the
+# persisted metrics but never stored. Every point already carries ``duration_s``.
+DURATION_SERIES = ('run', 'duration_s')
+
+
+def _has_is_key_column(conn):
+    try:
+        return any(row[1] == 'is_key'
+                   for row in conn.execute('PRAGMA table_info(run_metric)'))
+    except sqlite3.DatabaseError:
+        return False
+
+
+def _metric_rows(conn, run_ids):
+    """``(run_id, scope, name, value, unit, is_key)`` for the given runs."""
+    if not run_ids:
+        return []
+    col = 'is_key' if _has_is_key_column(conn) else 'NULL'
+    placeholders = ','.join('?' * len(run_ids))
+    return _run_query(
+        conn,
+        f'SELECT run_id, scope, name, value, unit, {col} FROM run_metric '
+        f'WHERE run_id IN ({placeholders}) ORDER BY run_id',
+        list(run_ids))
+
+
+def _identities(metric_rows):
+    """``{(scope, name): {'units': set, 'explicit': int|None}}`` over the rows."""
+    out = {}
+    for _run_id, scope, name, _value, unit, is_key in metric_rows:
+        info = out.setdefault((scope, name), {'units': set(), 'explicit': None})
+        if unit is not None:
+            info['units'].add(unit)
+        if is_key is not None:
+            info['explicit'] = int(is_key)   # rows are ordered by run_id
+    return out
+
+
+def _unit(scope, name, units):
+    if len(units) > 1:
+        raise QueryError(
+            f'metric {scope}/{name} has inconsistent units '
+            f'{sorted(units)} across the queried runs')
+    return next(iter(units)) if units else None
+
+
+def _identity_row(scope, name, info):
+    return {'scope': scope, 'name': name,
+            'unit': _unit(scope, name, info['units']),
+            'key': is_key_metric(name, info['explicit'])}
+
+
+def _fetch(conn, script_name, *, since, until, order, limit):
+    return _fetch_runs(conn, script=script_name, since=since, until=until,
+                       persisted_status=None, order=order,
+                       limit=limit if limit is not None else _FETCH_CAP)
+
+
+def available_metrics(conn, script_name, *, since=None, until=None,
+                      order='DESC', limit=None):
+    """
+    The ``(scope, name, unit, key)`` identities recorded by the queried runs of
+    ``script_name``, ordered by ``(scope, name)``. The same name under two
+    scopes yields two identities. Raises ``QueryError`` for an inconsistent unit.
+    """
+    rows = _fetch(conn, script_name, since=since, until=until,
+                  order=order, limit=limit)
+    idents = _identities(_metric_rows(conn, [r[0] for r in rows]))
+    return [_identity_row(scope, name, info)
+            for (scope, name), info in sorted(idents.items())]
+
+
+def default_key_metrics(conn, script_name, **kwargs):
+    """``available_metrics`` filtered to the identities that resolve as key."""
+    return [row for row in available_metrics(conn, script_name, **kwargs)
+            if row['key']]
+
+
+def _point(rec):
+    return {
+        'run_id': rec['run_id'],
+        'started_at': rec['started_at'],
+        'finished_at': rec['finished_at'],
+        'duration_s': rec['duration_s'],
+        'status': rec['status'],
+        'display_status': rec['display_status'],
+        'stale': rec['stale'],
+        'host': rec['host'],
+        'code_version': rec['code_version'],
+        'values': {},
+    }
+
+
+def fetch_series(conn, script_name, *, metrics=None, since=None, until=None,
+                 order='DESC', limit=None, now=None,
+                 stale_after_s=DEFAULT_STALE_AFTER_S):
+    """
+    Aligned per-run time series for ``script_name``.
+
+    ``metrics`` -- an iterable of ``(scope, name)`` pairs to select, order
+    preserved; ``('run', 'duration_s')`` selects the built-in duration series;
+    ``None`` selects the queried runs' key metrics. ``since`` / ``until`` bound
+    ``started_at``; ``order`` is ``'DESC'`` (default) or ``'ASC'``; ``limit``
+    caps the number of runs after ordering.
+
+    Returns::
+
+        {'script_name': str,
+         'series': [{'scope', 'name', 'unit', 'key'}, ...],
+         'points': [{'run_id', 'started_at', 'finished_at', 'duration_s',
+                     'status', 'display_status', 'stale', 'host',
+                     'code_version', 'values': {scope: {name: value}}}, ...]}
+
+    Every point always carries ``duration_s`` (``None`` until the run finishes).
+    ``values`` holds an entry only for metrics actually recorded on that run --
+    an absent metric is distinct from a stored ``0`` and is never zero-filled.
+    Raises ``QueryError`` if a selected metric has inconsistent units across the
+    queried runs.
+    """
+    now = now or datetime.now(timezone.utc)
+    order = 'ASC' if str(order).upper() == 'ASC' else 'DESC'
+
+    rows = _fetch(conn, script_name, since=since, until=until,
+                  order=order, limit=limit)
+    points = [_point(_record(r, now=now, stale_after=stale_after_s))
+              for r in rows]
+    by_id = {p['run_id']: p for p in points}
+
+    metric_rows = _metric_rows(conn, list(by_id))
+    idents = _identities(metric_rows)
+
+    if metrics is None:
+        selected = [k for k in sorted(idents)
+                    if is_key_metric(k[1], idents[k]['explicit'])]
+    else:
+        selected, seen = [], set()
+        for pair in metrics:
+            pair = tuple(pair)
+            if pair not in seen:
+                seen.add(pair)
+                selected.append(pair)
+
+    wanted = {p for p in selected if p != DURATION_SERIES}
+    for run_id, scope, name, value, _unit, _is_key in metric_rows:
+        if (scope, name) in wanted:
+            by_id[run_id]['values'].setdefault(scope, {})[name] = value
+
+    if DURATION_SERIES in selected:
+        for point in points:
+            if point['duration_s'] is not None:
+                point['values'].setdefault('run', {})['duration_s'] = \
+                    point['duration_s']
+
+    series = []
+    for scope, name in selected:
+        if (scope, name) == DURATION_SERIES:
+            series.append({'scope': 'run', 'name': 'duration_s',
+                           'unit': 'seconds', 'key': False})
+            continue
+        info = idents.get((scope, name), {'units': set(), 'explicit': None})
+        series.append(_identity_row(scope, name, info))
+
+    return {'script_name': script_name, 'series': series, 'points': points}

--- a/tests/test_run_record.py
+++ b/tests/test_run_record.py
@@ -1,5 +1,5 @@
 """
-Tests / reproducible verification for the run-record store (BL-0001).
+Tests / reproducible verification for the run-record store.
 
 Run from the repo root:
 
@@ -106,7 +106,9 @@ class SchemaTest(unittest.TestCase):
         conn = _connect(self.path)
         schema.init(conn)
         metric_cols = [r[1] for r in conn.execute('PRAGMA table_info(run_metric)')]
-        self.assertEqual(metric_cols, ['run_id', 'scope', 'name', 'value', 'unit'])
+        # schema v2 appends the nullable is_key column
+        self.assertEqual(metric_cols,
+                         ['run_id', 'scope', 'name', 'value', 'unit', 'is_key'])
         log_cols = [r[1] for r in conn.execute('PRAGMA table_info(run_log)')]
         self.assertEqual(log_cols, ['run_id', 'level', 'path'])
         conn.close()

--- a/tests/test_run_record_series.py
+++ b/tests/test_run_record_series.py
@@ -1,0 +1,401 @@
+"""
+Contract tests for the Phase 1.5 reading layer: the key-metric convention
+(``runrecord.keymetric``), the schema-v2 ``run_metric.is_key`` migration
+(``runrecord.schema``) and the aligned per-run time-series query
+(``runrecord.series``).
+
+Run from the repo root:
+
+    python -m unittest discover -s tests
+
+Stdlib only (unittest + the driver shim, which resolves to stdlib sqlite3 on a
+dev machine).
+"""
+
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runrecord import schema, series  # noqa: E402
+from runrecord.keymetric import is_key_metric  # noqa: E402
+from runrecord.recorder import RunRecorder  # noqa: E402
+from runrecord import query  # noqa: E402
+from runrecord._sqlite import sqlite3  # noqa: E402
+
+BASE = datetime(2026, 8, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _iso(dt):
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+class _DbCase(unittest.TestCase):
+    def setUp(self):
+        self.path = os.path.join(tempfile.mkdtemp(), 'run-records.sqlite3')
+
+    def _conn(self):
+        conn = sqlite3.connect(self.path)
+        self.addCleanup(conn.close)
+        return conn
+
+    def add_run(self, run_id, script, started, finished=None, status='running',
+                host='H', code_version='abc1234'):
+        conn = sqlite3.connect(self.path)
+        schema.init(conn)
+        conn.execute(
+            'INSERT INTO run (run_id, script_name, host, code_version, '
+            'started_at, finished_at, status) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            (run_id, script, host, code_version, _iso(started),
+             _iso(finished) if finished else None, status))
+        conn.commit()
+        conn.close()
+
+    def add_metric(self, run_id, scope, name, value, unit='count', is_key=None):
+        conn = sqlite3.connect(self.path)
+        conn.execute(
+            'INSERT OR REPLACE INTO run_metric '
+            '(run_id, scope, name, value, unit, is_key) VALUES (?, ?, ?, ?, ?, ?)',
+            (run_id, scope, name, float(value), unit, is_key))
+        conn.commit()
+        conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# key convention
+# --------------------------------------------------------------------------- #
+
+class KeyConventionTest(unittest.TestCase):
+    def test_name_convention(self):
+        for key_name in ('total_count', 'exception', 'other_exception',
+                         'code_error', 'batch_insert_fail',
+                         'record_dropped_queue_full', 'MillionException'):
+            self.assertTrue(is_key_metric(key_name), key_name)
+        for plain_name in ('success', 'new_video', 'records_added', '0_update'):
+            self.assertFalse(is_key_metric(plain_name), plain_name)
+
+    def test_explicit_flag_overrides_convention(self):
+        self.assertTrue(is_key_metric('records_added', True))    # promote
+        self.assertFalse(is_key_metric('total_count', False))    # suppress
+        self.assertFalse(is_key_metric('other_exception', 0))
+
+
+# --------------------------------------------------------------------------- #
+# schema v2 migration
+# --------------------------------------------------------------------------- #
+
+class SchemaMigrationTest(_DbCase):
+    def _cols(self):
+        return [r[1] for r in self._conn().execute(
+            'PRAGMA table_info(run_metric)')]
+
+    def _version(self):
+        return self._conn().execute('PRAGMA user_version').fetchone()[0]
+
+    def test_fresh_database_is_v2_with_is_key(self):
+        conn = sqlite3.connect(self.path)
+        schema.init(conn)
+        conn.close()
+        self.assertEqual(schema.SCHEMA_VERSION, 2)
+        self.assertEqual(self._version(), 2)
+        self.assertIn('is_key', self._cols())
+
+    def test_v1_database_migrates_and_keeps_history(self):
+        conn = sqlite3.connect(self.path)
+        conn.executescript(schema._DDL_V1)
+        conn.execute('PRAGMA user_version = 1')
+        conn.execute(
+            "INSERT INTO run (run_id, script_name, host, code_version, "
+            "started_at, finished_at, status) "
+            "VALUES ('r1', 's', 'H', 'v0', ?, ?, 'succeeded')",
+            (_iso(BASE), _iso(BASE + timedelta(minutes=5))))
+        conn.execute("INSERT INTO run_metric (run_id, scope, name, value, unit) "
+                     "VALUES ('r1', 'x', 'total_count', 42, 'count')")
+        conn.commit()
+        conn.close()
+
+        conn = sqlite3.connect(self.path)
+        schema.init(conn)
+        conn.close()
+
+        self.assertEqual(self._version(), 2)
+        self.assertIn('is_key', self._cols())
+        row = self._conn().execute(
+            'SELECT value, unit, is_key FROM run_metric WHERE run_id = ?',
+            ('r1',)).fetchone()
+        self.assertEqual(row, (42.0, 'count', None))
+
+    def test_migration_is_idempotent(self):
+        conn = sqlite3.connect(self.path)
+        schema.init(conn)
+        schema.init(conn)
+        conn.close()
+        self.assertEqual(self._version(), 2)
+        self.assertEqual(self._cols().count('is_key'), 1)
+
+    def test_migration_recovers_if_column_already_present(self):
+        # column added but version still 1 (process died mid-migration)
+        conn = sqlite3.connect(self.path)
+        conn.executescript(schema._DDL_V1)
+        conn.execute('ALTER TABLE run_metric ADD COLUMN is_key INTEGER')
+        conn.execute('PRAGMA user_version = 1')
+        conn.commit()
+        schema.init(conn)
+        conn.close()
+        self.assertEqual(self._version(), 2)
+        self.assertEqual(self._cols().count('is_key'), 1)
+
+    def test_recorder_writes_the_explicit_flag(self):
+        rec = RunRecorder.start('s', db_path=self.path)
+        rec.add_metric('x', 'plain', 1)
+        rec.add_metric('x', 'declared', 2, key=True)
+        rec.add_metric('x', 'suppressed', 3, key=False)
+        rec.finish('succeeded')
+        got = dict(self._conn().execute('SELECT name, is_key FROM run_metric'))
+        self.assertEqual((got['plain'], got['declared'], got['suppressed']),
+                         (None, 1, 0))
+
+
+# --------------------------------------------------------------------------- #
+# available_metrics
+# --------------------------------------------------------------------------- #
+
+class AvailableMetricsTest(_DbCase):
+    def seed(self):
+        self.add_run('r1', 's', BASE, BASE + timedelta(minutes=5), 'succeeded')
+        self.add_metric('r1', 'fetch', 'total_count', 100)
+        self.add_metric('r1', 'fetch', 'other_exception', 3)
+        self.add_metric('r1', 'fetch', 'success', 97)
+        self.add_metric('r1', 'db', 'total_count', 97)          # same name, other scope
+        self.add_metric('r1', 'fetch', 'records_added', 97, is_key=1)
+
+    def test_identities_carry_scope_name_unit_and_key(self):
+        self.seed()
+        rows = {(r['scope'], r['name']): r
+                for r in series.available_metrics(self._conn(), 's')}
+        self.assertEqual(set(rows), {
+            ('fetch', 'total_count'), ('fetch', 'other_exception'),
+            ('fetch', 'success'), ('fetch', 'records_added'),
+            ('db', 'total_count')})
+        self.assertTrue(rows[('fetch', 'total_count')]['key'])
+        self.assertTrue(rows[('db', 'total_count')]['key'])       # not merged with fetch
+        self.assertTrue(rows[('fetch', 'other_exception')]['key'])
+        self.assertFalse(rows[('fetch', 'success')]['key'])
+        self.assertTrue(rows[('fetch', 'records_added')]['key'])  # explicit is_key=1
+        self.assertEqual(rows[('fetch', 'total_count')]['unit'], 'count')
+
+    def test_default_key_metrics_filters(self):
+        self.seed()
+        keys = {(r['scope'], r['name'])
+                for r in series.default_key_metrics(self._conn(), 's')}
+        self.assertEqual(keys, {
+            ('fetch', 'total_count'), ('db', 'total_count'),
+            ('fetch', 'other_exception'), ('fetch', 'records_added')})
+
+    def test_unknown_script_is_empty(self):
+        self.seed()
+        self.assertEqual(series.available_metrics(self._conn(), 'nope'), [])
+
+
+# --------------------------------------------------------------------------- #
+# fetch_series
+# --------------------------------------------------------------------------- #
+
+class FetchSeriesTest(_DbCase):
+    def seed(self):
+        self.add_run('r1', 's', BASE, BASE + timedelta(minutes=5), 'succeeded')
+        self.add_run('r2', 's', BASE + timedelta(hours=1),
+                     BASE + timedelta(hours=1, minutes=10), 'succeeded')
+        self.add_run('r3', 's', BASE + timedelta(hours=2),
+                     BASE + timedelta(hours=2, minutes=3), 'failed')
+        self.add_run('r4', 's', BASE + timedelta(hours=3), None, 'running')
+        self.add_metric('r1', 'fetch', 'total_count', 100)
+        self.add_metric('r1', 'fetch', 'other_exception', 0)      # recorded zero
+        self.add_metric('r2', 'fetch', 'total_count', 200)
+        self.add_metric('r2', 'fetch', 'other_exception', 5)
+        self.add_metric('r3', 'fetch', 'total_count', 50)         # no exception metric
+
+    def test_points_are_aligned_and_carry_run_context(self):
+        self.seed()
+        res = series.fetch_series(
+            self._conn(), 's', order='ASC',
+            metrics=[('fetch', 'total_count'), ('fetch', 'other_exception')],
+            now=BASE + timedelta(hours=7))
+        self.assertEqual(res['script_name'], 's')
+        self.assertEqual([s['scope'] + '.' + s['name'] for s in res['series']],
+                         ['fetch.total_count', 'fetch.other_exception'])
+        p = {pt['run_id']: pt for pt in res['points']}
+        self.assertEqual(set(p['r1']), {
+            'run_id', 'started_at', 'finished_at', 'duration_s', 'status',
+            'display_status', 'stale', 'host', 'code_version', 'values'})
+        self.assertEqual(p['r1']['duration_s'], 300.0)
+        self.assertEqual(p['r1']['values'],
+                         {'fetch': {'total_count': 100.0, 'other_exception': 0.0}})
+        self.assertEqual(p['r2']['values'],
+                         {'fetch': {'total_count': 200.0, 'other_exception': 5.0}})
+
+    def test_missing_is_distinct_from_zero(self):
+        self.seed()
+        res = series.fetch_series(self._conn(), 's',
+                                  metrics=[('fetch', 'other_exception')],
+                                  now=BASE + timedelta(hours=7))
+        p = {pt['run_id']: pt for pt in res['points']}
+        self.assertEqual(p['r1']['values'], {'fetch': {'other_exception': 0.0}})
+        self.assertEqual(p['r3']['values'], {})       # never recorded -> absent
+        self.assertEqual(p['r4']['values'], {})
+
+    def test_same_name_under_two_scopes_stays_separate(self):
+        self.add_run('r1', 's', BASE, BASE + timedelta(minutes=5), 'succeeded')
+        self.add_metric('r1', 'fetch', 'total_count', 100, unit='count')
+        self.add_metric('r1', 'db', 'total_count', 98, unit='rows')
+        res = series.fetch_series(
+            self._conn(), 's',
+            metrics=[('fetch', 'total_count'), ('db', 'total_count')],
+            now=BASE + timedelta(hours=1))
+        self.assertEqual(res['series'], [
+            {'scope': 'fetch', 'name': 'total_count', 'unit': 'count', 'key': True},
+            {'scope': 'db', 'name': 'total_count', 'unit': 'rows', 'key': True}])
+        self.assertEqual(res['points'][0]['values'],
+                         {'fetch': {'total_count': 100.0},
+                          'db': {'total_count': 98.0}})
+
+    def test_metrics_none_selects_key_metrics(self):
+        self.seed()
+        res = series.fetch_series(self._conn(), 's', now=BASE + timedelta(hours=7))
+        self.assertEqual({(s['scope'], s['name']) for s in res['series']},
+                         {('fetch', 'total_count'), ('fetch', 'other_exception')})
+        self.assertTrue(all(s['key'] for s in res['series']))
+
+    def test_duration_is_a_builtin_series(self):
+        self.seed()
+        res = series.fetch_series(
+            self._conn(), 's',
+            metrics=[('fetch', 'total_count'), series.DURATION_SERIES],
+            now=BASE + timedelta(hours=7))
+        self.assertEqual(res['series'][-1], {'scope': 'run', 'name': 'duration_s',
+                                             'unit': 'seconds', 'key': False})
+        p = {pt['run_id']: pt for pt in res['points']}
+        self.assertEqual(p['r2']['duration_s'], 600.0)                  # point field
+        self.assertEqual(p['r2']['values']['run']['duration_s'], 600.0)  # mirrored
+        self.assertNotIn('run', p['r4']['values'])                      # unfinished
+
+    def test_duration_not_mirrored_unless_selected(self):
+        self.seed()
+        res = series.fetch_series(self._conn(), 's',
+                                  metrics=[('fetch', 'total_count')],
+                                  now=BASE + timedelta(hours=7))
+        p = {pt['run_id']: pt for pt in res['points']}
+        self.assertNotIn('run', p['r1']['values'])
+        self.assertEqual(p['r1']['duration_s'], 300.0)
+
+    def test_since_until_order_limit(self):
+        self.seed()
+        asc = series.fetch_series(self._conn(), 's', metrics=[], order='ASC',
+                                  now=BASE + timedelta(hours=7))
+        self.assertEqual([p['run_id'] for p in asc['points']],
+                         ['r1', 'r2', 'r3', 'r4'])
+        desc2 = series.fetch_series(self._conn(), 's', metrics=[], order='DESC',
+                                    limit=2, now=BASE + timedelta(hours=7))
+        self.assertEqual([p['run_id'] for p in desc2['points']], ['r4', 'r3'])
+        window = series.fetch_series(
+            self._conn(), 's', metrics=[],
+            since=BASE + timedelta(minutes=30),
+            until=BASE + timedelta(hours=2, minutes=30),
+            now=BASE + timedelta(hours=7))
+        self.assertEqual([p['run_id'] for p in window['points']], ['r3', 'r2'])
+
+    def test_lifecycle_points_are_returned_and_labelled(self):
+        self.seed()
+        res = series.fetch_series(self._conn(), 's', metrics=[],
+                                  now=BASE + timedelta(hours=7))
+        p = {pt['run_id']: pt for pt in res['points']}
+        self.assertEqual(p['r3']['display_status'], 'failed')
+        self.assertEqual(p['r4']['display_status'], 'stale')   # running > 3h
+        self.assertTrue(p['r4']['stale'])
+        self.assertIsNone(p['r4']['duration_s'])
+
+    def test_null_unit_coexists_with_one_declared_unit(self):
+        self.add_run('r1', 's', BASE, BASE + timedelta(minutes=5), 'succeeded')
+        self.add_run('r2', 's', BASE + timedelta(hours=1),
+                     BASE + timedelta(hours=1, minutes=5), 'succeeded')
+        self.add_metric('r1', 'x', 'n', 1, unit=None)
+        self.add_metric('r2', 'x', 'n', 2, unit='count')
+        res = series.fetch_series(self._conn(), 's', metrics=[('x', 'n')],
+                                  order='ASC', now=BASE + timedelta(hours=7))
+        self.assertEqual(res['series'][0]['unit'], 'count')
+        p = {pt['run_id']: pt for pt in res['points']}
+        self.assertEqual(p['r1']['values'], {'x': {'n': 1.0}})
+        self.assertEqual(p['r2']['values'], {'x': {'n': 2.0}})
+
+    def test_inconsistent_units_raise_query_error(self):
+        self.add_run('r1', 's', BASE, BASE + timedelta(minutes=5), 'succeeded')
+        self.add_run('r2', 's', BASE + timedelta(hours=1),
+                     BASE + timedelta(hours=1, minutes=5), 'succeeded')
+        self.add_metric('r1', 'x', 'window', 60, unit='count')
+        self.add_metric('r2', 'x', 'window', 3600, unit='seconds')
+        with self.assertRaises(query.QueryError) as ctx:
+            series.fetch_series(self._conn(), 's', metrics=[('x', 'window')],
+                                now=BASE + timedelta(hours=7))
+        msg = str(ctx.exception)
+        self.assertIn('x/window', msg)
+        self.assertIn('count', msg)
+        self.assertIn('seconds', msg)
+
+
+# --------------------------------------------------------------------------- #
+# pre-v2 read-only + read-only invariants
+# --------------------------------------------------------------------------- #
+
+class PreV2ReadOnlyTest(_DbCase):
+    def test_v1_database_is_queryable_read_only(self):
+        conn = sqlite3.connect(self.path)
+        conn.executescript(schema._DDL_V1)          # no is_key column
+        conn.execute('PRAGMA user_version = 1')
+        conn.execute(
+            "INSERT INTO run (run_id, script_name, host, code_version, "
+            "started_at, finished_at, status) "
+            "VALUES ('r1', 's', 'H', 'v0', ?, ?, 'succeeded')",
+            (_iso(BASE), _iso(BASE + timedelta(minutes=5))))
+        conn.executescript(
+            "INSERT INTO run_metric (run_id, scope, name, value, unit) VALUES "
+            "('r1', 'fetch', 'total_count', 100, 'count'),"
+            "('r1', 'fetch', 'success', 98, 'count');")
+        conn.commit()
+        conn.close()
+
+        ro = query._connect_ro(self.path)
+        self.addCleanup(ro.close)
+        rows = {(r['scope'], r['name']): r
+                for r in series.available_metrics(ro, 's')}
+        self.assertTrue(rows[('fetch', 'total_count')]['key'])
+        self.assertFalse(rows[('fetch', 'success')]['key'])
+        res = series.fetch_series(ro, 's', now=BASE + timedelta(hours=1))
+        self.assertEqual([s['name'] for s in res['series']], ['total_count'])
+        self.assertEqual(res['points'][0]['values']['fetch']['total_count'], 100.0)
+
+
+class ReadOnlyInvariantTest(_DbCase):
+    def test_queries_never_write_the_database(self):
+        self.add_run('r1', 's', BASE, BASE + timedelta(minutes=5), 'succeeded')
+        self.add_metric('r1', 'fetch', 'total_count', 100)
+        before = os.stat(self.path)
+        ro = query._connect_ro(self.path)
+        try:
+            series.available_metrics(ro, 's')
+            series.fetch_series(ro, 's')
+            series.fetch_series(ro, 's', metrics=[('fetch', 'total_count')],
+                                order='ASC', limit=5)
+        finally:
+            ro.close()
+        after = os.stat(self.path)
+        self.assertEqual((before.st_size, before.st_mtime),
+                         (after.st_size, after.st_mtime))
+        for sidecar in ('-wal', '-journal', '-shm'):
+            self.assertFalse(os.path.exists(self.path + sidecar))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

A small cross-script reading layer over the run-record store: a few metrics can be marked *key* for default overviews, and any recorded numeric metric can be read back as a per-run aligned time series. It organises facts that are already recorded — no health classification, thresholds, rate/ratio inference, anomaly detection, schedule config, or per-script dashboard config, and no new service or dependency.

## Schema (v2)

- Adds a **nullable `run_metric.is_key`** column via an additive, idempotent `ALTER TABLE ... ADD COLUMN`.
- `PRAGMA user_version` moves forward only; a migration that only half-applied (process died between the `ALTER` and the version bump) re-runs cleanly because the step is guarded on the column already existing.
- **Backward compatible.** A v1 database keeps working with the existing `list` / `show` CLI and the read-only web view — neither reads the new column. `RunRecorder.start` upgrades a v1 file in place on its next run. Existing rows are preserved with `is_key = NULL`.
- Code that opens the store **read-only** tolerates a pre-v2 database with no `is_key` column.

## `is_key` semantics

Generic display metadata only — \"reasonable to show by default in a cross-script overview\". No health / direction / threshold / alerting meaning; never changes a run's status. Resolution (`runrecord/keymetric.is_key_metric`):

1. An explicit non-NULL flag wins (including an explicit `0` that suppresses an otherwise key-looking name).
2. Otherwise a name convention: `total_count`, and any name containing `exception` / `error` / `fail` / `dropped` (case-insensitive substring), are key.

No per-script config table. `RunRecorder.add_metric` gains an optional `key=` argument to set or suppress the flag at the record site; `add_job_stat_metrics` is unchanged (its rows stay `NULL` and resolve by convention, so old and new rows behave identically).

## Query (`runrecord/series.py`, read-only)

Everything — metric discovery, `key`, `unit`, values — is scoped to the runs the query actually returns (after `since` / `until` / `order` / `limit`).

- `available_metrics` / `default_key_metrics` — the `(scope, name, unit, key)` identities recorded by the queried runs. The same `name` under two scopes stays two identities.
- `fetch_series(conn, script, metrics=None, since/until/order/limit)` returns:
  \`\`\`
  {script_name,
   series: [{scope, name, unit, key}, ...],
   points: [{run_id, started_at, finished_at, duration_s, status,
             display_status, stale, host, code_version,
             values: {scope: {name: value}}}, ...]}
  \`\`\`
  - **Missing != zero**: `values` holds an entry only for metrics actually recorded on that run; an absent metric is never zero-filled.
  - `('run', 'duration_s')` is a selectable **built-in series** (derived from timestamps, never stored); every point also always carries the top-level `duration_s` field.
  - `running` / `failed` / `stale` points are returned and labelled, not silently dropped.
  - `metrics=None` selects the queried runs' key metrics.

### Unit stability is a producer contract

A metric may be written with a NULL unit alongside one declared unit. But if a selected `(scope, name)` carries **more than one distinct non-null unit** across the queried runs, `fetch_series` / `available_metrics` raise `query.QueryError` naming the metric and the units (e.g. `metric x/window has inconsistent units ['count', 'seconds'] across the queried runs`) rather than trying to reconcile or partially recover.

## Tests

`tests/test_run_record_series.py` — 22 focused cases: the migration (fresh, v1→v2 preserving history, idempotent, column-already-present recovery, recorder writes the flag); the key convention; `available_metrics`; aligned multi-metric points; missing-vs-zero; two scopes with the same name; the duration built-in; `since`/`until`/`order`/`limit`; lifecycle context; the conflicting-unit error; pre-v2 read-only querying; and read-only invariants (file mtime/size unchanged, no `-wal` / `-journal` / `-shm`).

`tests/test_run_record.py` — the `run_metric` column assertion now includes `is_key`.

\`\`\`
python -m unittest discover -s tests
Ran 142 tests in ~8s
OK
\`\`\`
(Python 3.11: 142 pass. Framework Python 3.11.3: 142, 14 skipped — the pre-existing db/service integration suites that need SQLAlchemy.)

## Scope

Data layer only. No CLI or web surface for the new reading layer in this PR; no deployment.

## Accepted trade-off

`key` and `unit` reflect the runs being queried, so different `order` / `limit` / time windows for one script can surface different default metrics or a different reported `unit`. Fine for a single-machine personal tool at this data volume; a consumer that needs stable columns can pin them later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)