### PR TITLE
refactor: drop per-worker rate-limit cooldown and failover

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -332,23 +332,16 @@ class Service:
                     now = time.monotonic()
                     raise RateLimitError(
                         target, limited.reason, now, now + limited.cooldown_s)
-                if self._worker_selector.has_failover(target):
-                    self._worker_selector.mark_rate_limited(
-                        target, selected_worker, reason=limited.reason,
-                        cooldown_s=limited.cooldown_s)
-                    continue
-                # No worker can take over, so fall back to plain retries.
-                # A non-200 rate limit (HTTP 412) drops into the status-code
-                # branch below and retries there, but one signalled inside a
-                # 200 body (member-card code -352) has no such branch --
-                # retry it here so a rate-limited body is never handed back
-                # to the caller as a valid response.
-                if r.status_code == 200:
-                    logger.debug(
-                        f'Rate limited ({limited.reason}) with no failover worker. '
-                        f'url: {request_url}, params: {params}, trial: {trial}, duration: {trial_ms}ms'
-                    )
-                    continue
+                # Worker mode: retry within the caller's bounded retry budget.
+                # Cooling the worker down and reaching for another one was
+                # measured to help in no case -- see WorkerSelector -- and on
+                # single-worker targets it made the target unavailable
+                # outright. This must `continue` rather than fall through to
+                # the status-code branch below, because a rate limit signalled
+                # inside a 200 body (member-card code -352) would otherwise be
+                # handed back to the caller as a valid response. The API line
+                # above already recorded the status and trial.
+                continue
 
             # check status code
             if r.status_code != 200:

--- a/service/Service.py
+++ b/service/Service.py
@@ -332,15 +332,9 @@ class Service:
                     now = time.monotonic()
                     raise RateLimitError(
                         target, limited.reason, now, now + limited.cooldown_s)
-                # Worker mode: retry within the caller's bounded retry budget.
-                # Cooling the worker down and reaching for another one was
-                # measured to help in no case -- see WorkerSelector -- and on
-                # single-worker targets it made the target unavailable
-                # outright. This must `continue` rather than fall through to
-                # the status-code branch below, because a rate limit signalled
-                # inside a 200 body (member-card code -352) would otherwise be
-                # handed back to the caller as a valid response. The API line
-                # above already recorded the status and trial.
+                # `continue` rather than falling through to the status-code
+                # branch: an in-body rate limit (member-card -352, status 200)
+                # would otherwise be returned to the caller as a valid response.
                 continue
 
             # check status code

--- a/service/endpoints.json.example
+++ b/service/endpoints.json.example
@@ -18,22 +18,16 @@
     "direct": "http://api.bilibili.com/x/web-interface/card",
     "workers": [
       {
-        "id": "card-aws",
-        "url": "https://<function-url>.lambda-url.<region>.on.aws/",
-        "platform": "aws",
+        "id": "<worker-id>",
+        "url": "<worker-url>",
+        "platform": "<platform>",
         "weight": 1
       },
       {
-        "id": "card-azure",
-        "url": "https://<app-name>.azurewebsites.net/api/<route>",
-        "platform": "azure",
-        "weight": 2
-      },
-      {
-        "id": "card-gcp",
-        "url": "https://<service>-<hash>.<region>.run.app/",
-        "platform": "gcp",
-        "weight": 3,
+        "id": "<another-worker-id>",
+        "url": "<worker-url>",
+        "platform": "<platform>",
+        "weight": 2,
         "enabled": true
       }
     ]

