### PR TITLE
Add minimal multi-platform worker fleet support

### DIFF
--- a/16_update-member-info.py
+++ b/16_update-member-info.py
@@ -43,10 +43,9 @@ def update_member_info():
     for mid in mids:
         mid_queue.put(mid)
     # one sentinel per worker (UpdateMemberJob is sentinel-terminated)
-    # 50 workers (was 20): each member spends most of its ~25s parked in the
-    # member-card anti-crawler 60s sleep, so more workers just means more
-    # members sleeping in parallel -- worth trying to cut the multi-hour runtime.
-    # (The proper fix for the anti-crawler is a separate, thornier change.)
+    # Shared Service state keeps rate-limited member-card workers out of the
+    # candidate pool. If every worker is limited, each job records that condition
+    # and briefly slows down before moving to the next member.
     job_num = 50
     for _ in range(job_num):
         mid_queue.put(None)

--- a/job/FetchMemberFollowerRecordJob.py
+++ b/job/FetchMemberFollowerRecordJob.py
@@ -6,7 +6,6 @@ from core import MemberFollowerRecordNew
 from util import get_ts_s, ts_s_to_str
 from task import fetch_member_follower_record
 from typing import Optional
-import time
 
 __all__ = ['FetchMemberFollowerRecordJob']
 
@@ -66,16 +65,10 @@ class FetchMemberFollowerRecordJob(Job):
             try:
                 record = fetch_member_follower_record(mid, self.service, out_stat=stage_stat)
             except RateLimitError as e:
-                wait_s = max(0, e.retry_at - time.monotonic())
-                if self.duration_limit_due_ts_s is not None:
-                    wait_s = min(wait_s, max(
-                        0, self.duration_limit_due_ts_s - get_ts_s()))
-                self.mid_queue.put(mid)
                 self.logger.warning(
-                    f'Member follower API rate limited; requeued mid and waiting {wait_s:.1f}s. '
+                    f'Member follower API rate limited; skipping current mid. '
                     f'mid: {mid}, target: {e.target}, reason: {e.reason}')
                 self.stat.condition['rate_limited'] += 1
-                time.sleep(wait_s)
             except ServiceError as e:
                 self.logger.error(f'Fail to fetch member follower record. mid: {mid}, error: {e}')
                 self.stat.condition['exception'] += 1

--- a/job/FetchMemberFollowerRecordJob.py
+++ b/job/FetchMemberFollowerRecordJob.py
@@ -1,11 +1,12 @@
 from .Job import Job
-from service import Service, ServiceError
+from service import RateLimitError, Service, ServiceError
 from timer import Timer
 from queue import Queue, Empty, Full
 from core import MemberFollowerRecordNew
 from util import get_ts_s, ts_s_to_str
 from task import fetch_member_follower_record
 from typing import Optional
+import time
 
 __all__ = ['FetchMemberFollowerRecordJob']
 
@@ -64,6 +65,17 @@ class FetchMemberFollowerRecordJob(Job):
             stage_stat = {}
             try:
                 record = fetch_member_follower_record(mid, self.service, out_stat=stage_stat)
+            except RateLimitError as e:
+                wait_s = max(0, e.retry_at - time.monotonic())
+                if self.duration_limit_due_ts_s is not None:
+                    wait_s = min(wait_s, max(
+                        0, self.duration_limit_due_ts_s - get_ts_s()))
+                self.mid_queue.put(mid)
+                self.logger.warning(
+                    f'Member follower API rate limited; requeued mid and waiting {wait_s:.1f}s. '
+                    f'mid: {mid}, target: {e.target}, reason: {e.reason}')
+                self.stat.condition['rate_limited'] += 1
+                time.sleep(wait_s)
             except ServiceError as e:
                 self.logger.error(f'Fail to fetch member follower record. mid: {mid}, error: {e}')
                 self.stat.condition['exception'] += 1

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -1,6 +1,6 @@
 from .Job import Job
 from .VideoViewTrimmedBatchController import VideoViewTrimmedBatchController
-from service import Service, CodeError, MisalignmentError
+from service import Service, CodeError, MisalignmentError, RateLimitError
 from timer import Timer
 from queue import Queue, Empty, Full
 from core import RecordNew
@@ -151,6 +151,17 @@ class FetchVideoRecordJob(Job):
         try:
             record = fetch_video_record_via_video_view(
                 aid, self.service, out_stat=stage_stat)
+        except RateLimitError as e:
+            wait_s = max(0, e.retry_at - time.monotonic())
+            if self.duration_limit_due_ts_s is not None:
+                wait_s = min(wait_s, max(
+                    0, self.duration_limit_due_ts_s - get_ts_s()))
+            self.aid_queue.put(aid)
+            self.logger.warning(
+                f'Video API rate limited; requeued aid and waiting {wait_s:.1f}s. '
+                f'aid: {aid}, target: {e.target}, reason: {e.reason}')
+            self.stat.condition['rate_limited'] += 1
+            time.sleep(wait_s)
         except CodeError as e:
             # hand off to the UpdateVideoJob pool: refreshing tdd_video.code
             # is what drops this aid out of future need_insert lists, but it

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -152,16 +152,10 @@ class FetchVideoRecordJob(Job):
             record = fetch_video_record_via_video_view(
                 aid, self.service, out_stat=stage_stat)
         except RateLimitError as e:
-            wait_s = max(0, e.retry_at - time.monotonic())
-            if self.duration_limit_due_ts_s is not None:
-                wait_s = min(wait_s, max(
-                    0, self.duration_limit_due_ts_s - get_ts_s()))
-            self.aid_queue.put(aid)
             self.logger.warning(
-                f'Video API rate limited; requeued aid and waiting {wait_s:.1f}s. '
+                f'Video API rate limited; skipping current aid. '
                 f'aid: {aid}, target: {e.target}, reason: {e.reason}')
             self.stat.condition['rate_limited'] += 1
-            time.sleep(wait_s)
         except CodeError as e:
             # hand off to the UpdateVideoJob pool: refreshing tdd_video.code
             # is what drops this aid out of future need_insert lists, but it

--- a/job/UpdateMemberJob.py
+++ b/job/UpdateMemberJob.py
@@ -1,13 +1,16 @@
 from .Job import Job
 from db import Session
-from service import Service
+from service import RateLimitError, Service
 from queue import Queue, Empty
 from task import update_member
 from timer import Timer
 from util import format_ts_ms
 from typing import Optional
+import time
 
 __all__ = ['UpdateMemberJob']
+
+RATE_LIMIT_SLEEP_S = 60
 
 
 class UpdateMemberJob(Job):
@@ -44,6 +47,13 @@ class UpdateMemberJob(Job):
 
             try:
                 tdd_member_logs = update_member(mid, self.service, self.session)
+            except RateLimitError as e:
+                self.logger.warning(
+                    f'Member API rate limited; sleep {RATE_LIMIT_SLEEP_S}s before next member. '
+                    f'mid: {mid}, target: {e.target}, reason: {e.reason}, '
+                    f'first_seen: {e.first_seen}, retry_at: {e.retry_at}')
+                self.stat.condition['rate_limited'] += 1
+                time.sleep(RATE_LIMIT_SLEEP_S)
             except Exception as e:
                 # roll back, else the failed transaction poisons this session
                 # and every subsequent mid on this worker fails too

--- a/job/UpdateMemberJob.py
+++ b/job/UpdateMemberJob.py
@@ -48,10 +48,12 @@ class UpdateMemberJob(Job):
             try:
                 tdd_member_logs = update_member(mid, self.service, self.session)
             except RateLimitError as e:
+                now = time.monotonic()
                 self.logger.warning(
                     f'Member API rate limited; sleep {RATE_LIMIT_SLEEP_S}s before next member. '
                     f'mid: {mid}, target: {e.target}, reason: {e.reason}, '
-                    f'first_seen: {e.first_seen}, retry_at: {e.retry_at}')
+                    f'limited_for_s: {max(0, now - e.first_seen):.1f}, '
+                    f'retry_in_s: {max(0, e.retry_at - now):.1f}')
                 self.stat.condition['rate_limited'] += 1
                 time.sleep(RATE_LIMIT_SLEEP_S)
             except Exception as e:

