### PR TITLE
runrecord CLI: script overview and per-run metric trend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,26 @@ systems, local absolute paths, private session links, server aliases, or
 internal deployment records. Refer to private context only in the private
 system where it lives.
 
+This restriction also applies to every tracked file, including source comments,
+docstrings, tests, fixtures, examples, and repository documentation. Never add
+private ticket IDs (such as `BL-...`), knowledge-base paths, local absolute
+paths, agent/session links, or internal planning notes to tracked content.
+
+Before committing or opening a pull request, inspect the added lines in the
+public diff for private-context leaks. Use an equivalent check when the base is
+not `origin/master`:
+
+```bash
+git diff --unified=0 origin/master...HEAD \
+  | rg '^\+' \
+  | rg 'BL-[0-9]+|/Users/|Projects/kb|Projects/bl|claude\.ai|private (backlog|ticket)|session link'
+```
+
+Any match must be reviewed and removed unless the matched text is itself part
+of this public-hygiene instruction. Existing historical matches do not justify
+adding new ones; keep checks scoped to the current diff rather than treating
+the whole repository as clean.
+
 ## Repository notes
 
 - Scripts are numbered by role (`12_`, `51_`, …) and run from cron on the prod

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ ssh -N -L 8765:127.0.0.1:8765 <server>
 Or as a single command from the workstation:
 
 ```shell
-ssh -L 8765:127.0.0.1:8765 <server> \
-  'cd <project-directory> && python3 -m runrecord.web --host 127.0.0.1 --port 8765 --db data/run-records.sqlite3'
+ssh -t \
+  -o ServerAliveInterval=30 \
+  -o ServerAliveCountMax=3 \
+  -L 8765:127.0.0.1:8765 <server> \
+  'cd <project-directory> && exec python3 -m runrecord.web --host 127.0.0.1 --port 8765 --db data/run-records.sqlite3'
 ```
+
+The PTY makes the foreground server follow the SSH session lifecycle, while
+the keepalive options detect a dead connection instead of leaving it unnoticed.

--- a/README_zh-CN.md
+++ b/README_zh-CN.md
@@ -99,9 +99,14 @@ ssh -N -L 8765:127.0.0.1:8765 <服务器>
 也可在工作机上一条命令完成：
 
 ```shell script
-ssh -L 8765:127.0.0.1:8765 <服务器> \
-  'cd <项目目录> && python3 -m runrecord.web --host 127.0.0.1 --port 8765 --db data/run-records.sqlite3'
+ssh -t \
+  -o ServerAliveInterval=30 \
+  -o ServerAliveCountMax=3 \
+  -L 8765:127.0.0.1:8765 <服务器> \
+  'cd <项目目录> && exec python3 -m runrecord.web --host 127.0.0.1 --port 8765 --db data/run-records.sqlite3'
 ```
+
+PTY 使前台 Web 进程跟随 SSH session 的生命周期，keepalive 则会及时发现已经失效的连接。
 
 ## 脚本列表
 

--- a/runrecord/query.py
+++ b/runrecord/query.py
@@ -12,6 +12,15 @@ Run it as a module::
     python -m runrecord show --latest --script 51_hourly-video-record-add
     python -m runrecord show a1b2c3d4          # full id or a unique prefix
     python -m runrecord list --json            # stable machine-readable output
+    python -m runrecord overview               # one row per script, latest run + key metrics
+    python -m runrecord trend --script 51_hourly-video-record-add --since 7d
+    python -m runrecord trend --script 51_hourly-video-record-add \
+        --metric record-fetch/total_count --metric record-fetch/other_exception --json
+
+``overview`` and ``trend`` are the metric reading commands: ``overview`` compares
+scripts at a glance, ``trend`` aligns one script's runs into a per-run time
+series. Both organise already-recorded facts -- no health classification, rates,
+thresholds, anomaly detection or forecasting.
 
 Everything reused from the rest of the package rather than reimplemented:
 
@@ -38,10 +47,12 @@ import json
 import os
 import pathlib
 import re
+import shutil
 import sys
 from datetime import datetime, timedelta, timezone
 
 from ._sqlite import sqlite3