--- a/service/endpoints.json.example
+++ b/service/endpoints.json.example
@@ -17,6 +17,25 @@
   "get_member_card": {
     "direct": "http://api.bilibili.com/x/web-interface/card",
     "workers": [
+      {
+        "id": "card-aws",
+        "url": "https://<function-url>.lambda-url.<region>.on.aws/",
+        "platform": "aws",
+        "weight": 1
+      },
+      {
+        "id": "card-azure",
+        "url": "https://<app-name>.azurewebsites.net/api/<route>",
+        "platform": "azure",
+        "weight": 2
+      },
+      {
+        "id": "card-gcp",
+        "url": "https://<service>-<hash>.<region>.run.app/",
+        "platform": "gcp",
+        "weight": 3,
+        "enabled": true
+      }
     ]
   },
   "get_member_relation": {

--- a/service/worker.py
+++ b/service/worker.py
@@ -1,11 +1,7 @@
 from dataclasses import dataclass
 import logging
 import random
-from threading import Lock
-import time
-from typing import Callable, Iterable, Mapping
-
-from .error import RateLimitError
+from typing import Iterable, Mapping
 
 
 logger = logging.getLogger('Service')
@@ -26,21 +22,22 @@ class WorkerEndpoint:
     enabled: bool = True
 
 
-@dataclass(frozen=True)
-class RateLimitState:
-    first_seen: float
-    retry_at: float
-
-
 class WorkerSelector:
-    """Process-local worker selection and rate-limit cooldown tracking."""
+    """
+    Process-local worker selection.
 
-    def __init__(self, endpoints: Mapping[str, dict], *,
-                 clock: Callable[[], float] = time.monotonic):
-        self._clock = clock
-        self._lock = Lock()
+    Deliberately stateless beyond the parsed config. It used to cool a worker
+    down on a rate limit so another could take over, which assumed the limit is
+    per-worker AND that some other worker still has headroom. Neither held in
+    production: five of six targets run a single worker, and on the one target
+    with three, all three were measured hitting the limit inside the same 10
+    second window because load is spread evenly across them. The cooldown only
+    ever made the target unavailable. Rate limits are now handled by the
+    caller's bounded retry instead.
+    """
+
+    def __init__(self, endpoints: Mapping[str, dict]):
         self._workers: dict[str, tuple[WorkerEndpoint, ...]] = {}
-        self._rate_limits: dict[tuple[str, str], RateLimitState] = {}
 
         for target, endpoint_config in endpoints.items():
             raw_workers = endpoint_config.get('workers', [])
@@ -93,63 +90,9 @@ class WorkerSelector:
         return WorkerEndpoint(worker_id, url, platform, weight, enabled)
 
     def select(self, target: str) -> WorkerEndpoint:
-        workers = self._enabled_workers(target)
-        now = self._clock()
-        recovered: list[WorkerEndpoint] = []
-
-        with self._lock:
-            for worker in workers:
-                key = (target, worker.id)
-                state = self._rate_limits.get(key)
-                if state is not None and state.retry_at <= now:
-                    del self._rate_limits[key]
-                    recovered.append(worker)
-            available = tuple(
-                worker for worker in workers
-                if (target, worker.id) not in self._rate_limits)
-            window = self._rate_limit_window(target, workers, now)
-
-        for worker in recovered:
-            logger.info('worker_rate_limit_cleared target=%s worker_id=%s platform=%s',
-                        target, worker.id, worker.platform)
-        if not available:
-            self._raise_rate_limited(target, 'all_workers_rate_limited', window)
-        return random.choice(available)
-
-    def has_failover(self, target: str) -> bool:
-        return len({worker.id for worker in self._enabled_workers(target)}) > 1
-
-    def mark_rate_limited(self, target: str, worker: WorkerEndpoint, *,
-                          reason: str, cooldown_s: int) -> None:
-        workers = self._enabled_workers(target)
-        now = self._clock()
-        retry_at = now + cooldown_s
-        key = (target, worker.id)
-
-        with self._lock:
-            previous = self._rate_limits.get(key)
-            transitioned = previous is None or previous.retry_at <= now
-            first_seen = now if transitioned else previous.first_seen
-            self._rate_limits[key] = RateLimitState(
-                first_seen=first_seen,
-                retry_at=max(previous.retry_at if previous else retry_at,
-                             retry_at))
-            exhausted = all(
-                (state := self._rate_limits.get((target, candidate.id))) is not None
-                and state.retry_at > now for candidate in workers)
-            window = self._rate_limit_window(target, workers, now)
-
-        if transitioned:
-            logger.warning(
-                'worker_rate_limited target=%s worker_id=%s platform=%s reason=%s cooldown_s=%s',
-                target, worker.id, worker.platform, reason, cooldown_s)
-        if exhausted:
-            self._raise_rate_limited(target, reason, window)
-
-    def rate_limit_window(self, target: str) -> tuple[float | None, float | None]:
-        workers = self._enabled_workers(target)
-        with self._lock:
-            return self._rate_limit_window(target, workers, self._clock())
+        # `_weighted` repeats each worker `weight` times, so a uniform choice
+        # here gives the configured weight ratio.
+        return random.choice(self._enabled_workers(target))
 
     def _enabled_workers(self, target: str) -> tuple[WorkerEndpoint, ...]:
         workers = self._workers.get(target, ())
@@ -157,28 +100,6 @@ class WorkerSelector:
             raise WorkerConfigurationError(
                 f'Endpoint {target!r} has no enabled worker configured.')
         return workers
-
-    def _rate_limit_window(
-            self, target: str, workers: Iterable[WorkerEndpoint], now: float
-    ) -> tuple[float | None, float | None]:
-        states = [self._rate_limits[(target, worker.id)]
-                  for worker in workers
-                  if (target, worker.id) in self._rate_limits
-                  and self._rate_limits[(target, worker.id)].retry_at > now]
-        return (min((state.first_seen for state in states), default=None),
-                min((state.retry_at for state in states), default=None))
-
-    def _raise_rate_limited(
-            self, target: str, reason: str,
-            window: tuple[float | None, float | None]) -> None:
-        first_seen, retry_at = window
-        now = self._clock()
-        logger.error(
-            'worker_pool_rate_limited target=%s limited_for_s=%s earliest_retry_in_s=%s',
-            target,
-            None if first_seen is None else max(0, int(now - first_seen)),
-            None if retry_at is None else max(0, int(retry_at - now)))
-        raise RateLimitError(target, reason, first_seen, retry_at)
 
     @staticmethod
     def _weighted(workers: Iterable[WorkerEndpoint]) -> tuple[WorkerEndpoint, ...]:

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -1,11 +1,12 @@
 import json
 import logging
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from unittest import TestCase, mock
 
 import requests
 
-from service import (Service, RateLimitError,
+from service import (Service, RateLimitError, WorkerConfigurationError,
                      WorkerSelector, default_rate_limit, member_card_rate_limit)
 
 
@@ -123,104 +124,54 @@ class WorkerSelectorConfigTest(TestCase):
         with self.assertRaises(ValueError):
             service._worker_selector.select('unused')
 
-    def test_failover_requires_two_distinct_enabled_workers(self):
-        selector = WorkerSelector(endpoints_for('view', [
-            worker('only', 'https://only.invalid/', weight=3),
-            worker('off', 'https://off.invalid/', enabled=False),
-        ]))
-        self.assertFalse(selector.has_failover('view'))
 
-        selector = WorkerSelector(endpoints_for('view', [
-            worker('a', 'https://a.invalid/'),
-            worker('b', 'https://b.invalid/'),
-        ]))
-        self.assertTrue(selector.has_failover('view'))
-
-
-class WorkerSelectorStateTest(TestCase):
+class WorkerSelectorSelectionTest(TestCase):
     def setUp(self):
-        self.clock = FakeClock()
         self.selector = WorkerSelector({
             'view': {'workers': [
-                worker('view-a', 'https://a.invalid/'),
-                worker('view-b', 'https://b.invalid/'),
+                worker('view-a', 'https://a.invalid/', weight=1),
+                worker('view-b', 'https://b.invalid/', weight=2),
+                worker('view-c', 'https://c.invalid/', weight=3),
+                worker('view-off', 'https://off.invalid/', enabled=False),
             ]},
             'card': {'workers': [
                 worker('card-a', 'https://card.invalid/'),
             ]},
-        }, clock=self.clock)
+        })
 