--- a/service/Service.py
+++ b/service/Service.py
@@ -1,12 +1,15 @@
 import requests
 from requests.adapters import HTTPAdapter
 from http.cookiejar import DefaultCookiePolicy
+from dataclasses import dataclass
 import json
 import time
 import random
 from pathlib import Path
 from typing import Optional, Callable, Literal
-from .error import ResponseError, FormatError, CodeError, MisalignmentError
+from .error import (ResponseError, RateLimitError,
+                    FormatError, CodeError, MisalignmentError)
+from .worker import WorkerConfigurationError, WorkerSelector
 from .response import \
     VideoViewOwner, VideoViewStat, VideoViewStaffItem, VideoView, VideoViewTrimmed, \
     VideoViewTrimmedBatchItem, \
@@ -22,6 +25,7 @@ logger = logging.getLogger('Service')
 RequestMode = Literal['direct', 'worker']
 
 __all__ = ['Service', 'RequestMode',
+           'RateLimit', 'default_rate_limit', 'member_card_rate_limit',
            'VIDEO_VIEW_TRIMMED_BATCH_PROTOCOL_VERSION',
            'VIDEO_VIEW_TRIMMED_BATCH_READ_TIMEOUT_S',
            'VIDEO_VIEW_TRIMMED_BATCH_DEADLINE_S']
@@ -42,6 +46,41 @@ VIDEO_VIEW_TRIMMED_BATCH_PROTOCOL_VERSION = 1
 VIDEO_VIEW_TRIMMED_BATCH_READ_TIMEOUT_S = 8.0
 VIDEO_VIEW_TRIMMED_BATCH_DEADLINE_S = 12.0
 
+WORKER_HTTP_412_COOLDOWN_S = 30 * 60
+MEMBER_CARD_352_COOLDOWN_S = 5 * 60
+
+
+@dataclass(frozen=True)
+class RateLimit:
+    reason: str
+    cooldown_s: int
+
+
+def default_rate_limit(response: requests.Response) -> Optional[RateLimit]:
+    if response.status_code == 412:
+        return RateLimit('http_412', WORKER_HTTP_412_COOLDOWN_S)
+    return None
+
+
+def member_card_rate_limit(response: requests.Response) -> Optional[RateLimit]:
+    limited = default_rate_limit(response)
+    if limited is not None:
+        return limited
+    if response.status_code != 200:
+        return None
+    try:
+        body = response.json()
+    except (json.JSONDecodeError, requests.exceptions.JSONDecodeError):
+        return None
+    if isinstance(body, dict) and body.get('code') == -352:
+        return RateLimit('code_-352', MEMBER_CARD_352_COOLDOWN_S)
+    return None
+
+
+RATE_LIMIT_CHECKERS: dict[str, Callable[[requests.Response], Optional[RateLimit]]] = {
+    'get_member_card': member_card_rate_limit,
+}
+
 
 class Service:
 
@@ -50,6 +89,10 @@ class Service:
             mode: RequestMode = 'direct', pool_maxsize: int = 256, deadline: float = 10.0,
             min_throughput_bps: float = 80_000.0, endpoints: Optional[dict] = None
     ):
+        if mode not in ('direct', 'worker'):
+            logger.critical(f'Invalid request mode: {mode}.')
+            raise SystemExit(1)
+
         # set default config
         self._headers = headers if headers is not None else {}
         self._retry = retry
@@ -100,6 +143,14 @@ class Service:
                 logger.critical(
                     f'An unexpected error occurred when load and parse endpoints.json file. {e}')
                 exit(1)
