### PR TITLE
fix: retry rate limits when no worker can take over

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -321,10 +321,11 @@ class Service:
                     now = time.monotonic()
                     raise RateLimitError(
                         target, limited.reason, now, now + limited.cooldown_s)
-                self._worker_selector.mark_rate_limited(
-                    target, selected_worker, reason=limited.reason,
-                    cooldown_s=limited.cooldown_s)
-                continue
+                if self._worker_selector.has_failover(target):
+                    self._worker_selector.mark_rate_limited(
+                        target, selected_worker, reason=limited.reason,
+                        cooldown_s=limited.cooldown_s)
+                    continue
 
             # check status code
             if r.status_code != 200:

--- a/service/Service.py
+++ b/service/Service.py
@@ -326,6 +326,18 @@ class Service:
                         target, selected_worker, reason=limited.reason,
                         cooldown_s=limited.cooldown_s)
                     continue
+                # No worker can take over, so fall back to plain retries.
+                # A non-200 rate limit (HTTP 412) drops into the status-code
+                # branch below and retries there, but one signalled inside a
+                # 200 body (member-card code -352) has no such branch --
+                # retry it here so a rate-limited body is never handed back
+                # to the caller as a valid response.
+                if r.status_code == 200:
+                    logger.debug(
+                        f'Rate limited ({limited.reason}) with no failover worker. '
+                        f'url: {request_url}, params: {params}, trial: {trial}, duration: {trial_ms}ms'
+                    )
+                    continue
 
             # check status code
             if r.status_code != 200:

--- a/service/worker.py
+++ b/service/worker.py
@@ -116,6 +116,9 @@ class WorkerSelector:
             self._raise_rate_limited(target, 'all_workers_rate_limited', window)
         return random.choice(available)
 
+    def has_failover(self, target: str) -> bool:
+        return len({worker.id for worker in self._enabled_workers(target)}) > 1
+
     def mark_rate_limited(self, target: str, worker: WorkerEndpoint, *,
                           reason: str, cooldown_s: int) -> None:
         workers = self._enabled_workers(target)

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -287,6 +287,28 @@ class ServiceWorkerRoutingTest(TestCase):
         self.assertEqual(service._worker_selector.rate_limit_window('view'),
                          (None, None))
 
+    def test_json_352_on_single_worker_retries_instead_of_returning_body(self):
+        service = self.make_service('get_member_card', [
+            worker('only', 'https://only.invalid/'),
+        ], {
+            'https://only.invalid/': [
+                response(200, {'code': -352}),
+                response(200, {'code': -352}),
+                response(200, {'code': 0}),
+            ],
+        })
+
+        with mock.patch('service.Service.time.sleep'):
+            self.assertIsNone(service._get('get_member_card', 'worker', retry=2))
+            self.assertEqual(service._get('get_member_card', 'worker', retry=1),
+                             {'code': 0})
+
+        self.assertEqual(service._session.calls,
+                         ['https://only.invalid/'] * 3)
+        self.assertEqual(
+            service._worker_selector.rate_limit_window('get_member_card'),
+            (None, None))
+
     @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
     def test_json_352_uses_member_card_checker_without_60_second_sleep(self, _choice):
         service = self.make_service('get_member_card', [

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -123,6 +123,19 @@ class WorkerSelectorConfigTest(TestCase):
         with self.assertRaises(ValueError):
             service._worker_selector.select('unused')
 
+    def test_failover_requires_two_distinct_enabled_workers(self):
+        selector = WorkerSelector(endpoints_for('view', [
+            worker('only', 'https://only.invalid/', weight=3),
+            worker('off', 'https://off.invalid/', enabled=False),
+        ]))
+        self.assertFalse(selector.has_failover('view'))
+
+        selector = WorkerSelector(endpoints_for('view', [
+            worker('a', 'https://a.invalid/'),
+            worker('b', 'https://b.invalid/'),
+        ]))
+        self.assertTrue(selector.has_failover('view'))
+
 
 class WorkerSelectorStateTest(TestCase):
     def setUp(self):
@@ -252,6 +265,28 @@ class ServiceWorkerRoutingTest(TestCase):
         self.assertEqual(service._session.calls,
                          ['https://a.invalid/', 'https://b.invalid/'])
 
+    def test_http_412_on_single_worker_uses_normal_retry_without_cooldown(self):
+        service = self.make_service('view', [
+            worker('only', 'https://only.invalid/'),
+        ], {
+            'https://only.invalid/': [
+                response(412, b'blocked'),
+                response(412, b'blocked'),
+                response(412, b'blocked'),
+                response(200, {'code': 0}),
+            ],
+        })
+
+        with mock.patch('service.Service.time.sleep'):
+            self.assertIsNone(service._get('view', 'worker', retry=3))
+            self.assertEqual(service._get('view', 'worker', retry=1),
+                             {'code': 0})
+
+        self.assertEqual(service._session.calls,
+                         ['https://only.invalid/'] * 4)
+        self.assertEqual(service._worker_selector.rate_limit_window('view'),
+                         (None, None))
+
     @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
     def test_json_352_uses_member_card_checker_without_60_second_sleep(self, _choice):
         service = self.make_service('get_member_card', [
@@ -307,18 +342,6 @@ class ServiceWorkerRoutingTest(TestCase):
 
         self.assertEqual((card.mid, card.name), ('123', 'name'))
         self.assertNotIn(mock.call(60), sleep.mock_calls)
-
-    def test_single_rate_limited_worker_raises_pool_exhausted_immediately(self):
-        service = self.make_service('view', [
-            worker('a', 'https://a.invalid/'),
-        ], {'https://a.invalid/': [response(412, b'blocked')]})
-
-        with mock.patch('service.Service.time.sleep') as sleep:
-            with self.assertRaises(RateLimitError):
-                service._get('view', 'worker', retry=20)
-
-        sleep.assert_not_called()
-        self.assertEqual(service._session.calls, ['https://a.invalid/'])
 
     def test_ordinary_failure_can_retry_the_same_worker(self):
         service = self.make_service('view', [


### PR DESCRIPTION
A rate-limit cooldown only helps when another worker can take over. For targets with one distinct enabled worker, keep the rate limit in the existing bounded retry path instead of making the whole target unavailable. Multi-worker failover and direct-mode behavior remain unchanged.

Two shapes of rate limit are handled on that no-failover path:

- HTTP 412 falls through to the existing non-200 branch and retries there.
- A rate limit signalled inside a 200 body (`get_member_card` code `-352`) has no non-200 branch to fall through to, so it is retried explicitly. Without that it would be handed back as a valid response, turning a `RateLimitError` (which the job answers with a 60s backoff) into a `CodeError` with no cooldown.

Validation:
- `python -m unittest tests.test_worker_selector` — 25 passed
- `python -m unittest discover -s tests` — 217 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)