-    def test_rate_limit_is_target_scoped_and_cooldown_restores_directly(self):
-        view_a = next(item for item in self.selector._workers['view']
-                      if item.id == 'view-a')
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
+    def test_weighted_selection_follows_the_configured_ratio(self):
+        picked = Counter()
+        with mock.patch('service.worker.random.choice',
+                        side_effect=lambda items: items[0]) as choose:
+            self.selector.select('view')
+        pool = choose.call_args.args[0]
+        for item in pool:
+            picked[item.id] += 1
+        self.assertEqual(picked, Counter({'view-c': 3, 'view-b': 2, 'view-a': 1}))
 
-        self.assertEqual(self.selector.select('view').id, 'view-b')
-        self.assertEqual(self.selector.select('card').id, 'card-a')
-        self.clock.now += 30
-        with self.assertLogs('Service', logging.INFO) as captured, \
-                mock.patch('service.worker.random.choice', side_effect=lambda items: items[0]):
-            self.assertEqual(self.selector.select('view').id, 'view-a')
-        self.assertIn('worker_rate_limit_cleared', '\n'.join(captured.output))
+    def test_disabled_workers_are_never_selected(self):
+        with mock.patch('service.worker.random.choice',
+                        side_effect=lambda items: items[0]) as choose:
+            self.selector.select('view')
+        self.assertNotIn('view-off',
+                         {item.id for item in choose.call_args.args[0]})
 
     def test_empty_pool_is_reported(self):