+
+        try:
+            self._worker_selector = WorkerSelector(self.endpoints)
+            if self._mode == 'worker':
+                self._worker_selector.validate_worker_mode()
+        except WorkerConfigurationError as e:
+            logger.critical(f'Invalid worker configuration: {e}')
+            raise SystemExit(1)
 
         # define User Agent list
         self._ua_list = [
@@ -167,7 +218,8 @@ class Service:
     # default config getters end
 
     def _get(
-            self, url: str, params: Optional[dict] = None, headers: Optional[dict] = None,
+            self, target: str, mode: RequestMode,
+            params: Optional[dict] = None, headers: Optional[dict] = None,
             retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
             deadline: Optional[float] = None,
             parser: Optional[Callable[[str], Optional[dict]]] = None
@@ -186,10 +238,33 @@ class Service:
         timeout = timeout if timeout is not None else self._timeout
         colddown_factor = colddown_factor if colddown_factor is not None else self._colddown_factor
         deadline = deadline if deadline is not None else self._deadline
+        rate_limit_checker = RATE_LIMIT_CHECKERS.get(target, default_rate_limit)
+
+        if mode == 'direct':
+            try:
+                direct_url = self.endpoints[target]['direct']
+            except KeyError:
+                logger.critical(f'Endpoint "{target}" not found.')
+                raise SystemExit(1)
+        elif mode == 'worker':
+            direct_url = None
+        else:
+            logger.critical(f'Invalid request mode: {mode}.')
+            raise SystemExit(1)
 
         # go request
         response = None
         for trial in range(1, retry + 1):
+            selected_worker = None
+            request_url = direct_url
+            if mode == 'worker':
+                try:
+                    selected_worker = self._worker_selector.select(target)
+                except WorkerConfigurationError as e:
+                    logger.critical(f'Invalid worker configuration: {e}')
+                    raise SystemExit(1)
+                request_url = selected_worker.url
+
             # colddown for retry
             if trial > 1:
                 # fluctuation range 0.75 ~ 1.25
@@ -199,12 +274,12 @@ class Service:
             # try to get response
             trial_start = time.perf_counter()
             try:
-                r = self._session.get(url, params=params, headers=headers,
+                r = self._session.get(request_url, params=params, headers=headers,
                                       timeout=timeout, stream=True)
             except requests.exceptions.RequestException as e:
                 logger.debug(
                     f'Fail to get response. '
-                    f'url: {url}, params: {params}, trial: {trial}, error: {e}'
+                    f'url: {request_url}, params: {params}, trial: {trial}, error: {e}'
                 )
                 continue
 
@@ -242,7 +317,7 @@ class Service:
                 r.close()
                 logger.debug(
                     f'Fail to read response body. '
-                    f'url: {url}, params: {params}, trial: {trial}, error: {e}'
+                    f'url: {request_url}, params: {params}, trial: {trial}, error: {e}'
                 )
                 continue
             if deadline_exceeded:
@@ -250,7 +325,7 @@ class Service:
                 trial_ms = int((time.perf_counter() - trial_start) * 1000)
                 logger.debug(
                     f'Deadline exceeded while downloading response body. '
-                    f'url: {url}, params: {params}, trial: {trial}, deadline: {trial_deadline:.1f}s, '
+                    f'url: {request_url}, params: {params}, trial: {trial}, deadline: {trial_deadline:.1f}s, '
                     f'content_length: {content_length}, duration: {trial_ms}ms'
                 )
                 continue
@@ -262,18 +337,29 @@ class Service:
 
             trial_ms = int((time.perf_counter() - trial_start) * 1000)
 
+            limited = rate_limit_checker(r)
+            if limited is not None:
+                if mode == 'direct':
+                    now = time.monotonic()
+                    raise RateLimitError(
+                        target, limited.reason, now, now + limited.cooldown_s)
+                self._worker_selector.mark_rate_limited(
+                    target, selected_worker, reason=limited.reason,
+                    cooldown_s=limited.cooldown_s)
+                continue
+
             # check status code
             if r.status_code != 200:
                 logger.debug(
                     f'Fail to get response with status code {r.status_code}. '
-                    f'url: {url}, params: {params}, trial: {trial}, duration: {trial_ms}ms'
+                    f'url: {request_url}, params: {params}, trial: {trial}, duration: {trial_ms}ms'
                 )
                 continue
 
             # greppable per-request line (REQUEST): trial > 1 means retries
             # happened; duration is the pure network round-trip of this trial
             logger.debug(
-                f'REQUEST url: {url}, params: {params}, trial: {trial}, duration: {trial_ms}ms')
+                f'REQUEST url: {request_url}, params: {params}, trial: {trial}, duration: {trial_ms}ms')
 
             # parse response
             if parser is None:
@@ -283,7 +369,7 @@ class Service:
                 except json.JSONDecodeError:
                     logger.debug(
                         f'Fail to decode response to json. '
-                        f'response: {r.text}, url: {url}, params: {params}, trial: {trial}'
+                        f'response: {r.text}, url: {request_url}, params: {params}, trial: {trial}'
                     )
                     continue
             else:
@@ -309,18 +395,8 @@ class Service:
             logger.critical(f'Invalid request mode: {mode}.')
             exit(1)
 
-        # get endpoint url
-        try:
-            url = self.endpoints['get_video_view']['direct']
-            if mode == 'worker':
-                url = random.choice(
-                    self.endpoints['get_video_view']['workers'])
-        except KeyError:
-            logger.critical('Endpoint "get_video_view" not found.')
-            exit(1)
-
         # get response
-        response = self._get(url, params=params, headers=headers,
+        response = self._get('get_video_view', mode, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
         if response is None:
             raise ResponseError('video_view', params)
@@ -459,19 +535,8 @@ class Service:
                             f'Use get_video_view for direct mode.')
             exit(1)
 
-        # get endpoint url (worker-only, no direct fallback)
-        try:
-            url = random.choice(
-                self.endpoints['get_video_view_trimmed']['workers'])
-        except KeyError:
-            logger.critical('Endpoint "get_video_view_trimmed" not found.')
-            exit(1)
-        except IndexError:
-            logger.critical('Endpoint "get_video_view_trimmed" has no worker configured.')
-            exit(1)
-
         # get response
-        response = self._get(url, params=params, headers=headers,
+        response = self._get('get_video_view_trimmed', 'worker', params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
         if response is None:
             raise ResponseError('video_view_trimmed', params)
@@ -583,19 +648,9 @@ class Service:
 
         params = {'aids': ','.join(str(aid) for aid in aids)}
 
-        # get endpoint url (worker-only). Unlike the siblings, missing config
-        # is a loud *recoverable* failure -- see docstring.
-        try:
-            url = random.choice(
-                self.endpoints['get_video_view_trimmed_batch']['workers'])
-        except (KeyError, IndexError):
-            logger.error('Endpoint "get_video_view_trimmed_batch" not found or has no '
-                         'worker configured; treating as whole-batch failure.')
-            raise ResponseError('video_view_trimmed_batch', params)
-
         # get response (batch-specific timeout/deadline; single whole-batch
         # trial, see docstring)
-        response = self._get(url, params=params, headers=headers,
+        response = self._get('get_video_view_trimmed_batch', 'worker', params=params, headers=headers,
                              retry=1, timeout=VIDEO_VIEW_TRIMMED_BATCH_READ_TIMEOUT_S,
                              deadline=VIDEO_VIEW_TRIMMED_BATCH_DEADLINE_S)
         if response is None:
@@ -750,16 +805,6 @@ class Service:
             logger.critical(f'Invalid request mode: {mode}.')
             exit(1)
 
-        # get endpoint url
-        try:
-            url = self.endpoints['get_video_tags']['direct']
-            if mode == 'worker':
-                url = random.choice(
-                    self.endpoints['get_video_tags']['workers'])
-        except KeyError:
-            logger.critical('Endpoint "get_video_tags" not found.')
-            exit(1)
-
         # define parser
         def parser(text: str) -> Optional[dict]:
             logger.debug(
@@ -778,7 +823,7 @@ class Service:
             return parsed_response
 
         # get response
-        response = self._get(url, params=params, headers=headers,
+        response = self._get('get_video_tags', mode, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor,
                              parser=parser)
         if response is None:
@@ -836,42 +881,9 @@ class Service:
             logger.critical(f'Invalid request mode: {mode}.')
             exit(1)
 
-        # get endpoint url
-        try:
-            url = self.endpoints['get_member_card']['direct']
-            if mode == 'worker':
-                url = random.choice(
-                    self.endpoints['get_member_card']['workers'])
-        except KeyError:
-            logger.critical('Endpoint "get_member_card" not found.')
-            exit(1)
-
-        # define parser
-        def parser(text: str) -> Optional[dict]:
-            logger.debug(
-                f'Try to parse member card response text. text: {text}.')
-            parsed_response = None
-            try:
-                parsed_response = json.loads(text)
-            except json.JSONDecodeError:
-                logger.debug(f'Fail to decode text to json. Return None.')
-            if parsed_response is not None:
-                code = parsed_response['code']
-                if code in [-352]:
-                    logger.debug(
-                        f'Status code {code} found. Anti-crawler detected, return None for retry.')
-                    # TMP sleep 60 seconds
-                    logger.warning(f'TMP sleep 60 seconds.')
-                    time.sleep(60)
-                    logger.warning(f'TMP sleep 60 seconds end.')
-                    # TMP end
-                    parsed_response = None
-            return parsed_response
-
         # get response
-        response = self._get(url, params=params, headers=headers,
-                             retry=retry, timeout=timeout, colddown_factor=colddown_factor,
-                             parser=parser)
+        response = self._get('get_member_card', mode, params=params, headers=headers,
+                             retry=retry, timeout=timeout, colddown_factor=colddown_factor)
         if response is None:
             raise ResponseError('member_card', params)
 
@@ -930,18 +942,8 @@ class Service:
             logger.critical(f'Invalid request mode: {mode}.')
             exit(1)
 
-        # get endpoint url
-        try:
-            url = self.endpoints['get_member_relation']['direct']
-            if mode == 'worker':
-                url = random.choice(
-                    self.endpoints['get_member_relation']['workers'])
-        except KeyError:
-            logger.critical('Endpoint "get_member_relation" not found.')
-            exit(1)
-
         # get response
-        response = self._get(url, params=params, headers=headers,
+        response = self._get('get_member_relation', mode, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
         if response is None:
             raise ResponseError('member_relation', params)
@@ -992,14 +994,6 @@ class Service:
             exit(1)
 
         # get endpoint url
-        try:
-            url = self.endpoints['get_newlist']['direct']
-            if mode == 'worker':
-                url = random.choice(self.endpoints['get_newlist']['workers'])
-        except KeyError:
-            logger.critical('Endpoint "get_newlist" not found.')
-            exit(1)
-
         # define parser
         def parser(text: str) -> Optional[dict]:
             logger.debug(f'Try to parse newlist response text. text: {text}.')
@@ -1017,7 +1011,7 @@ class Service:
             return parsed_response
 
         # get response
-        response = self._get(url, params=params, headers=headers,
+        response = self._get('get_newlist', mode, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor,
                              parser=parser)
         if response is None:

--- a/service/Service.py
+++ b/service/Service.py
@@ -146,8 +146,6 @@ class Service:
 
         try:
             self._worker_selector = WorkerSelector(self.endpoints)
-            if self._mode == 'worker':
-                self._worker_selector.validate_worker_mode()
         except WorkerConfigurationError as e:
             logger.critical(f'Invalid worker configuration: {e}')
             raise SystemExit(1)
@@ -619,9 +617,9 @@ class Service:
           parses non-200 bodies, so a code==0 body on a 500 is NOT trusted)
           carries a ResponseError: retry this item only.
         - raises ResponseError: whole-batch transport failure -- HTTP != 200 /
-          unparsable top level (includes the worker's own 400/500 envelopes),
-          or no batch worker endpoint configured. The caller owns the retry
-          and counts one attempt for every aid in the batch.
+          unparsable top level (includes the worker's own 400/500 envelopes).
+          The caller owns the retry and counts one attempt for every aid in
+          the batch.
         - raises MisalignmentError: top level parsed but violates the batch
           contract (v != 1, requested/results length mismatch) or an item
           fails an identity/format check (aid echo, body.data.aid, bvid,
@@ -632,10 +630,9 @@ class Service:
         caller's per-aid attempt accounting; stacking Service-level retries
         under them would multiply Lambda invocations invisibly.
 
-        A missing/empty endpoints entry raises ResponseError instead of the
-        sibling methods' critical+exit: the batch path has a designed fallback
-        (kill-switch -> single path), so config drift here must degrade the
-        run, never kill it.
+        Missing worker configuration is treated as a startup/configuration
+        error consistently with the sibling methods and exits when this target
+        is first used.
         """
         # config mode
         mode = mode if mode is not None else self._mode

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -1,3 +1,4 @@
 from .error import *
 from .response import *
 from .Service import *
+from .worker import *

--- a/service/error.py
+++ b/service/error.py
@@ -32,8 +32,7 @@ class RateLimitError(ServiceError):
         self.retry_at = retry_at
 
     def __str__(self):
-        return (f'<RateLimitError(target={self.target},reason={self.reason},'
-                f'first_seen={self.first_seen},retry_at={self.retry_at})>')
+        return f'<RateLimitError(target={self.target},reason={self.reason})>'
 
 
 class ValidationError(ServiceError):

--- a/service/error.py
+++ b/service/error.py
@@ -1,7 +1,7 @@
 from core import TddError
 
-__all__ = ['ServiceError', 'ResponseError', 'ValidationError', 'FormatError', 'CodeError',
-           'MisalignmentError']
+__all__ = ['ServiceError', 'ResponseError', 'RateLimitError',
+           'ValidationError', 'FormatError', 'CodeError', 'MisalignmentError']
 
 
 class ServiceError(TddError):
@@ -20,6 +20,20 @@ class ResponseError(ServiceError):
 
     def __str__(self):
         return f'<ResponseError(target={self.target},params={self.params})>'
+
+
+class RateLimitError(ServiceError):
+    def __init__(self, target: str, reason: str,
+                 first_seen: float, retry_at: float):
+        super().__init__()
+        self.target = target
+        self.reason = reason
+        self.first_seen = first_seen
+        self.retry_at = retry_at
+
+    def __str__(self):
+        return (f'<RateLimitError(target={self.target},reason={self.reason},'
+                f'first_seen={self.first_seen},retry_at={self.retry_at})>')
 
 
 class ValidationError(ServiceError):

--- a/service/worker.py
+++ b/service/worker.py
@@ -1,0 +1,181 @@
+from dataclasses import dataclass
+import logging
+import random
+from threading import Lock
+import time
+from typing import Callable, Iterable, Mapping
+
+from .error import RateLimitError
+
+
+logger = logging.getLogger('Service')
+
+__all__ = ['WorkerEndpoint', 'WorkerSelector']
+
+
+class WorkerConfigurationError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class WorkerEndpoint:
+    id: str
+    url: str
+    platform: str
+    weight: int = 1
+    enabled: bool = True
+
+
+@dataclass(frozen=True)
+class RateLimitState:
+    first_seen: float
+    retry_at: float
+
+
+class WorkerSelector:
+    """Process-local worker selection and rate-limit cooldown tracking."""
+
+    def __init__(self, endpoints: Mapping[str, dict], *,
+                 clock: Callable[[], float] = time.monotonic):
+        self._clock = clock
+        self._lock = Lock()
+        self._workers: dict[str, tuple[WorkerEndpoint, ...]] = {}
+        self._rate_limits: dict[tuple[str, str], RateLimitState] = {}
+
+        for target, endpoint_config in endpoints.items():
+            raw_workers = endpoint_config.get('workers', [])
+            workers = tuple(self._parse_worker(target, index, raw)
+                            for index, raw in enumerate(raw_workers))
+            worker_ids = [worker.id for worker in workers]
+            if len(worker_ids) != len(set(worker_ids)):
+                raise WorkerConfigurationError(
+                    f'Duplicate worker id for {target!r}.')
+            self._workers[target] = self._weighted(workers)
+
+    @staticmethod
+    def _parse_worker(target: str, index: int, raw) -> WorkerEndpoint:
+        if isinstance(raw, str):
+            if not raw:
+                raise WorkerConfigurationError(
+                    f'Worker URL for {target!r} must not be empty.')
+            return WorkerEndpoint(
+                id=f'{target}:legacy:{index}', url=raw, platform='unknown')
+
+        if not isinstance(raw, dict):
+            raise WorkerConfigurationError(
+                f'Worker entry for {target!r} must be a URL or object.')
+
+        worker_id = raw.get('id')
+        url = raw.get('url')
+        platform = raw.get('platform')
+        weight = raw.get('weight', 1)
+        enabled = raw.get('enabled', True)
+        if not isinstance(worker_id, str) or not worker_id:
+            raise WorkerConfigurationError(
+                f'Worker id for {target!r} must be a non-empty string.')
+        if not isinstance(url, str) or not url:
+            raise WorkerConfigurationError(
+                f'Worker URL for {worker_id!r} must be a non-empty string.')
+        if not isinstance(platform, str) or not platform:
+            raise WorkerConfigurationError(
+                f'Worker platform for {worker_id!r} must be a non-empty string.')
+        if isinstance(weight, bool) or not isinstance(weight, int) or weight <= 0:
+            raise WorkerConfigurationError(
+                f'Worker weight for {worker_id!r} must be a positive integer.')
+        if not isinstance(enabled, bool):
+            raise WorkerConfigurationError(
+                f'Worker enabled for {worker_id!r} must be a boolean.')
+        return WorkerEndpoint(worker_id, url, platform, weight, enabled)
+
+    def validate_worker_mode(self) -> None:
+        if not self._workers:
+            raise WorkerConfigurationError('No worker endpoints are configured.')
+        for target in self._workers:
+            self._enabled_workers(target)
+
+    def select(self, target: str) -> WorkerEndpoint:
+        workers = self._enabled_workers(target)
+        now = self._clock()
+        recovered: list[WorkerEndpoint] = []
+
+        with self._lock:
+            for worker in workers:
+                key = (target, worker.id)
+                state = self._rate_limits.get(key)
+                if state is not None and state.retry_at <= now:
+                    del self._rate_limits[key]
+                    recovered.append(worker)
+            available = tuple(
+                worker for worker in workers
+                if (target, worker.id) not in self._rate_limits)
+            window = self._rate_limit_window(target, workers)
+
+        for worker in recovered:
+            logger.info('worker_rate_limit_cleared target=%s worker_id=%s platform=%s',
+                        target, worker.id, worker.platform)
+        if not available:
+            self._raise_rate_limited(target, 'all_workers_rate_limited', window)
+        return random.choice(available)
+
+    def mark_rate_limited(self, target: str, worker: WorkerEndpoint, *,
+                          reason: str, cooldown_s: int) -> None:
+        workers = self._enabled_workers(target)
+        now = self._clock()
+        retry_at = now + cooldown_s
+        key = (target, worker.id)
+
+        with self._lock:
+            previous = self._rate_limits.get(key)
+            transitioned = previous is None or previous.retry_at <= now
+            first_seen = now if transitioned else previous.first_seen
+            self._rate_limits[key] = RateLimitState(
+                first_seen=first_seen,
+                retry_at=max(previous.retry_at if previous else retry_at,
+                             retry_at))
+            exhausted = all(
+                (target, candidate.id) in self._rate_limits
+                for candidate in workers)
+            window = self._rate_limit_window(target, workers)
+
+        if transitioned:
+            logger.warning(
+                'worker_rate_limited target=%s worker_id=%s platform=%s reason=%s cooldown_s=%s',
+                target, worker.id, worker.platform, reason, cooldown_s)
+        if exhausted:
+            self._raise_rate_limited(target, reason, window)
+
+    def rate_limit_window(self, target: str) -> tuple[float | None, float | None]:
+        workers = self._enabled_workers(target)
+        with self._lock:
+            return self._rate_limit_window(target, workers)
+
+    def _enabled_workers(self, target: str) -> tuple[WorkerEndpoint, ...]:
+        workers = self._workers.get(target, ())
+        if not workers:
+            raise WorkerConfigurationError(
+                f'Endpoint {target!r} has no enabled worker configured.')
+        return workers
+
+    def _rate_limit_window(
+            self, target: str, workers: Iterable[WorkerEndpoint]
+    ) -> tuple[float | None, float | None]:
+        states = [self._rate_limits[(target, worker.id)]
+                  for worker in workers
+                  if (target, worker.id) in self._rate_limits]
+        return (min((state.first_seen for state in states), default=None),
+                min((state.retry_at for state in states), default=None))
+
+    def _raise_rate_limited(
+            self, target: str, reason: str,
+            window: tuple[float | None, float | None]) -> None:
+        first_seen, retry_at = window
+        logger.error(
+            'worker_pool_rate_limited target=%s first_seen=%s earliest_retry_in_s=%s',
+            target, first_seen,
+            None if retry_at is None else max(0, int(retry_at - self._clock())))
+        raise RateLimitError(target, reason, first_seen, retry_at)
+
+    @staticmethod
+    def _weighted(workers: Iterable[WorkerEndpoint]) -> tuple[WorkerEndpoint, ...]:
+        return tuple(worker for worker in workers if worker.enabled
+                     for _ in range(worker.weight))

--- a/service/worker.py
+++ b/service/worker.py
@@ -10,7 +10,7 @@ from .error import RateLimitError
 
 logger = logging.getLogger('Service')
 
-__all__ = ['WorkerEndpoint', 'WorkerSelector']
+__all__ = ['WorkerConfigurationError', 'WorkerEndpoint', 'WorkerSelector']
 
 
 class WorkerConfigurationError(ValueError):
@@ -65,6 +65,11 @@ class WorkerSelector:
             raise WorkerConfigurationError(
                 f'Worker entry for {target!r} must be a URL or object.')
 
+        unknown = set(raw) - {'id', 'url', 'platform', 'weight', 'enabled'}
+        if unknown:
+            raise WorkerConfigurationError(
+                f'Unknown worker field(s) for {target!r}: {sorted(unknown)!r}.')
+
         worker_id = raw.get('id')
         url = raw.get('url')
         platform = raw.get('platform')
@@ -87,12 +92,6 @@ class WorkerSelector:
                 f'Worker enabled for {worker_id!r} must be a boolean.')
         return WorkerEndpoint(worker_id, url, platform, weight, enabled)
 
-    def validate_worker_mode(self) -> None:
-        if not self._workers:
-            raise WorkerConfigurationError('No worker endpoints are configured.')
-        for target in self._workers:
-            self._enabled_workers(target)
-
     def select(self, target: str) -> WorkerEndpoint:
         workers = self._enabled_workers(target)
         now = self._clock()
@@ -108,7 +107,7 @@ class WorkerSelector:
             available = tuple(
                 worker for worker in workers
                 if (target, worker.id) not in self._rate_limits)
-            window = self._rate_limit_window(target, workers)
+            window = self._rate_limit_window(target, workers, now)
 
         for worker in recovered:
             logger.info('worker_rate_limit_cleared target=%s worker_id=%s platform=%s',
@@ -133,9 +132,9 @@ class WorkerSelector:
                 retry_at=max(previous.retry_at if previous else retry_at,
                              retry_at))
             exhausted = all(
-                (target, candidate.id) in self._rate_limits
-                for candidate in workers)
-            window = self._rate_limit_window(target, workers)
+                (state := self._rate_limits.get((target, candidate.id))) is not None
+                and state.retry_at > now for candidate in workers)
+            window = self._rate_limit_window(target, workers, now)
 
         if transitioned:
             logger.warning(
@@ -147,7 +146,7 @@ class WorkerSelector:
     def rate_limit_window(self, target: str) -> tuple[float | None, float | None]:
         workers = self._enabled_workers(target)
         with self._lock:
-            return self._rate_limit_window(target, workers)
+            return self._rate_limit_window(target, workers, self._clock())
 
     def _enabled_workers(self, target: str) -> tuple[WorkerEndpoint, ...]:
         workers = self._workers.get(target, ())
@@ -157,11 +156,12 @@ class WorkerSelector:
         return workers
 
     def _rate_limit_window(
-            self, target: str, workers: Iterable[WorkerEndpoint]
+            self, target: str, workers: Iterable[WorkerEndpoint], now: float
     ) -> tuple[float | None, float | None]:
         states = [self._rate_limits[(target, worker.id)]
                   for worker in workers
-                  if (target, worker.id) in self._rate_limits]
+                  if (target, worker.id) in self._rate_limits
+                  and self._rate_limits[(target, worker.id)].retry_at > now]
         return (min((state.first_seen for state in states), default=None),
                 min((state.retry_at for state in states), default=None))
 
@@ -169,10 +169,12 @@ class WorkerSelector:
             self, target: str, reason: str,
             window: tuple[float | None, float | None]) -> None:
         first_seen, retry_at = window
+        now = self._clock()
         logger.error(
-            'worker_pool_rate_limited target=%s first_seen=%s earliest_retry_in_s=%s',
-            target, first_seen,
-            None if retry_at is None else max(0, int(retry_at - self._clock())))
+            'worker_pool_rate_limited target=%s limited_for_s=%s earliest_retry_in_s=%s',
+            target,
+            None if first_seen is None else max(0, int(now - first_seen)),
+            None if retry_at is None else max(0, int(retry_at - now)))
         raise RateLimitError(target, reason, first_seen, retry_at)
 
     @staticmethod

--- a/tests/test_update_member_job_rate_limit.py
+++ b/tests/test_update_member_job_rate_limit.py
@@ -2,7 +2,8 @@ import logging
 from queue import Queue
 from unittest import TestCase, mock
 
-from job import JobStat, UpdateMemberJob
+from job import (FetchMemberFollowerRecordJob, FetchVideoRecordJob, JobStat,
+                 UpdateMemberJob)
 from service import RateLimitError
 
 
@@ -30,7 +31,8 @@ class UpdateMemberJobRateLimitTest(TestCase):
             'get_member_card', 'code_-352', first_seen=95.0, retry_at=105.0)
         with mock.patch('job.UpdateMemberJob.update_member',
                         side_effect=[limited, []]) as update, \
-                mock.patch('job.UpdateMemberJob.time.sleep') as sleep:
+                mock.patch('job.UpdateMemberJob.time.sleep') as sleep, \
+                mock.patch('job.UpdateMemberJob.time.monotonic', return_value=100.0):
             job.process()
 
         self.assertEqual(update.call_args_list, [
@@ -42,3 +44,53 @@ class UpdateMemberJobRateLimitTest(TestCase):
         self.assertEqual(job.stat.condition['0_update'], 1)
         self.assertEqual(job.stat.condition['rate_limited'], 1)
         self.assertEqual(job.stat.condition['update_exception'], 0)
+
+
+class FetchJobRateLimitTest(TestCase):
+    def test_video_fetch_requeues_aid_and_waits_until_retry(self):
+        job = object.__new__(FetchVideoRecordJob)
+        job.aid_queue = Queue()
+        job.service = object()
+        job.code_error_aid_queue = None
+        job.duration_limit_due_ts_s = None
+        job.stat = JobStat()
+        job.logger = logging.getLogger('test.FetchVideoRecordJob')
+
+        limited = RateLimitError(
+            'get_video_view_trimmed', 'http_412',
+            first_seen=95.0, retry_at=105.0)
+        with mock.patch('job.FetchVideoRecordJob.fetch_video_record_via_video_view',
+                        side_effect=limited), \
+                mock.patch('job.FetchVideoRecordJob.time.monotonic', return_value=100.0), \
+                mock.patch('job.FetchVideoRecordJob.time.sleep') as sleep:
+            self.assertTrue(job._fetch_single(123))
+
+        self.assertEqual(job.aid_queue.get_nowait(), 123)
+        sleep.assert_called_once_with(5.0)
+        self.assertEqual(job.stat.condition['rate_limited'], 1)
+
+    def test_follower_fetch_requeues_mid_and_waits_until_retry(self):
+        job = object.__new__(FetchMemberFollowerRecordJob)
+        job.mid_queue = Queue()
+        job.mid_queue.put(123)
+        job.record_queue = Queue()
+        job.service = object()
+        job.duration_limit_s = None
+        job.duration_limit_due_ts_s = None
+        job.put_timeout_s = 0.01
+        job.stat = JobStat()
+        job.logger = logging.getLogger('test.FetchMemberFollowerRecordJob')
+
+        limited = RateLimitError(
+            'get_member_relation', 'http_412',
+            first_seen=95.0, retry_at=105.0)
+        with mock.patch('job.FetchMemberFollowerRecordJob.fetch_member_follower_record',
+                        side_effect=[limited, RuntimeError('stop')]) as fetch, \
+                mock.patch('job.FetchMemberFollowerRecordJob.time.monotonic',
+                           return_value=100.0), \
+                mock.patch('job.FetchMemberFollowerRecordJob.time.sleep') as sleep:
+            job.process()
+
+        self.assertEqual(fetch.call_count, 2)
+        sleep.assert_called_once_with(5.0)
+        self.assertEqual(job.stat.condition['rate_limited'], 1)

--- a/tests/test_update_member_job_rate_limit.py
+++ b/tests/test_update_member_job_rate_limit.py
@@ -47,7 +47,7 @@ class UpdateMemberJobRateLimitTest(TestCase):
 
 
 class FetchJobRateLimitTest(TestCase):
-    def test_video_fetch_requeues_aid_and_waits_until_retry(self):
+    def test_video_fetch_counts_rate_limit_and_skips_aid(self):
         job = object.__new__(FetchVideoRecordJob)
         job.aid_queue = Queue()
         job.service = object()
@@ -60,19 +60,17 @@ class FetchJobRateLimitTest(TestCase):
             'get_video_view_trimmed', 'http_412',
             first_seen=95.0, retry_at=105.0)
         with mock.patch('job.FetchVideoRecordJob.fetch_video_record_via_video_view',
-                        side_effect=limited), \
-                mock.patch('job.FetchVideoRecordJob.time.monotonic', return_value=100.0), \
-                mock.patch('job.FetchVideoRecordJob.time.sleep') as sleep:
+                        side_effect=limited):
             self.assertTrue(job._fetch_single(123))
 
-        self.assertEqual(job.aid_queue.get_nowait(), 123)
-        sleep.assert_called_once_with(5.0)
+        self.assertTrue(job.aid_queue.empty())
         self.assertEqual(job.stat.condition['rate_limited'], 1)
 
-    def test_follower_fetch_requeues_mid_and_waits_until_retry(self):
+    def test_follower_fetch_counts_rate_limit_and_moves_to_next_mid(self):
         job = object.__new__(FetchMemberFollowerRecordJob)
         job.mid_queue = Queue()
         job.mid_queue.put(123)
+        job.mid_queue.put(456)
         job.record_queue = Queue()
         job.service = object()
         job.duration_limit_s = None
@@ -85,12 +83,8 @@ class FetchJobRateLimitTest(TestCase):
             'get_member_relation', 'http_412',
             first_seen=95.0, retry_at=105.0)
         with mock.patch('job.FetchMemberFollowerRecordJob.fetch_member_follower_record',
-                        side_effect=[limited, RuntimeError('stop')]) as fetch, \
-                mock.patch('job.FetchMemberFollowerRecordJob.time.monotonic',
-                           return_value=100.0), \
-                mock.patch('job.FetchMemberFollowerRecordJob.time.sleep') as sleep:
+                        side_effect=[limited, RuntimeError('stop')]) as fetch:
             job.process()
 
         self.assertEqual(fetch.call_count, 2)
-        sleep.assert_called_once_with(5.0)
         self.assertEqual(job.stat.condition['rate_limited'], 1)

--- a/tests/test_update_member_job_rate_limit.py
+++ b/tests/test_update_member_job_rate_limit.py
@@ -1,0 +1,44 @@
+import logging
+from queue import Queue
+from unittest import TestCase, mock
+
+from job import JobStat, UpdateMemberJob
+from service import RateLimitError
+
+
+class FakeSession:
+    def rollback(self):
+        raise AssertionError('rate limiting must not roll back the DB session')
+
+
+class UpdateMemberJobRateLimitTest(TestCase):
+    def test_rate_limit_waits_then_moves_to_next_member(self):
+        mid_queue = Queue()
+        mid_queue.put(123)
+        mid_queue.put(456)
+        mid_queue.put(None)
+
+        job = object.__new__(UpdateMemberJob)
+        job.mid_queue = mid_queue
+        job.service = object()
+        job.poll_timeout_s = 0.01
+        job.session = FakeSession()
+        job.stat = JobStat()
+        job.logger = logging.getLogger('test.UpdateMemberJob')
+
+        limited = RateLimitError(
+            'get_member_card', 'code_-352', first_seen=95.0, retry_at=105.0)
+        with mock.patch('job.UpdateMemberJob.update_member',
+                        side_effect=[limited, []]) as update, \
+                mock.patch('job.UpdateMemberJob.time.sleep') as sleep:
+            job.process()
+
+        self.assertEqual(update.call_args_list, [
+            mock.call(123, job.service, job.session),
+            mock.call(456, job.service, job.session),
+        ])
+        sleep.assert_called_once_with(60)
+        self.assertEqual(job.stat.total_count, 2)
+        self.assertEqual(job.stat.condition['0_update'], 1)
+        self.assertEqual(job.stat.condition['rate_limited'], 1)
+        self.assertEqual(job.stat.condition['update_exception'], 0)

--- a/tests/test_video_view_trimmed_batch_service.py
+++ b/tests/test_video_view_trimmed_batch_service.py
@@ -247,8 +247,9 @@ class TestWholeBatchFailures(unittest.TestCase):
 
     def test_missing_endpoint_exits_as_configuration_error(self):
         for endpoints in ({}, {'get_video_view_trimmed_batch': {'workers': []}}):
+            service = make_service(endpoints=endpoints)
             with self.assertRaises(SystemExit):
-                make_service(endpoints=endpoints)
+                service.get_video_view_trimmed_batch([1, 2])
 
     def test_direct_mode_is_a_programming_error(self):
         service = Service(mode='direct', endpoints=BATCH_ENDPOINTS)

--- a/tests/test_video_view_trimmed_batch_service.py
+++ b/tests/test_video_view_trimmed_batch_service.py
@@ -48,8 +48,9 @@ def stub_get(service, response):
     """Replace service._get with a stub returning `response`, recording calls."""
     calls = []
 
-    def _get(url, params=None, headers=None, **kwargs):
-        calls.append({'url': url, 'params': params, 'headers': headers, **kwargs})
+    def _get(target, mode, params=None, headers=None, **kwargs):
+        calls.append({'target': target, 'mode': mode,
+                      'params': params, 'headers': headers, **kwargs})
         return response
 
     service._get = _get
@@ -109,6 +110,8 @@ class TestBatchHappyPath(unittest.TestCase):
         service.get_video_view_trimmed_batch(aids)
 
         call = calls[0]
+        self.assertEqual(call['target'], 'get_video_view_trimmed_batch')
+        self.assertEqual(call['mode'], 'worker')
         self.assertEqual(call['params'], {'aids': '1,2,3'})
         # single whole-batch trial: retries are the CALLER's per-aid attempts
         self.assertEqual(call['retry'], 1)
@@ -242,13 +245,10 @@ class TestWholeBatchFailures(unittest.TestCase):
         with self.assertRaises(ResponseError):
             service.get_video_view_trimmed_batch([1, 2])
 
-    def test_missing_endpoint_raises_response_error_not_exit(self):
-        # unlike the sibling methods (critical + exit), the batch path has a
-        # designed fallback -- config drift degrades the run, never kills it
+    def test_missing_endpoint_exits_as_configuration_error(self):
         for endpoints in ({}, {'get_video_view_trimmed_batch': {'workers': []}}):
-            service = make_service(endpoints=endpoints)
-            with self.assertRaises(ResponseError):
-                service.get_video_view_trimmed_batch([1])
+            with self.assertRaises(SystemExit):
+                make_service(endpoints=endpoints)
 
     def test_direct_mode_is_a_programming_error(self):
         service = Service(mode='direct', endpoints=BATCH_ENDPOINTS)

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -84,6 +84,12 @@ class WorkerSelectorConfigTest(TestCase):
             with self.subTest(item=item), self.assertRaises(ValueError):
                 WorkerSelector(endpoints_for('view', [item]))
 
+    def test_unknown_new_worker_field_is_rejected(self):
+        item = worker('w', 'https://worker.invalid/')
+        item['enable'] = False
+        with self.assertRaisesRegex(ValueError, 'Unknown worker field'):
+            WorkerSelector(endpoints_for('view', [item]))
+
     def test_worker_ids_only_need_to_be_unique_within_a_target(self):
         endpoints = {
             'view': {'workers': [worker('same', 'https://one.invalid/')]},
@@ -107,6 +113,15 @@ class WorkerSelectorConfigTest(TestCase):
     def test_service_exits_on_invalid_request_mode(self):
         with self.assertRaises(SystemExit):
             Service(mode='invalid', endpoints={})
+
+    def test_worker_configuration_is_validated_when_target_is_used(self):
+        service = Service(mode='worker', endpoints={
+            'unused': {'workers': []},
+            'view': {'workers': [worker('view-a', 'https://a.invalid/')]},
+        })
+        self.assertEqual(service._worker_selector.select('view').id, 'view-a')
+        with self.assertRaises(ValueError):
+            service._worker_selector.select('unused')
 
 
 class WorkerSelectorStateTest(TestCase):
@@ -159,6 +174,17 @@ class WorkerSelectorStateTest(TestCase):
         first_seen, retry_at = self.selector.rate_limit_window('view')
         self.assertEqual(first_seen, 1000.0)
         self.assertEqual(retry_at, 1040.0)
+
+    def test_expired_other_worker_does_not_cause_pool_exhaustion(self):
+        view_a, view_b = self.selector._workers['view']
+        self.selector.mark_rate_limited(
+            'view', view_a, reason='http_412', cooldown_s=30)
+        self.clock.now += 31
+
+        self.selector.mark_rate_limited(
+            'view', view_b, reason='http_412', cooldown_s=30)
+
+        self.assertEqual(self.selector.select('view').id, 'view-a')
 
     def test_selection_uses_state_lock(self):
         state_lock = mock.MagicMock()

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -1,0 +1,322 @@
+import json
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from unittest import TestCase, mock
+
+import requests
+
+from service import (Service, RateLimitError,
+                     WorkerSelector, default_rate_limit, member_card_rate_limit)
+
+
+def worker(worker_id, url, platform='test', weight=1, enabled=True):
+    return {
+        'id': worker_id,
+        'url': url,
+        'platform': platform,
+        'weight': weight,
+        'enabled': enabled,
+    }
+
+
+def endpoints_for(target, workers):
+    return {target: {'direct': 'https://direct.invalid/', 'workers': workers}}
+
+
+class FakeClock:
+    def __init__(self):
+        self.now = 1000.0
+
+    def __call__(self):
+        return self.now
+
+
+def response(status, body):
+    item = requests.Response()
+    item.status_code = status
+    item.headers = {}
+    item._content = (body if isinstance(body, bytes)
+                     else json.dumps(body).encode())
+    item._content_consumed = True
+    item.url = 'https://worker.invalid/'
+    return item
+
+
+class ScriptedSession:
+    def __init__(self, responses_by_url):
+        self.responses_by_url = {
+            url: list(responses) for url, responses in responses_by_url.items()
+        }
+        self.calls = []
+
+    def get(self, url, **kwargs):
+        self.calls.append(url)
+        return self.responses_by_url[url].pop(0)
+
+
+class WorkerSelectorConfigTest(TestCase):
+    def test_legacy_url_and_new_objects_are_supported(self):
+        selector = WorkerSelector(endpoints_for('view', [
+            'https://legacy.invalid/',
+            worker('new', 'https://new.invalid/', weight=2),
+            worker('off', 'https://off.invalid/', enabled=False),
+        ]))
+
+        with mock.patch('service.worker.random.choice',
+                        side_effect=lambda items: items[0]) as choose:
+            selector.select('view')
+        available = choose.call_args.args[0]
+        self.assertEqual([item.id for item in available].count('new'), 2)
+        self.assertEqual(sum(item.url == 'https://legacy.invalid/'
+                             for item in available), 1)
+        self.assertNotIn('off', {item.id for item in available})
+
+    def test_invalid_new_worker_fields_are_rejected(self):
+        invalid = [
+            worker('', 'https://worker.invalid/'),
+            worker('w', ''),
+            worker('w', 'https://worker.invalid/', platform=''),
+            worker('w', 'https://worker.invalid/', weight=0),
+            worker('w', 'https://worker.invalid/', weight=True),
+            worker('w', 'https://worker.invalid/', enabled='yes'),
+        ]
+        for item in invalid:
+            with self.subTest(item=item), self.assertRaises(ValueError):
+                WorkerSelector(endpoints_for('view', [item]))
+
+    def test_worker_ids_only_need_to_be_unique_within_a_target(self):
+        endpoints = {
+            'view': {'workers': [worker('same', 'https://one.invalid/')]},
+            'card': {'workers': [worker('same', 'https://two.invalid/')]},
+        }
+        WorkerSelector(endpoints)
+
+        endpoints['view']['workers'].append(
+            worker('same', 'https://three.invalid/'))
+        with self.assertRaisesRegex(ValueError, 'Duplicate worker id'):
+            WorkerSelector(endpoints)
+
+    def test_service_exits_on_invalid_worker_configuration(self):
+        endpoints = endpoints_for('view', [
+            worker('same', 'https://one.invalid/'),
+            worker('same', 'https://two.invalid/'),
+        ])
+        with self.assertRaises(SystemExit):
+            Service(mode='worker', endpoints=endpoints)
+
+    def test_service_exits_on_invalid_request_mode(self):
+        with self.assertRaises(SystemExit):
+            Service(mode='invalid', endpoints={})
+
+
+class WorkerSelectorStateTest(TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+        self.selector = WorkerSelector({
+            'view': {'workers': [
+                worker('view-a', 'https://a.invalid/'),
+                worker('view-b', 'https://b.invalid/'),
+            ]},
+            'card': {'workers': [
+                worker('card-a', 'https://card.invalid/'),
+            ]},
+        }, clock=self.clock)
+
+    def test_rate_limit_is_target_scoped_and_cooldown_restores_directly(self):
+        view_a = next(item for item in self.selector._workers['view']
+                      if item.id == 'view-a')
+        self.selector.mark_rate_limited(
+            'view', view_a, reason='http_412', cooldown_s=30)
+
+        self.assertEqual(self.selector.select('view').id, 'view-b')
+        self.assertEqual(self.selector.select('card').id, 'card-a')
+        self.clock.now += 30
+        with self.assertLogs('Service', logging.INFO) as captured, \
+                mock.patch('service.worker.random.choice', side_effect=lambda items: items[0]):
+            self.assertEqual(self.selector.select('view').id, 'view-a')
+        self.assertIn('worker_rate_limit_cleared', '\n'.join(captured.output))
+
+    def test_empty_pool_is_reported(self):
+        selected = self.selector.select('card')
+        with self.assertLogs('Service', logging.ERROR) as captured:
+            with self.assertRaises(RateLimitError) as raised:
+                self.selector.mark_rate_limited(
+                    'card', selected, reason='code_-352', cooldown_s=30)
+        self.assertEqual(raised.exception.target, 'card')
+        self.assertEqual(raised.exception.first_seen, 1000.0)
+        self.assertEqual(raised.exception.retry_at, 1030.0)
+        self.assertIn('worker_pool_rate_limited', '\n'.join(captured.output))
+
+    def test_repeated_rate_limit_preserves_first_seen_and_extends_retry_at(self):
+        view_a = next(item for item in self.selector._workers['view']
+                      if item.id == 'view-a')
+        self.selector.mark_rate_limited(
+            'view', view_a, reason='http_412', cooldown_s=30)
+        self.clock.now += 10
+        self.selector.mark_rate_limited(
+            'view', view_a, reason='http_412', cooldown_s=30)
+
+        first_seen, retry_at = self.selector.rate_limit_window('view')
+        self.assertEqual(first_seen, 1000.0)
+        self.assertEqual(retry_at, 1040.0)
+
+    def test_selection_uses_state_lock(self):
+        state_lock = mock.MagicMock()
+        self.selector._lock = state_lock
+        self.selector.select('view')
+        state_lock.__enter__.assert_called_once()
+
+    def test_300_threads_select_safely_after_transition(self):
+        view_a = next(item for item in self.selector._workers['view']
+                      if item.id == 'view-a')
+        self.selector.mark_rate_limited(
+            'view', view_a, reason='http_412', cooldown_s=30)
+        with ThreadPoolExecutor(max_workers=300) as pool:
+            selected = list(pool.map(lambda _: self.selector.select('view'), range(3000)))
+        self.assertEqual({item.id for item in selected}, {'view-b'})
+
+    def test_50_concurrent_rate_limit_calls_leave_consistent_state(self):
+        view_a = next(item for item in self.selector._workers['view']
+                      if item.id == 'view-a')
+        with ThreadPoolExecutor(max_workers=50) as pool:
+            list(pool.map(lambda _: self.selector.mark_rate_limited(
+                'view', view_a, reason='http_412', cooldown_s=30), range(50)))
+        self.assertEqual(self.selector.select('view').id, 'view-b')
+
+
+class RateLimitCheckerTest(TestCase):
+    def test_default_checker_only_handles_http_412(self):
+        limited = default_rate_limit(response(412, b'blocked'))
+        self.assertEqual((limited.reason, limited.cooldown_s), ('http_412', 1800))
+        self.assertIsNone(default_rate_limit(response(200, {'code': -412})))
+        self.assertIsNone(default_rate_limit(response(200, {'code': -352})))
+
+    def test_member_card_extends_default_with_json_352(self):
+        limited = member_card_rate_limit(response(200, {'code': -352}))
+        self.assertEqual((limited.reason, limited.cooldown_s), ('code_-352', 300))
+        self.assertEqual(member_card_rate_limit(response(412, b'blocked')).reason,
+                         'http_412')
+        self.assertIsNone(member_card_rate_limit(response(200, {'code': -404})))
+        self.assertIsNone(member_card_rate_limit(response(500, {'code': -352})))
+        self.assertIsNone(member_card_rate_limit(response(200, b'not json')))
+
+
+class ServiceWorkerRoutingTest(TestCase):
+    def make_service(self, target, workers, responses):
+        service = Service(
+            mode='worker', retry=3, colddown_factor=0,
+            endpoints=endpoints_for(target, workers))
+        service._session = ScriptedSession(responses)
+        return service
+
+    @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
+    def test_http_412_disables_worker_and_retry_uses_another(self, _choice):
+        service = self.make_service('view', [
+            worker('a', 'https://a.invalid/'),
+            worker('b', 'https://b.invalid/'),
+        ], {
+            'https://a.invalid/': [response(412, b'blocked')],
+            'https://b.invalid/': [response(200, {'code': 0})],
+        })
+
+        with mock.patch('service.Service.time.sleep'):
+            result = service._get('view', 'worker')
+
+        self.assertEqual(result, {'code': 0})
+        self.assertEqual(service._session.calls,
+                         ['https://a.invalid/', 'https://b.invalid/'])
+
+    @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
+    def test_json_352_uses_member_card_checker_without_60_second_sleep(self, _choice):
+        service = self.make_service('get_member_card', [
+            worker('a', 'https://a.invalid/'),
+            worker('b', 'https://b.invalid/'),
+        ], {
+            'https://a.invalid/': [response(200, {'code': -352})],
+            'https://b.invalid/': [response(200, {'code': 0})],
+        })
+
+        with mock.patch('service.Service.time.sleep') as sleep:
+            result = service._get('get_member_card', 'worker')
+
+        self.assertEqual(result, {'code': 0})
+        self.assertNotIn(mock.call(60), sleep.mock_calls)
+        self.assertEqual(service._session.calls,
+                         ['https://a.invalid/', 'https://b.invalid/'])
+
+    def test_member_card_uses_generic_json_parser_and_retries_non_json(self):
+        service = self.make_service('get_member_card', [
+            worker('a', 'https://a.invalid/'),
+        ], {'https://a.invalid/': [
+            response(200, b'not json'),
+            response(200, {'code': 0}),
+        ]})
+
+        with mock.patch('service.Service.time.sleep'):
+            result = service._get('get_member_card', 'worker')
+
+        self.assertEqual(result, {'code': 0})
+        self.assertEqual(service._session.calls,
+                         ['https://a.invalid/', 'https://a.invalid/'])
+
+    @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
+    def test_member_card_public_method_uses_special_checker(self, _choice):
+        valid = {
+            'code': 0, 'message': '0', 'ttl': 1,
+            'data': {'card': {
+                'mid': '123', 'name': 'name', 'sex': '保密',
+                'face': 'https://image.invalid/', 'sign': '',
+            }},
+        }
+        service = self.make_service('get_member_card', [
+            worker('a', 'https://a.invalid/'),
+            worker('b', 'https://b.invalid/'),
+        ], {
+            'https://a.invalid/': [response(200, {'code': -352})],
+            'https://b.invalid/': [response(200, valid)],
+        })
+
+        with mock.patch('service.Service.time.sleep') as sleep:
+            card = service.get_member_card({'mid': 123})
+
+        self.assertEqual((card.mid, card.name), ('123', 'name'))
+        self.assertNotIn(mock.call(60), sleep.mock_calls)
+
+    def test_single_rate_limited_worker_raises_pool_exhausted_immediately(self):
+        service = self.make_service('view', [
+            worker('a', 'https://a.invalid/'),
+        ], {'https://a.invalid/': [response(412, b'blocked')]})
+
+        with mock.patch('service.Service.time.sleep') as sleep:
+            with self.assertRaises(RateLimitError):
+                service._get('view', 'worker', retry=20)
+
+        sleep.assert_not_called()
+        self.assertEqual(service._session.calls, ['https://a.invalid/'])
+
+    def test_ordinary_failure_can_retry_the_same_worker(self):
+        service = self.make_service('view', [
+            worker('a', 'https://a.invalid/'),
+        ], {'https://a.invalid/': [
+            response(500, b'upstream failed'),
+            response(200, {'code': 0}),
+        ]})
+
+        with mock.patch('service.Service.time.sleep'):
+            result = service._get('view', 'worker')
+
+        self.assertEqual(result, {'code': 0})
+        self.assertEqual(service._session.calls,
+                         ['https://a.invalid/', 'https://a.invalid/'])
+
+    def test_direct_rate_limit_does_not_use_selector(self):
+        service = Service(mode='direct', endpoints=endpoints_for('view', []))
+        service._session = ScriptedSession({
+            'https://direct.invalid/': [response(412, b'blocked')],
+        })
+        with mock.patch.object(service._worker_selector, 'select') as select:
+            with self.assertRaises(RateLimitError) as raised:
+                service._get('view', 'direct')
+        self.assertEqual(raised.exception.reason, 'http_412')
+        self.assertGreater(raised.exception.retry_at, 0)
+        select.assert_not_called()


### PR DESCRIPTION
## Summary

- add target-scoped worker selection with legacy URL and structured endpoint configuration
- track per-worker rate-limit cooldowns and raise a unified RateLimitError when the pool is exhausted
- detect HTTP 412 by default and member-card code -352 specifically
- let the member update job record rate limiting, pause briefly, and continue with the next member
- add routing, configuration, cooldown, concurrency, parser, and job behavior tests

## Validation

- 269 Python tests passed
- 10 Node worker tests passed
- git diff --check passed