+from .keymetric import is_key_metric
 from .recorder import (
     _parse_iso,
     _resolve_db_path,
@@ -248,6 +259,15 @@ def _run_query(conn, sql, params=()):
         raise QueryError(f'query failed: {e}', EXIT_DB_ERROR)
 
 
+def _has_is_key_col(conn):
+    """True if this database is schema v2+ (``run_metric.is_key`` present)."""
+    try:
+        return any(row[1] == 'is_key'
+                   for row in conn.execute('PRAGMA table_info(run_metric)'))
+    except sqlite3.DatabaseError:
+        return False
+
+
 def _grouped_metrics(conn, run_id):
     out = {}
     rows = _run_query(
@@ -258,6 +278,21 @@ def _grouped_metrics(conn, run_id):
         out.setdefault(scope, []).append(
             {'name': name, 'value': value, 'unit': unit})
     return out
+
+
+def _explicit_key_flags(conn, run_id):
+    """``{(scope, name): 0|1}`` for metrics of ``run_id`` with an explicit flag.
+
+    Empty on a schema-v1 database (no ``is_key`` column) -- callers then fall
+    back to the name-based key convention alone.
+    """
+    if not _has_is_key_col(conn):
+        return {}
+    rows = _run_query(
+        conn,
+        'SELECT scope, name, is_key FROM run_metric '
+        'WHERE run_id = ? AND is_key IS NOT NULL', (run_id,))
+    return {(scope, name): flag for scope, name, flag in rows}
 
 
 def _log_paths(conn, run_id):
@@ -318,8 +353,10 @@ def _persisted_prefilter(status):
 
 
 def _query_dict(args, command):
-    q = {'command': command, 'script': getattr(args, 'script', None),
-         'status': getattr(args, 'status', None)}
+    q = {'command': command, 'stale_after_s': args.stale_after}
+    if command in ('list', 'show'):
+        q['script'] = getattr(args, 'script', None)
+        q['status'] = getattr(args, 'status', None)
     if command == 'list':
         q['since'] = args.since.isoformat() if args.since else None
         q['until'] = args.until.isoformat() if args.until else None
@@ -327,7 +364,15 @@ def _query_dict(args, command):
     if command == 'show':
         q['run_id'] = args.run_id
         q['latest'] = args.latest
-    q['stale_after_s'] = args.stale_after
+    if command == 'overview':
+        q['since'] = args.since.isoformat() if args.since else None
+        q['max_metrics'] = args.max_metrics
+    if command == 'trend':
+        q['script'] = args.script
+        q['since'] = args.since.isoformat() if args.since else None
+        q['until'] = args.until.isoformat() if args.until else None
+        q['limit'] = args.limit
+        q['metrics'] = ([list(m) for m in args.metrics] if args.metrics else None)
     return q
 
 
@@ -409,6 +454,106 @@ def _resolve_one(conn, run_id):
 
 
 # --------------------------------------------------------------------------- #
+# overview / trend commands (metric overview and trend)
+# --------------------------------------------------------------------------- #
+
+def _parse_metric_arg(raw):
+    """``"scope/name"`` -> ``(scope, name)``; ``"duration"`` -> the built-in series."""
+    from .series import DURATION_SERIES
+
+    text = raw.strip()
+    if text in ('duration', 'duration_s', 'run/duration_s'):
+        return DURATION_SERIES
+    scope, sep, name = text.partition('/')
+    scope, name = scope.strip(), name.strip()
+    if not sep or not scope or not name:
+        raise QueryError(
+            f'--metric {raw!r} must be SCOPE/NAME (or "duration")', EXIT_USAGE)
+    return (scope, name)
+
+
+def _pick_key_metrics(grouped, flags, cap):
+    """Flatten ``{scope: [entry]}`` to the key metrics, capped and ordered.
+
+    ``flags`` is ``{(scope, name): 0|1}`` of explicit ``is_key`` values; the
+    name-based convention decides the rest. Order is deterministic and
+    independent of the run: ``total_count`` first, then everything else, each
+    group sorted by ``(scope, name)``. A display choice only -- it carries no
+    health, direction or threshold meaning.
+    """
+    flat = []
+    for scope in grouped:
+        for e in grouped[scope]:
+            if is_key_metric(e['name'], flags.get((scope, e['name']))):
+                flat.append({'scope': scope, 'name': e['name'],
+                             'value': e['value'], 'unit': e['unit']})
+    flat.sort(key=lambda m: (0 if m['name'].lower() == 'total_count' else 1,
+                             m['scope'], m['name']))
+    return flat if cap is None else flat[:cap]
+
+
+def _cmd_overview(args, conn, db_path, db_version):
+    now = datetime.now(timezone.utc)
+    rows = _fetch_runs(conn, since=args.since, order='DESC')
+
+    latest = {}
+    for row in rows:
+        latest.setdefault(row[1], row)          # row[1] == script_name; DESC -> newest kept
+
+    records = []
+    for script in sorted(latest):
+        rec = _record(latest[script], now=now, stale_after=args.stale_after,
+                      conn=conn, detail=True)
+        flags = _explicit_key_flags(conn, rec['run_id'])
+        rec['key_metrics'] = _pick_key_metrics(rec['metrics'], flags,
+                                               args.max_metrics)
+        records.append(rec)
+
+    payload = {
+        'schema_version': db_version,
+        'db_path': db_path,
+        'generated_at': now.isoformat(),
+        'query': _query_dict(args, 'overview'),
+        'count': len(records),
+        'scripts': records,
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True))
+    else:
+        _print_overview(records, db_path=db_path, db_version=db_version)
+    return EXIT_OK if records else EXIT_NO_MATCH
+
+
+def _cmd_trend(args, conn, db_path, db_version):
+    from . import series as _series
+
+    now = datetime.now(timezone.utc)
+    # select the most recent --limit runs in the window, then present them
+    # oldest -> newest so the table and the sparkline read left-to-right in time.
+    result = _series.fetch_series(
+        conn, args.script, metrics=args.metrics,
+        since=args.since, until=args.until, order='DESC',
+        limit=args.limit, now=now, stale_after_s=args.stale_after)
+    result['points'].reverse()
+
+    payload = {
+        'schema_version': db_version,
+        'db_path': db_path,
+        'generated_at': now.isoformat(),
+        'query': _query_dict(args, 'trend'),
+        'script_name': result['script_name'],
+        'series': result['series'],
+        'count': len(result['points']),
+        'points': result['points'],
+    }
+    if args.json:
+        print(json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True))
+    else:
+        _print_trend(payload, args=args, db_path=db_path, db_version=db_version)
+    return EXIT_OK if result['points'] else EXIT_NO_MATCH
+
+
+# --------------------------------------------------------------------------- #
 # human-readable rendering
 # --------------------------------------------------------------------------- #
 
@@ -486,12 +631,161 @@ def _print_detail(r, *, db_path, db_version):
 
 
 # --------------------------------------------------------------------------- #