-        selected = self.selector.select('card')
-        with self.assertLogs('Service', logging.ERROR) as captured:
-            with self.assertRaises(RateLimitError) as raised:
-                self.selector.mark_rate_limited(
-                    'card', selected, reason='code_-352', cooldown_s=30)
-        self.assertEqual(raised.exception.target, 'card')
-        self.assertEqual(raised.exception.first_seen, 1000.0)
-        self.assertEqual(raised.exception.retry_at, 1030.0)
-        self.assertIn('worker_pool_rate_limited', '\n'.join(captured.output))
+        selector = WorkerSelector({'view': {'workers': []}})
+        with self.assertRaises(WorkerConfigurationError):
+            selector.select('view')
 
-    def test_repeated_rate_limit_preserves_first_seen_and_extends_retry_at(self):
-        view_a = next(item for item in self.selector._workers['view']
-                      if item.id == 'view-a')
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
-        self.clock.now += 10
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
+    def test_a_rate_limit_never_takes_a_worker_out_of_the_pool(self):
+        # the selector is stateless: nothing a response says can shrink the
+        # candidate set, so a limited worker keeps taking its share of traffic
+        seen = {self.selector.select('view').id for _ in range(300)}
+        self.assertEqual(seen, {'view-a', 'view-b', 'view-c'})
 
-        first_seen, retry_at = self.selector.rate_limit_window('view')
-        self.assertEqual(first_seen, 1000.0)
-        self.assertEqual(retry_at, 1040.0)
-
-    def test_expired_other_worker_does_not_cause_pool_exhaustion(self):
-        view_a, view_b = self.selector._workers['view']
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
-        self.clock.now += 31
-
-        self.selector.mark_rate_limited(
-            'view', view_b, reason='http_412', cooldown_s=30)
-
-        self.assertEqual(self.selector.select('view').id, 'view-a')
-
-    def test_selection_uses_state_lock(self):
-        state_lock = mock.MagicMock()
-        self.selector._lock = state_lock
-        self.selector.select('view')
-        state_lock.__enter__.assert_called_once()
-
-    def test_300_threads_select_safely_after_transition(self):
-        view_a = next(item for item in self.selector._workers['view']
-                      if item.id == 'view-a')
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
+    def test_300_threads_select_safely(self):
         with ThreadPoolExecutor(max_workers=300) as pool:
-            selected = list(pool.map(lambda _: self.selector.select('view'), range(3000)))
-        self.assertEqual({item.id for item in selected}, {'view-b'})
-
-    def test_50_concurrent_rate_limit_calls_leave_consistent_state(self):
-        view_a = next(item for item in self.selector._workers['view']
-                      if item.id == 'view-a')
-        with ThreadPoolExecutor(max_workers=50) as pool:
-            list(pool.map(lambda _: self.selector.mark_rate_limited(
-                'view', view_a, reason='http_412', cooldown_s=30), range(50)))
-        self.assertEqual(self.selector.select('view').id, 'view-b')
+            selected = list(pool.map(lambda _: self.selector.select('card'),
+                                     range(3000)))
+        self.assertEqual({item.id for item in selected}, {'card-a'})
 
 
 class RateLimitCheckerTest(TestCase):
@@ -248,22 +199,30 @@ class ServiceWorkerRoutingTest(TestCase):
         service._session = ScriptedSession(responses)
         return service
 
-    @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
-    def test_http_412_disables_worker_and_retry_uses_another(self, _choice):
+    def test_http_412_keeps_the_worker_in_the_pool(self):
+        # a 412 used to cool this worker down and hand the retry to the other
+        # one; it is now just a retry, and the limited worker stays eligible
         service = self.make_service('view', [
             worker('a', 'https://a.invalid/'),
             worker('b', 'https://b.invalid/'),
         ], {
-            'https://a.invalid/': [response(412, b'blocked')],
-            'https://b.invalid/': [response(200, {'code': 0})],
+            'https://a.invalid/': [response(412, b'blocked'),
+                                   response(200, {'code': 0})],
+            'https://b.invalid/': [response(412, b'blocked'),
+                                   response(200, {'code': 0})],
         })
 
-        with mock.patch('service.Service.time.sleep'):
+        with mock.patch('service.Service.time.sleep'), \
+                mock.patch('service.worker.random.choice',
+                           side_effect=lambda items: items[0]) as choose:
             result = service._get('view', 'worker')
 
         self.assertEqual(result, {'code': 0})
         self.assertEqual(service._session.calls,
-                         ['https://a.invalid/', 'https://b.invalid/'])
+                         ['https://a.invalid/', 'https://a.invalid/'])
+        # the second selection still saw both workers as candidates
+        self.assertEqual({item.id for item in choose.call_args.args[0]},
+                         {'a', 'b'})
 
     def test_http_412_on_single_worker_uses_normal_retry_without_cooldown(self):
         service = self.make_service('view', [
@@ -284,8 +243,6 @@ class ServiceWorkerRoutingTest(TestCase):
 
         self.assertEqual(service._session.calls,
                          ['https://only.invalid/'] * 4)
-        self.assertEqual(service._worker_selector.rate_limit_window('view'),
-                         (None, None))
 
     def test_json_352_on_single_worker_retries_instead_of_returning_body(self):
         service = self.make_service('get_member_card', [
@@ -305,9 +262,6 @@ class ServiceWorkerRoutingTest(TestCase):
 
         self.assertEqual(service._session.calls,
                          ['https://only.invalid/'] * 3)
-        self.assertEqual(
-            service._worker_selector.rate_limit_window('get_member_card'),
-            (None, None))
 
     @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
     def test_json_352_uses_member_card_checker_without_60_second_sleep(self, _choice):
@@ -315,7 +269,8 @@ class ServiceWorkerRoutingTest(TestCase):
             worker('a', 'https://a.invalid/'),
             worker('b', 'https://b.invalid/'),
         ], {
-            'https://a.invalid/': [response(200, {'code': -352})],
+            'https://a.invalid/': [response(200, {'code': -352}),
+                                   response(200, {'code': 0})],
             'https://b.invalid/': [response(200, {'code': 0})],
         })
 
@@ -325,7 +280,7 @@ class ServiceWorkerRoutingTest(TestCase):
         self.assertEqual(result, {'code': 0})
         self.assertNotIn(mock.call(60), sleep.mock_calls)
         self.assertEqual(service._session.calls,
-                         ['https://a.invalid/', 'https://b.invalid/'])
+                         ['https://a.invalid/', 'https://a.invalid/'])
 
     def test_member_card_uses_generic_json_parser_and_retries_non_json(self):
         service = self.make_service('get_member_card', [
@@ -355,7 +310,8 @@ class ServiceWorkerRoutingTest(TestCase):
             worker('a', 'https://a.invalid/'),
             worker('b', 'https://b.invalid/'),
         ], {
-            'https://a.invalid/': [response(200, {'code': -352})],
+            'https://a.invalid/': [response(200, {'code': -352}),
+                                   response(200, valid)],
             'https://b.invalid/': [response(200, valid)],
         })
 


### PR DESCRIPTION
Cooling a worker down on a rate limit assumed two things: that the limit is per-worker, and that some other worker still has headroom. Neither holds.

- **Five of the six targets run a single worker.** There is nothing to fail over to, so the cooldown only made the target unavailable. #68 already stopped that by cooling down only when a failover exists.
- **On the one target with three workers, all three hit the limit inside the same 10-second window, every cycle.** Load is spread evenly across them, so their headroom runs out together. Measured over five consecutive cycles:

  | cycle | w0 ok | w1 ok | w2 ok | all three limited within |
  |---|---|---|---|---|
  | 1 | 84 | 111 | 99 | same 10s bucket |
  | 2 | 104 | 109 | 111 | same 10s bucket |
  | 3 | 111 | 87 | 113 | same 10s bucket |
  | 4 | 105 | 100 | 100 | same 10s bucket |
  | 5 | 116 | 99 | 96 | same 10s bucket |

  There was never a worker with headroom to fail over to.

So remove the mechanism instead of special-casing it further.

## What changes

`WorkerSelector` becomes stateless beyond the parsed config: `select()` is a weighted random choice over the enabled workers, and nothing a response says can shrink the candidate set. Gone: `RateLimitState`, `_rate_limits`, the lock, `mark_rate_limited`, `has_failover`, `rate_limit_window`, `_raise_rate_limited`, and the `worker_rate_limited` / `worker_rate_limit_cleared` / `worker_pool_rate_limited` log lines.

A rate limit in worker mode is now handled by the caller's bounded retry — which is exactly what every single-worker target has been doing since #68. Direct mode still raises `RateLimitError`: there is no worker and no retry budget to fall back on there.

**This is a no-op for every single-worker target.** It only changes the member-card target, where the cooldown was doing nothing useful.

## Note on backpressure

The cooldown did have one incidental effect: it stopped concurrent jobs from retrying into a wall for the length of the cooldown. That is now bounded only by each caller's `retry` budget. The member-card job is the only caller that meets a sustained limit, its cron is disabled, and it is run by hand — so this is acceptable as is, but it is the reason to keep an eye on that job's request volume rather than assume it is free.

`endpoints.json.example` now shows the object worker format with per-worker weights, which is how a target with several workers is configured.

Validation:
- `python -m unittest discover -s tests` — 217 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)