+# overview / trend rendering
+# --------------------------------------------------------------------------- #
+
+_SPARK_TICKS = '▁▂▃▄▅▆▇█'
+
+
+def _fmt_num(value):
+    """Render a metric value compactly; ``None`` (a missing point) -> ``'-'``."""
+    if value is None:
+        return '-'
+    if isinstance(value, bool):
+        return str(value)
+    if isinstance(value, float):
+        return str(int(value)) if value.is_integer() else repr(value)
+    return str(value)
+
+
+def _trend_value(point, scope, name):
+    return point['values'].get(scope, {}).get(name)
+
+
+def _sparkline(values):
+    """A fixed-width magnitude sketch; a missing entry renders as ``·``.
+
+    It encodes only the min..max range of the values actually present -- never a
+    direction, rate or judgement. ``·`` marks a gap and is never a zero.
+    """
+    present = [v for v in values if v is not None]
+    if not present:
+        return '·' * len(values)
+    lo, hi = min(present), max(present)
+    span = hi - lo
+    out = []
+    for v in values:
+        if v is None:
+            out.append('·')
+        elif span == 0:
+            out.append(_SPARK_TICKS[len(_SPARK_TICKS) // 2])
+        else:
+            out.append(_SPARK_TICKS[
+                int(round((v - lo) / span * (len(_SPARK_TICKS) - 1)))])
+    return ''.join(out)
+
+
+def _print_overview(records, *, db_path, db_version):
+    print(f'{len(records)} script(s)   db: {db_path}   schema: v{db_version}   '
+          f'times: {_local_tz_label()}')
+    if not records:
+        print('(no runs recorded)')
+        return
+    print()
+    print(f'{"SCRIPT":<34}  {"LATEST (local)":<19}  {"STATUS":<9}  '
+          f'{"DURATION":>8}  KEY METRICS')
+    for r in records:
+        script = r['script_name']
+        if len(script) > 34:
+            script = script[:33] + '…'
+        km = r['key_metrics']
+        rendered = ('  '.join(f'{m["scope"]}/{m["name"]}={_fmt_num(m["value"])}'
+                              for m in km)
+                    if km else '(no key metrics)')
+        print(f'{script:<34}  {_local(r["started_at"]):<19}  '
+              f'{r["display_status"]:<9}  {_human_duration(r["duration_s"]):>8}  '
+              f'{rendered}')
+
+
+def _print_trend(payload, *, args, db_path, db_version):
+    points = payload['points']
+    series_defs = payload['series']
+
+    print(f'{len(points)} run(s)   script: {payload["script_name"]}   '
+          f'db: {db_path}   schema: v{db_version}   times: {_local_tz_label()}')
+    since = f'since {args.since.isoformat()}' if args.since else 'since -'
+    until = f'until {args.until.isoformat()}' if args.until else 'until now'
+    print(f'window: {since}   {until}   limit: {args.limit} newest, oldest first')
+    print()
+
+    if not points:
+        print('(no runs in window)')
+        return
+
+    print('series:')
+    for s in series_defs:
+        unit = f' ({s["unit"]})' if s.get('unit') else ''
+        tag = ' [key]' if s.get('key') else ''
+        print(f'  {s["scope"]}/{s["name"]}{unit}{tag}')
+    if not series_defs:
+        print('  (no key metrics recorded by these runs; '
+              'select some with --metric)')
+    print()
+
+    labels = [f'{s["scope"]}/{s["name"]}' for s in series_defs]
+    cells = [[_fmt_num(_trend_value(p, s['scope'], s['name'])) for p in points]
+             for s in series_defs]
+
+    layout = args.layout
+    if layout == 'auto':
+        colw = [max([len(lab)] + [len(c) for c in col])
+                for lab, col in zip(labels, cells)]
+        table_w = 8 + 2 + 19 + 2 + 9 + 2 + 8 + sum(w + 2 for w in colw)
+        term_w = shutil.get_terminal_size(fallback=(80, 24)).columns
+        layout = 'table' if table_w <= term_w else 'blocks'
+
+    if layout == 'table':
+        _trend_as_table(points, labels, cells)
+    else:
+        _trend_as_blocks(points, labels, cells)
+
+    if not series_defs:
+        return
+    print()
+    print('trend (oldest -> newest, magnitude only -- not a health signal):')
+    labw = max(len(l) for l in labels)
+    for lab, s in zip(labels, series_defs):
+        raw = [_trend_value(p, s['scope'], s['name']) for p in points]
+        present = [v for v in raw if v is not None]
+        ends = (f'{_fmt_num(present[0])} -> {_fmt_num(present[-1])}'
+                if present else '(no values)')
+        missing = sum(1 for v in raw if v is None)
+        note = f'   {missing} missing' if missing else ''
+        print(f'  {lab:<{labw}}  {_sparkline(raw)}  {ends}{note}')
+
+
+def _trend_as_table(points, labels, cells):
+    colw = [max([len(lab)] + [len(c) for c in col])
+            for lab, col in zip(labels, cells)]
+    header = (f'{"RUN":<8}  {"STARTED (local)":<19}  {"STATUS":<9}  '
+              f'{"DURATION":>8}')
+    for lab, w in zip(labels, colw):
+        header += f'  {lab:>{w}}'
+    print(header)
+    for i, p in enumerate(points):
+        line = (f'{p["run_id"][:8]:<8}  {_local(p["started_at"]):<19}  '
+                f'{p["display_status"]:<9}  {_human_duration(p["duration_s"]):>8}')
+        for col, w in zip(cells, colw):
+            line += f'  {col[i]:>{w}}'
+        print(line)
+
+
+def _trend_as_blocks(points, labels, cells):
+    labw = max([0] + [len(l) for l in labels])
+    for i, p in enumerate(points):
+        print(f'{p["run_id"][:8]}  {_local(p["started_at"])}  '
+              f'{p["display_status"]}  {_human_duration(p["duration_s"])}')
+        for lab, col in zip(labels, cells):
+            print(f'  {lab:<{labw}}  {col[i]}')
+
+
+# --------------------------------------------------------------------------- #
 # argument parsing / entry point
 # --------------------------------------------------------------------------- #
 
 _EPILOG = (
     '`list` is the default command and may be omitted. --db, --stale-after and\n'
-    '--json may appear before or after an explicit list / show.\n\n'
+    '--json may appear before or after an explicit list / show / overview / trend.\n\n'
     'exit codes: 0 ok, 1 no match, 2 bad arguments, 3 incompatible schema, '
     '4 database error, 5 database file not found.\n\n'
     'examples:\n'
@@ -499,7 +793,11 @@ _EPILOG = (
     '  python -m runrecord list --script 51_hourly-video-record-add --since 7d\n'
     '  python -m runrecord --json list --status stale\n'
     '  python -m runrecord show --latest --script 51_hourly-video-record-add\n'
-    '  python -m runrecord --db ./run-records.sqlite3 show a1b2c3d4\n')
+    '  python -m runrecord --db ./run-records.sqlite3 show a1b2c3d4\n'
+    '  python -m runrecord overview\n'
+    '  python -m runrecord trend --script 51_hourly-video-record-add --since 7d\n'
+    '  python -m runrecord --json trend --script 51_hourly-video-record-add '
+    '--metric record-fetch/total_count --metric duration\n')
 
 
 def _add_common(parser):
@@ -521,11 +819,17 @@ def _top_parser():
         prog='python -m runrecord',
         description='Read-only query CLI over the run-record store. The default '
                     'command is "list"; --db, --stale-after and --json may '
-                    'appear before or after an explicit list / show.',
+                    'appear before or after an explicit list / show / overview / '
+                    'trend.',
         epilog=_EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
-    sub = parser.add_subparsers(dest='command', metavar='{list,show}')
+    sub = parser.add_subparsers(dest='command',
+                                metavar='{list,show,overview,trend}')
     sub.add_parser('list', help='list recent runs (default)', add_help=False)
     sub.add_parser('show', help='show one run in full', add_help=False)
+    sub.add_parser('overview', help='one row per script: latest run + key metrics',
+                   add_help=False)
+    sub.add_parser('trend', help="one script's runs as an aligned metric series",
+                   add_help=False)
     _add_common(parser)
     return parser
 
@@ -566,6 +870,53 @@ def _show_parser():
     return parser
 
 
+def _overview_parser():
+    parser = argparse.ArgumentParser(
+        prog='python -m runrecord overview',
+        description="One row per script_name: its most recent run and up to a "
+                    "few of that run's key metrics. A scan aid -- it never "
+                    "interprets a metric as good or bad.",
+        epilog=_EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
+    _add_common(parser)
+    parser.add_argument('--since', metavar='WHEN',
+                        help='only consider runs started at/after this '
+                             '(span 24h/7d or ISO); a script whose last run is '
+                             'older then drops out of the overview')
+    parser.add_argument('--max-metrics', type=int, default=4, metavar='N',
+                        help='key metrics to show per script (default: 4)')
+    return parser
+
+
+def _trend_parser():
+    parser = argparse.ArgumentParser(
+        prog='python -m runrecord trend',
+        description="One script's runs aligned into a per-run metric time "
+                    "series: one run per row, chosen metric values in columns, "
+                    "missing values shown as '-' and never zero-filled. It "
+                    "organises recorded facts -- no rates, ratios, thresholds, "
+                    "anomaly detection or forecasting.",
+        epilog=_EPILOG, formatter_class=argparse.RawDescriptionHelpFormatter)
+    _add_common(parser)
+    parser.add_argument('--script', metavar='NAME', required=True,
+                        help='exact script_name (required scope)')
+    parser.add_argument('--metric', metavar='SCOPE/NAME', action='append',
+                        help='metric to include; repeatable. "duration" selects '
+                             'the built-in duration series. Default: the key '
+                             'metrics of the runs in range.')
+    parser.add_argument('--since', metavar='WHEN',
+                        help='only runs started at/after this (span 24h/7d or ISO)')
+    parser.add_argument('--until', metavar='WHEN',
+                        help='only runs started at/before this (span or ISO)')
+    parser.add_argument('--limit', type=int, default=20, metavar='N',
+                        help='keep the most recent N runs in the window, then '
+                             'render them oldest -> newest (default: 20)')
+    parser.add_argument('--layout', choices=('auto', 'table', 'blocks'),
+                        default='auto',
+                        help='auto (default) picks the aligned table or per-run '
+                             'blocks by terminal width')
+    return parser
+
+
 def _dispatch(args):
     db_path = _resolve_db_path(args.db)
     conn = _connect_ro(db_path)
@@ -573,6 +924,10 @@ def _dispatch(args):
         db_version = _check_schema(conn)
         if args.command == 'show':
             return _cmd_show(args, conn, db_path, db_version)
+        if args.command == 'overview':
+            return _cmd_overview(args, conn, db_path, db_version)
+        if args.command == 'trend':
+            return _cmd_trend(args, conn, db_path, db_version)
         return _cmd_list(args, conn, db_path, db_version)
     finally:
         conn.close()
@@ -580,15 +935,18 @@ def _dispatch(args):
 
 # options (on any command) that consume the following token as their value;
 # used only to skip over `--opt value` while locating the command token
+_COMMANDS = ('list', 'show', 'overview', 'trend')
 _VALUE_OPTS = frozenset((
-    '--db', '--stale-after', '--script', '--status', '--since', '--until', '--limit',
+    '--db', '--stale-after', '--script', '--status', '--since', '--until',
+    '--limit', '--metric', '--max-metrics', '--layout',
 ))
 
 
 def _split_command(argv):
     """
-    Find an explicit ``list`` / ``show`` token anywhere before the first bare
-    positional, and return ``(command, argv_without_that_token)``.
+    Find an explicit ``list`` / ``show`` / ``overview`` / ``trend`` token
+    anywhere before the first bare positional, and return
+    ``(command, argv_without_that_token)``.
 
     This lets the common options (--db, --stale-after, --json) sit on either
     side of the command: everything is then handed to one flat per-command
@@ -599,7 +957,7 @@ def _split_command(argv):
         tok = argv[i]
         if tok == '--':
             break
-        if tok in ('list', 'show'):
+        if tok in _COMMANDS:
             return tok, argv[:i] + argv[i + 1:]
         if tok in _VALUE_OPTS:
             i += 2                     # skip the option and its value
@@ -619,7 +977,11 @@ def _parse_args(argv):
     command, rest = _split_command(argv)
     if command is None:
         command = 'list'
-    parser = _show_parser() if command == 'show' else _list_parser()
+    parser = {
+        'show': _show_parser,
+        'overview': _overview_parser,
+        'trend': _trend_parser,
+    }.get(command, _list_parser)()
 
     args = parser.parse_args(rest)
     args.command = command
@@ -627,6 +989,8 @@ def _parse_args(argv):
         parser.error('--limit must be non-negative')
     if args.stale_after < 0:
         parser.error('--stale-after must be non-negative')
+    if getattr(args, 'max_metrics', 0) < 0:
+        parser.error('--max-metrics must be non-negative')
 
     # resolve time bounds here so a bad value is a clean usage error (exit 2)
     # rather than surfacing after the database is opened
@@ -638,6 +1002,16 @@ def _parse_args(argv):
                 setattr(args, attr, _parse_time(raw, now))
             except QueryError as e:
                 parser.error(str(e))
+
+    if command == 'trend':
+        parsed = []
+        for raw in (args.metric or []):
+            try:
+                parsed.append(_parse_metric_arg(raw))
+            except QueryError as e:
+                parser.error(str(e))
+        args.metrics = parsed or None
+
     return args
 
 

--- a/tests/test_run_record_overview_trend.py
+++ b/tests/test_run_record_overview_trend.py
@@ -1,0 +1,426 @@
+"""
+Tests for the metric reading commands ``runrecord overview`` and
+``runrecord trend`` (built on the ``runrecord.series`` core).
+
+Run from the repo root:
+
+    python tests/test_run_record_overview_trend.py
+    # or
+    python -m unittest discover -s tests
+
+Stdlib only (unittest + the driver shim). The CLI is exercised through
+``query.main(argv)`` so exit codes and rendered output are both asserted.
+``--layout`` is always passed explicitly so the assertions do not depend on the
+runner's terminal width.
+"""
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from runrecord import schema  # noqa: E402
+from runrecord import query  # noqa: E402
+from runrecord._sqlite import sqlite3  # noqa: E402
+
+
+def _iso(dt):
+    return dt.astimezone(timezone.utc).isoformat()
+
+
+def run_cli(argv):
+    out, err = io.StringIO(), io.StringIO()
+    try:
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+            code = query.main(argv)
+    except SystemExit as e:  # argparse
+        code = e.code if isinstance(e.code, int) else (0 if e.code is None else 1)
+    return code, out.getvalue(), err.getvalue()
+
+
+class _DbCase(unittest.TestCase):
+    def setUp(self):
+        self.dir = tempfile.mkdtemp()
+        self.path = os.path.join(self.dir, 'run-records.sqlite3')
+        conn = sqlite3.connect(self.path)
+        schema.init(conn)
+        conn.close()
+        self.now = datetime.now(timezone.utc)
+
+    def add_run(self, run_id, script, started, finished=None, status='succeeded',
+                host='H', code_version='abc1234'):
+        conn = sqlite3.connect(self.path)
+        conn.execute(
+            'INSERT INTO run (run_id, script_name, host, code_version, '
+            'started_at, finished_at, status) VALUES (?, ?, ?, ?, ?, ?, ?)',
+            (run_id, script, host, code_version, _iso(started),
+             _iso(finished) if finished else None, status))
+        conn.commit()
+        conn.close()
+
+    def add_metric(self, run_id, scope, name, value, unit='count', is_key=None):
+        conn = sqlite3.connect(self.path)
+        conn.execute(
+            'INSERT OR REPLACE INTO run_metric '
+            '(run_id, scope, name, value, unit, is_key) VALUES (?, ?, ?, ?, ?, ?)',
+            (run_id, scope, name, float(value), unit, is_key))
+        conn.commit()
+        conn.close()
+
+    def rid(self, prefix):
+        return prefix + 'z' * (32 - len(prefix))
+
+    def seed(self):
+        """Two scripts. 51_ has three finished runs plus one still running;
+        71_ has a single finished run."""
+        h = lambda n: self.now - timedelta(hours=n)  # noqa: E731
+        self.add_run(self.rid('a1'), '51_x', h(4), h(4) + timedelta(minutes=8))
+        self.add_metric(self.rid('a1'), 'record-fetch', 'total_count', 170000)
+        self.add_metric(self.rid('a1'), 'record-fetch', 'other_exception', 12)
+        self.add_metric(self.rid('a1'), 'record-fetch', 'success', 169988)
+
+        self.add_run(self.rid('a2'), '51_x', h(3), h(3) + timedelta(minutes=10))
+        self.add_metric(self.rid('a2'), 'record-fetch', 'total_count', 171000)
+        self.add_metric(self.rid('a2'), 'record-fetch', 'other_exception', 877)
+        # NOTE: run a2 records no 'success' -> a genuinely missing value
+
+        self.add_run(self.rid('a3'), '51_x', h(2), h(2) + timedelta(minutes=9),
+                     status='failed')
+        self.add_metric(self.rid('a3'), 'record-fetch', 'total_count', 5000)
+
+        self.add_run(self.rid('a4'), '51_x', h(1), None, status='running')
+
+        self.add_run(self.rid('b1'), '71_y', h(2), h(2) + timedelta(seconds=40))
+        self.add_metric(self.rid('b1'), 'sprint', 'total_count', 13)
+        self.add_metric(self.rid('b1'), 'sprint', 'exception', 1)
+
+
+# --------------------------------------------------------------------------- #
+# overview
+# --------------------------------------------------------------------------- #
+
+class OverviewText(_DbCase):
+    def test_one_row_per_script_with_latest_run(self):
+        self.seed()
+        code, out, _ = run_cli(['overview', '--db', self.path])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.count('51_x'), 1)
+        self.assertEqual(out.count('71_y'), 1)
+        # 51_x's latest run is the running one -> shown as 'running'
+        line = next(l for l in out.splitlines() if l.startswith('51_x'))
+        self.assertIn('running', line)
+        # 71_y's key metrics are surfaced inline, not as columns
+        line = next(l for l in out.splitlines() if l.startswith('71_y'))
+        self.assertIn('sprint/total_count=13', line)
+        self.assertIn('sprint/exception=1', line)
+
+    def test_key_metrics_only_and_capped(self):
+        self.seed()
+        # a2 is 51_x's latest *finished* run; make it the latest overall
+        self.add_run(self.rid('a5'), '51_x', self.now - timedelta(minutes=5),
+                     self.now - timedelta(minutes=1))
+        for i, name in enumerate(['total_count', 'other_exception', 'code_error',
+                                  'batch_insert_fail', 'success', 'new_video']):
+            self.add_metric(self.rid('a5'), 's', name, i + 1)
+        code, out, _ = run_cli(['overview', '--db', self.path, '--max-metrics', '2'])
+        self.assertEqual(code, 0)
+        line = next(l for l in out.splitlines() if l.startswith('51_x'))
+        # non-key metrics never appear
+        self.assertNotIn('success', line)
+        self.assertNotIn('new_video', line)
+        # capped at 2, total_count floated first
+        self.assertIn('s/total_count=', line)
+        self.assertEqual(line.count('s/'), 2)
+
+    def test_explicit_is_key_zero_suppresses_convention(self):
+        self.add_run(self.rid('c1'), 'z_', self.now - timedelta(minutes=5),
+                     self.now - timedelta(minutes=1))
+        self.add_metric(self.rid('c1'), 's', 'total_count', 9, is_key=0)
+        self.add_metric(self.rid('c1'), 's', 'widgets', 5, is_key=1)
+        code, out, _ = run_cli(['overview', '--db', self.path])
+        self.assertEqual(code, 0)
+        line = next(l for l in out.splitlines() if l.startswith('z_'))
+        self.assertNotIn('total_count', line)      # suppressed
+        self.assertIn('s/widgets=5', line)          # promoted
+
+    def test_since_drops_scripts_whose_last_run_is_older(self):
+        self.seed()
+        code, out, _ = run_cli(['overview', '--db', self.path, '--since', '90m'])
+        self.assertEqual(code, 0)
+        self.assertIn('51_x', out)      # has a run 1h ago
+        self.assertNotIn('71_y', out)   # last run 2h ago
+
+    def test_empty_db_exits_no_match(self):
+        code, out, _ = run_cli(['overview', '--db', self.path])
+        self.assertEqual(code, 1)
+        self.assertIn('no runs recorded', out)
+
+
+class OverviewJson(_DbCase):
+    def test_json_structure(self):
+        self.seed()
+        code, out, _ = run_cli(['--json', 'overview', '--db', self.path])
+        self.assertEqual(code, 0)
+        doc = json.loads(out)
+        self.assertEqual(doc['query']['command'], 'overview')
+        self.assertEqual(doc['query']['max_metrics'], 4)
+        self.assertEqual(doc['schema_version'], 2)
+        self.assertEqual(doc['count'], 2)
+        names = [s['script_name'] for s in doc['scripts']]
+        self.assertEqual(names, sorted(names))
+        y = next(s for s in doc['scripts'] if s['script_name'] == '71_y')
+        self.assertEqual(
+            {(m['scope'], m['name'], m['value']) for m in y['key_metrics']},
+            {('sprint', 'total_count', 13.0), ('sprint', 'exception', 1.0)})
+        # the full latest-run record is still there
+        self.assertIn('metrics', y)
+        self.assertIn('logs', y)
+
+
+# --------------------------------------------------------------------------- #
+# trend
+# --------------------------------------------------------------------------- #
+
+class TrendArgs(_DbCase):
+    def test_script_is_required(self):
+        code, _, err = run_cli(['trend', '--db', self.path])
+        self.assertEqual(code, 2)
+        self.assertIn('--script', err)
+
+    def test_bad_metric_arg_is_usage_error(self):
+        code, _, err = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--metric', 'noslash'])
+        self.assertEqual(code, 2)
+        self.assertIn('SCOPE/NAME', err)
+
+    def test_negative_limit_rejected(self):
+        code, _, err = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--limit', '-1'])
+        self.assertEqual(code, 2)
+
+    def test_order_option_is_gone(self):
+        self.seed()
+        code, _, err = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--order', 'desc'])
+        self.assertEqual(code, 2)
+        self.assertIn('--order', err)
+
+
+class TrendText(_DbCase):
+    def test_default_is_key_metrics_only(self):
+        self.seed()
+        code, out, _ = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--layout', 'table'])
+        self.assertEqual(code, 0)
+        self.assertIn('record-fetch/total_count', out)
+        self.assertIn('record-fetch/other_exception', out)
+        self.assertNotIn('record-fetch/success', out)   # not key, not selected
+
+    def test_multi_metric_run_aligned_table_with_missing(self):
+        self.seed()
+        code, out, _ = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--layout', 'table',
+                                '--metric', 'record-fetch/total_count',
+                                '--metric', 'record-fetch/success'])
+        self.assertEqual(code, 0)
+        rows = [l for l in out.splitlines() if l[:2] in ('a1', 'a2', 'a3', 'a4')]
+        self.assertEqual(len(rows), 4)
+        # one row per run, always oldest -> newest
+        self.assertTrue(rows[0].startswith('a1'))
+        self.assertTrue(rows[3].startswith('a4'))
+        # 'success' is the last column; a2 recorded none -> trailing '-', not 0
+        a2 = next(r for r in rows if r.startswith('a2'))
+        self.assertTrue(a2.rstrip().endswith('-'), a2)
+        self.assertNotIn(' 0 ', a2)
+
+    def test_incomplete_lifecycle_points_are_shown_and_labelled(self):
+        self.seed()
+        code, out, _ = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--layout', 'table',
+                                '--metric', 'record-fetch/total_count'])
+        self.assertEqual(code, 0)
+        self.assertIn('failed', out)     # a3
+        self.assertIn('running', out)    # a4 (within stale budget)
+        a4 = next(l for l in out.splitlines() if l.startswith('a4'))
+        # a4 has neither a finish time nor total_count -> both render '-'
+        self.assertTrue(a4.rstrip().endswith('-'))
+
+    def test_selected_metric_never_recorded_still_listed(self):
+        self.seed()
+        code, out, _ = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--layout', 'table',
+                                '--metric', 'record-fetch/ghost'])
+        self.assertEqual(code, 0)
+        self.assertIn('record-fetch/ghost', out)
+        self.assertIn('4 missing', out)
+
+    def test_duration_builtin_series(self):
+        self.seed()
+        code, out, _ = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--layout', 'blocks', '--metric', 'duration'])
+        self.assertEqual(code, 0)
+        self.assertIn('run/duration_s', out)
+        self.assertIn('(seconds)', out)
+
+    def test_empty_window_exits_no_match(self):
+        self.seed()
+        code, out, _ = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--since', '2000-01-01', '--until', '2000-02-01'])
+        self.assertEqual(code, 1)
+        self.assertIn('no runs in window', out)
+
+    def test_unknown_script_exits_no_match(self):
+        self.seed()
+        code, out, _ = run_cli(['trend', '--db', self.path, '--script', 'nope'])
+        self.assertEqual(code, 1)
+
+    def test_limit_keeps_newest_then_renders_chronologically(self):
+        self.seed()
+        code, out, _ = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--layout', 'table', '--limit', '2',
+                                '--metric', 'record-fetch/total_count'])
+        self.assertEqual(code, 0)
+        rows = [l for l in out.splitlines() if l[:2] in ('a1', 'a2', 'a3', 'a4')]
+        self.assertEqual(len(rows), 2)
+        # newest two runs are a3 + a4, rendered oldest -> newest
+        self.assertTrue(rows[0].startswith('a3'))
+        self.assertTrue(rows[1].startswith('a4'))
+
+    def test_default_limit_keeps_newest_twenty_chronological(self):
+        # 25 finished runs, one metric that increases every run
+        for i in range(25):
+            rid = self.rid('r%02d' % i)
+            st = self.now - timedelta(hours=25 - i)
+            self.add_run(rid, 'big_', st, st + timedelta(minutes=5))
+            self.add_metric(rid, 'sc', 'total_count', 1000 + i)
+        code, out, _ = run_cli(['--json', 'trend', '--db', self.path,
+                                '--script', 'big_',
+                                '--metric', 'sc/total_count'])
+        self.assertEqual(code, 0)
+        doc = json.loads(out)
+        self.assertEqual(doc['count'], 20)
+        vals = [p['values']['sc']['total_count'] for p in doc['points']]
+        # oldest five (1000..1004) dropped, newest twenty kept, chronological
+        self.assertEqual(vals, [float(v) for v in range(1005, 1025)])
+        starts = [p['started_at'] for p in doc['points']]
+        self.assertEqual(starts, sorted(starts))
+        # text output is chronological too
+        _, txt, _ = run_cli(['trend', '--db', self.path, '--script', 'big_',
+                             '--layout', 'table', '--metric', 'sc/total_count'])
+        rows = [l for l in txt.splitlines() if l.startswith('r')]
+        self.assertEqual(len(rows), 20)
+        self.assertTrue(rows[0].startswith('r05'))
+        self.assertTrue(rows[-1].startswith('r24'))
+
+    def test_blocks_layout(self):
+        self.seed()
+        code, out, _ = run_cli(['trend', '--db', self.path, '--script', '51_x',
+                                '--layout', 'blocks',
+                                '--metric', 'record-fetch/total_count'])
+        self.assertEqual(code, 0)
+        self.assertIn('trend (', out)   # sparkline block still present
+
+    def test_unit_conflict_is_reported(self):
+        self.add_run(self.rid('u1'), 's_', self.now - timedelta(hours=2),
+                     self.now - timedelta(hours=2) + timedelta(minutes=1))
+        self.add_run(self.rid('u2'), 's_', self.now - timedelta(hours=1),
+                     self.now - timedelta(hours=1) + timedelta(minutes=1))
+        self.add_metric(self.rid('u1'), 'x', 'm', 1, unit='count')
+        self.add_metric(self.rid('u2'), 'x', 'm', 2, unit='items')
+        code, _, err = run_cli(['trend', '--db', self.path, '--script', 's_',
+                                '--metric', 'x/m'])
+        self.assertEqual(code, 4)
+        self.assertIn('inconsistent units', err)
+
+
+class TrendJson(_DbCase):
+    def test_contract(self):
+        self.seed()
+        code, out, _ = run_cli(['--json', 'trend', '--db', self.path,
+                                '--script', '51_x',
+                                '--metric', 'record-fetch/total_count',
+                                '--metric', 'record-fetch/success',
+                                '--metric', 'duration'])
+        self.assertEqual(code, 0)
+        doc = json.loads(out)
+
+        # query scope
+        q = doc['query']
+        self.assertEqual(q['command'], 'trend')
+        self.assertEqual(q['script'], '51_x')
+        self.assertNotIn('order', q)
+        self.assertEqual(q['metrics'], [['record-fetch', 'total_count'],
+                                        ['record-fetch', 'success'],
+                                        ['run', 'duration_s']])
+
+        # series identity, request order preserved
+        self.assertEqual([(s['scope'], s['name']) for s in doc['series']],
+                         [('record-fetch', 'total_count'),
+                          ('record-fetch', 'success'),
+                          ('run', 'duration_s')])
+        dur = next(s for s in doc['series'] if s['name'] == 'duration_s')
+        self.assertEqual(dur['unit'], 'seconds')
+
+        # per-point run identity + context
+        self.assertEqual(doc['count'], 4)
+        # points are chronological, oldest -> newest
+        self.assertTrue(doc['points'][0]['run_id'].startswith('a1'))
+        self.assertTrue(doc['points'][-1]['run_id'].startswith('a4'))
+        pt = doc['points'][0]
+        for field in ('run_id', 'started_at', 'finished_at', 'duration_s',
+                      'status', 'display_status', 'stale', 'host',
+                      'code_version', 'values'):
+            self.assertIn(field, pt)
+
+        # missing stays missing, never zero-filled
+        a2 = next(p for p in doc['points'] if p['run_id'].startswith('a2'))
+        self.assertEqual(a2['values']['record-fetch']['total_count'], 171000.0)
+        self.assertNotIn('success', a2['values'].get('record-fetch', {}))
+
+        # a non-finished run: duration missing, not 0
+        a4 = next(p for p in doc['points'] if p['run_id'].startswith('a4'))
+        self.assertIsNone(a4['duration_s'])
+        self.assertNotIn('run', a4['values'])
+        self.assertEqual(a4['display_status'], 'running')
+
+
+# --------------------------------------------------------------------------- #
+# compatibility + read-only invariants
+# --------------------------------------------------------------------------- #
+
+class Compatibility(_DbCase):
+    def test_list_and_show_unchanged(self):
+        self.seed()
+        code, out, _ = run_cli(['list', '--db', self.path])
+        self.assertEqual(code, 0)
+        self.assertIn('51_x', out)
+
+        code, out, _ = run_cli(['--json', 'show', self.rid('a1'), '--db', self.path])
+        self.assertEqual(code, 0)
+        doc = json.loads(out)
+        entry = doc['runs'][0]['metrics']['record-fetch'][0]
+        # show's metric dicts stay exactly {name, value, unit} -- no is_key leak
+        self.assertEqual(set(entry), {'name', 'value', 'unit'})
+
+    def test_queries_do_not_touch_the_database_file(self):
+        self.seed()
+        before = os.stat(self.path)
+        for argv in (['overview', '--db', self.path],
+                     ['trend', '--db', self.path, '--script', '51_x'],
+                     ['--json', 'trend', '--db', self.path, '--script', '51_x']):
+            run_cli(argv)
+        after = os.stat(self.path)
+        self.assertEqual((before.st_size, before.st_mtime),
+                         (after.st_size, after.st_mtime))
+        for sidecar in ('-wal', '-journal', '-shm'):
+            self.assertFalse(os.path.exists(self.path + sidecar))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## What

Two read-only commands on `python -m runrecord`, built on the existing aligned per-run metric series core.

### `overview`

One row per `script_name`: its most recent run and up to a few of that run's key metrics, rendered inline as `scope/name=value` (never expanded into a per-script column set). Flags: `--since`, `--max-metrics` (default 4), `--json`.

### `trend --script NAME`

That script's runs aligned into a per-run time series — one run per row, selected metric values in columns.

- `--metric SCOPE/NAME` (repeatable); `--metric duration` selects the built-in duration series; default is the key metrics of the runs in range
- `--since` / `--until` bound the window; **`--limit N` (default 20) keeps the most recent N runs in that window**, and they are always rendered **oldest → newest** in both text and JSON, so the sparkline reads left-to-right in time. There is no order option.
- `--layout auto|table|blocks` — `auto` falls back from the aligned table to per-run blocks on a narrow terminal or when there are many metrics
- text output ends with a dependency-free Unicode-block sparkline per series (magnitude only, missing points shown as gaps, explicitly *not* a health signal)
- missing values render `-` in text and are omitted from JSON — never zero-filled; `running` / `failed` / `stale` points are returned and labelled
- `--json` carries the full query scope, series identity (scope/name/unit/key, request order preserved) and per-point run context (run id, timestamps, duration, status, host, code_version, values)
- empty window → exit 1; inconsistent units for a selected metric → the existing `QueryError` (exit 4)

`list` / `show` behaviour and their JSON contract are unchanged.

## README: reliable run-record web tunnel

The single-command SSH form for the read-only web view now uses `ssh -t` (foreground server follows the SSH session lifecycle), `ServerAliveInterval` / `ServerAliveCountMax` (detect a dead connection), and `exec` (server replaces the shell).

## Tests

`tests/test_run_record_overview_trend.py` — 24 cases: text + JSON, multi-metric alignment, filtering, empty results, missing metrics, non-complete lifecycle points, unit conflict, newest-N-then-chronological selection (including a 25-run regression), layout modes, argument validation, `list`/`show` compatibility, and the read-only invariant.

```
python3 -m unittest discover -s tests
Ran 166 tests — OK (skipped=14)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)