### PR TITLE
refactor: classify a rate limit once the retry budget is spent

### DIFF
--- a/16_update-member-info.py
+++ b/16_update-member-info.py
@@ -19,7 +19,7 @@ def update_member_info():
     timer.start()
 
     session = Session()
-    service = Service(mode='worker', retry=20)
+    service = Service(mode='worker')
 
     # get all mids
     all_mids: list[int] = DBOperation.query_all_member_mids(session)
@@ -46,10 +46,13 @@ def update_member_info():
     # Shared Service state keeps rate-limited member-card workers out of the
     # candidate pool. If every worker is limited, each job records that condition
     # and briefly slows down before moving to the next member.
-    # 20, not 50: member-card is rate limited below what 50 concurrent jobs
-    # ask for, so the extra concurrency only buys a shorter burst before the
-    # whole pool cools down.
-    job_num = 20
+    # 2, not 50. Each job thread sustains ~1.8 req/s, and the member-card
+    # limit is on request rate: measured at roughly 24-30 req/s, against the
+    # 33-37 req/s that 20 threads were producing. Two threads is ~3.6 req/s,
+    # about a seventh of the threshold, and finishes the day's ~25k members in
+    # two hours -- there is no reason for this job to be fast, and the headroom
+    # belongs to the jobs that add videos.
+    job_num = 2
     for _ in range(job_num):
         mid_queue.put(None)
     logger.info(f'{len(mids)} mids put into queue.')

--- a/61_update-member-info-of-name-duplicated-member.py
+++ b/61_update-member-info-of-name-duplicated-member.py
@@ -18,7 +18,7 @@ def update_member_info_of_name_duplicated_member():
     start_ts = get_ts_s()  # get start ts
 
     session = Session()
-    service = Service(mode="worker", retry=20)
+    service = Service(mode="worker")
     statistics = defaultdict(int)
 
     logger.info('Now get duplicated names...')

--- a/62_add-evocalrank-video.py
+++ b/62_add-evocalrank-video.py
@@ -50,7 +50,7 @@ def add_evocalrank_video(ranknum: int):
     timer.start()
 
     with track(script_fullname) as recorder:
-        service = Service(mode="worker", retry=20)
+        service = Service(mode="worker")
 
         logger.info(f'Will add evocalrank video with ranknum: {ranknum}')
 

--- a/job/UpdateMemberJob.py
+++ b/job/UpdateMemberJob.py
@@ -48,12 +48,9 @@ class UpdateMemberJob(Job):
             try:
                 tdd_member_logs = update_member(mid, self.service, self.session)
             except RateLimitError as e:
-                now = time.monotonic()
                 self.logger.warning(
                     f'Member API rate limited; sleep {RATE_LIMIT_SLEEP_S}s before next member. '
-                    f'mid: {mid}, target: {e.target}, reason: {e.reason}, '
-                    f'limited_for_s: {max(0, now - e.first_seen):.1f}, '
-                    f'retry_in_s: {max(0, e.retry_at - now):.1f}')
+                    f'mid: {mid}, target: {e.target}, reason: {e.reason}')
                 self.stat.condition['rate_limited'] += 1
                 time.sleep(RATE_LIMIT_SLEEP_S)
             except Exception as e:

--- a/service/Service.py
+++ b/service/Service.py
@@ -26,19 +26,14 @@ RequestMode = Literal['direct', 'worker']
 __all__ = ['Service', 'RequestMode',
            'RateLimit', 'default_rate_limit', 'member_card_rate_limit']
 
-WORKER_HTTP_412_COOLDOWN_S = 30 * 60
-MEMBER_CARD_352_COOLDOWN_S = 5 * 60
-
-
 @dataclass(frozen=True)
 class RateLimit:
     reason: str
-    cooldown_s: int
 
 
 def default_rate_limit(response: requests.Response) -> Optional[RateLimit]:
     if response.status_code == 412:
-        return RateLimit('http_412', WORKER_HTTP_412_COOLDOWN_S)
+        return RateLimit('http_412')
     return None
 
 
@@ -53,7 +48,7 @@ def member_card_rate_limit(response: requests.Response) -> Optional[RateLimit]:
     except (json.JSONDecodeError, requests.exceptions.JSONDecodeError):
         return None
     if isinstance(body, dict) and body.get('code') == -352:
-        return RateLimit('code_-352', MEMBER_CARD_352_COOLDOWN_S)
+        return RateLimit('code_-352')
     return None
 
 
@@ -232,6 +227,7 @@ class Service:
 
         # go request
         response = None
+        last_failure = 'no_attempt'
         for trial in range(1, retry + 1):
             selected_worker = None
             request_url = direct_url
@@ -255,6 +251,7 @@ class Service:
                 r = self._session.get(request_url, params=params, headers=headers,
                                       timeout=timeout, stream=True)
             except requests.exceptions.RequestException as e:
+                last_failure = 'request_exception'
                 logger.debug(
                     f'Fail to get response. '
                     f'url: {request_url}, params: {params}, trial: {trial}, error: {e}'
@@ -293,6 +290,7 @@ class Service:
                         break
             except requests.exceptions.RequestException as e:
                 r.close()
+                last_failure = 'body_exception'
                 logger.debug(
                     f'Fail to read response body. '
                     f'url: {request_url}, params: {params}, trial: {trial}, error: {e}'
@@ -300,6 +298,7 @@ class Service:
                 continue
             if deadline_exceeded:
                 r.close()
+                last_failure = 'deadline_exceeded'
                 trial_ms = int((time.perf_counter() - trial_start) * 1000)
                 logger.debug(
                     f'Deadline exceeded while downloading response body. '
@@ -328,30 +327,15 @@ class Service:
                 f'trial: {trial}, duration: {trial_ms}ms'
             )
             if limited is not None:
-                if mode == 'direct':
-                    now = time.monotonic()
-                    raise RateLimitError(
-                        target, limited.reason, now, now + limited.cooldown_s)
-                if self._worker_selector.has_failover(target):
-                    self._worker_selector.mark_rate_limited(
-                        target, selected_worker, reason=limited.reason,
-                        cooldown_s=limited.cooldown_s)
-                    continue
-                # No worker can take over, so fall back to plain retries.
-                # A non-200 rate limit (HTTP 412) drops into the status-code
-                # branch below and retries there, but one signalled inside a
-                # 200 body (member-card code -352) has no such branch --
-                # retry it here so a rate-limited body is never handed back
-                # to the caller as a valid response.
-                if r.status_code == 200:
-                    logger.debug(
-                        f'Rate limited ({limited.reason}) with no failover worker. '
-                        f'url: {request_url}, params: {params}, trial: {trial}, duration: {trial_ms}ms'
-                    )
-                    continue
+                # Retrying a rate limit is the one thing that provably makes it
+                # worse: the limit is on request rate, so every extra attempt
+                # extends the wall. Stop here and let the caller back off --
+                # this deliberately does not spend a trial.
+                raise RateLimitError(target, limited.reason)
 
             # check status code
             if r.status_code != 200:
+                last_failure = f'http_{r.status_code}'
                 logger.debug(
                     f'Fail to get response with status code {r.status_code}. '
                     f'url: {request_url}, params: {params}, trial: {trial}, duration: {trial_ms}ms'
@@ -369,6 +353,7 @@ class Service:
                     response = r.json()
                     break
                 except json.JSONDecodeError:
+                    last_failure = 'json_error'
                     logger.debug(
                         f'Fail to decode response to json. '
                         f'response: {r.text}, url: {request_url}, params: {params}, trial: {trial}'
@@ -378,6 +363,9 @@ class Service:
                 response = parser(r.text)
                 if response is not None:
                     break
+                last_failure = 'parse_error'
+        if response is None:
+            raise ResponseError(target, params or {}, last_failure, retry)
         return response
 
     def get_video_view(
@@ -400,8 +388,6 @@ class Service:
         # get response
         response = self._get('get_video_view', mode, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
-        if response is None:
-            raise ResponseError('video_view', params)
 
         # validate format
 
@@ -540,8 +526,6 @@ class Service:
         # get response
         response = self._get('get_video_view_trimmed', 'worker', params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
-        if response is None:
-            raise ResponseError('video_view_trimmed', params)
 
         # validate format
 
@@ -633,8 +617,6 @@ class Service:
         response = self._get('get_video_tags', mode, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor,
                              parser=parser)
-        if response is None:
-            raise ResponseError('video_tags', params)
 
         # validate format
 
@@ -691,8 +673,6 @@ class Service:
         # get response
         response = self._get('get_member_card', mode, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
-        if response is None:
-            raise ResponseError('member_card', params)
 
         # validate format
 
@@ -752,8 +732,6 @@ class Service:
         # get response
         response = self._get('get_member_relation', mode, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
-        if response is None:
-            raise ResponseError('member_relation', params)
 
         # validate format
 
@@ -821,8 +799,6 @@ class Service:
         response = self._get('get_newlist', mode, params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor,
                              parser=parser)
-        if response is None:
-            raise ResponseError('newlist', params)
 
         # validate format
 

--- a/service/Service.py
+++ b/service/Service.py
@@ -196,7 +196,7 @@ class Service:
             retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
             deadline: Optional[float] = None,
             parser: Optional[Callable[[str], Optional[dict]]] = None
-    ) -> Optional[dict]:
+    ) -> dict:
         # assemble headers
         if headers is None:
             headers = self._headers
@@ -227,7 +227,7 @@ class Service:
 
         # go request
         response = None
-        last_failure = 'no_attempt'
+        last_failure = None
         rate_limited_trials = 0
         for trial in range(1, retry + 1):
             selected_worker = None
@@ -328,17 +328,8 @@ class Service:
                 f'trial: {trial}, duration: {trial_ms}ms'
             )
             if limited is not None:
-                # Retry it like any other failure. Measured on the video-view
-                # target: 7.75% of requests come back 412, and 99.05% of those
-                # succeed on the next attempt or the one after -- treating a
-                # rate limit as fatal on sight would throw away ~13k records an
-                # hour. Whether retrying was hopeless is a question that can
-                # only be answered once the budget is spent, so it is answered
-                # after the loop.
-                #
-                # `continue` rather than falling through to the status-code
-                # branch: an in-body rate limit (member-card -352, status 200)
-                # would otherwise be returned to the caller as a valid response.
+                # `continue`, not fall through: a -352 comes back as status 200
+                # with a valid body, which would otherwise be returned as data
                 last_failure = limited.reason
                 rate_limited_trials += 1
                 continue
@@ -375,10 +366,6 @@ class Service:
                     break
                 last_failure = 'parse_error'
         if response is None:
-            # Every trial failed. If every one of them was a rate limit, this
-            # is a wall rather than bad luck, and callers that know how to wait
-            # (back off, requeue, slow down) need to be able to tell. Anything
-            # else -- including a mix -- is an ordinary exhausted request.
             if retry > 0 and rate_limited_trials == retry:
                 raise RateLimitError(target, last_failure)
             raise ResponseError(target, params or {}, last_failure, retry)

--- a/service/Service.py
+++ b/service/Service.py
@@ -228,6 +228,7 @@ class Service:
         # go request
         response = None
         last_failure = 'no_attempt'
+        rate_limited_trials = 0
         for trial in range(1, retry + 1):
             selected_worker = None
             request_url = direct_url
@@ -327,11 +328,20 @@ class Service:
                 f'trial: {trial}, duration: {trial_ms}ms'
             )
             if limited is not None:
-                # Retrying a rate limit is the one thing that provably makes it
-                # worse: the limit is on request rate, so every extra attempt
-                # extends the wall. Stop here and let the caller back off --
-                # this deliberately does not spend a trial.
-                raise RateLimitError(target, limited.reason)
+                # Retry it like any other failure. Measured on the video-view
+                # target: 7.75% of requests come back 412, and 99.05% of those
+                # succeed on the next attempt or the one after -- treating a
+                # rate limit as fatal on sight would throw away ~13k records an
+                # hour. Whether retrying was hopeless is a question that can
+                # only be answered once the budget is spent, so it is answered
+                # after the loop.
+                #
+                # `continue` rather than falling through to the status-code
+                # branch: an in-body rate limit (member-card -352, status 200)
+                # would otherwise be returned to the caller as a valid response.
+                last_failure = limited.reason
+                rate_limited_trials += 1
+                continue
 
             # check status code
             if r.status_code != 200:
@@ -365,6 +375,12 @@ class Service:
                     break
                 last_failure = 'parse_error'
         if response is None:
+            # Every trial failed. If every one of them was a rate limit, this
+            # is a wall rather than bad luck, and callers that know how to wait
+            # (back off, requeue, slow down) need to be able to tell. Anything
+            # else -- including a mix -- is an ordinary exhausted request.
+            if retry > 0 and rate_limited_trials == retry:
+                raise RateLimitError(target, last_failure)
             raise ResponseError(target, params or {}, last_failure, retry)
         return response
 

--- a/service/endpoints.json.example
+++ b/service/endpoints.json.example
@@ -29,7 +29,7 @@
         "url": "<worker-url>",
         "platform": "<platform>",
         "weight": 2,
-        "enabled": true
+        "enabled": false
       }
     ]
   },

--- a/service/endpoints.json.example
+++ b/service/endpoints.json.example
@@ -21,7 +21,8 @@
         "id": "<worker-id>",
         "url": "<worker-url>",
         "platform": "<platform>",
-        "weight": 1
+        "weight": 1,
+        "enabled": true
       },
       {
         "id": "<another-worker-id>",

--- a/service/endpoints.json.example
+++ b/service/endpoints.json.example
@@ -17,6 +17,19 @@
   "get_member_card": {
     "direct": "http://api.bilibili.com/x/web-interface/card",
     "workers": [
+      {
+        "id": "<worker-id>",
+        "url": "<worker-url>",
+        "platform": "<platform>",
+        "weight": 1
+      },
+      {
+        "id": "<another-worker-id>",
+        "url": "<worker-url>",
+        "platform": "<platform>",
+        "weight": 2,
+        "enabled": true
+      }
     ]
   },
   "get_member_relation": {

--- a/service/error.py
+++ b/service/error.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 from core import TddError
 
 __all__ = ['ServiceError', 'ResponseError', 'RateLimitError',
@@ -13,12 +15,8 @@ class ServiceError(TddError):
 
 
 class ResponseError(ServiceError):
-    # `reason` and `trials` say WHY the retry budget ran out -- a timeout, a
-    # 502, an unparseable body. Without them an exhausted request is
-    # indistinguishable from any other in a caller's stats, and answering
-    # "what actually failed" means re-running with debug logging on.
     def __init__(self, target: str, params: dict,
-                 reason: str = 'unknown', trials: int = 0):
+                 reason: Optional[str] = None, trials: int = 0):
         super().__init__()
         self.target = target
         self.params = params
@@ -31,9 +29,6 @@ class ResponseError(ServiceError):
 
 
 class RateLimitError(ServiceError):
-    # Raised as soon as an upstream rate limit is seen. It carries no timing:
-    # the per-worker cooldown that used to predict a retry time is gone, and
-    # how long to wait is the caller's decision, not the Service's.
     def __init__(self, target: str, reason: str):
         super().__init__()
         self.target = target

--- a/service/error.py
+++ b/service/error.py
@@ -13,23 +13,31 @@ class ServiceError(TddError):
 
 
 class ResponseError(ServiceError):
-    def __init__(self, target: str, params: dict):
+    # `reason` and `trials` say WHY the retry budget ran out -- a timeout, a
+    # 502, an unparseable body. Without them an exhausted request is
+    # indistinguishable from any other in a caller's stats, and answering
+    # "what actually failed" means re-running with debug logging on.
+    def __init__(self, target: str, params: dict,
+                 reason: str = 'unknown', trials: int = 0):
         super().__init__()
         self.target = target
         self.params = params
+        self.reason = reason
+        self.trials = trials
 
     def __str__(self):
-        return f'<ResponseError(target={self.target},params={self.params})>'
+        return (f'<ResponseError(target={self.target},params={self.params},'
+                f'reason={self.reason},trials={self.trials})>')
 
 
 class RateLimitError(ServiceError):
-    def __init__(self, target: str, reason: str,
-                 first_seen: float, retry_at: float):
+    # Raised as soon as an upstream rate limit is seen. It carries no timing:
+    # the per-worker cooldown that used to predict a retry time is gone, and
+    # how long to wait is the caller's decision, not the Service's.
+    def __init__(self, target: str, reason: str):
         super().__init__()
         self.target = target
         self.reason = reason
-        self.first_seen = first_seen
-        self.retry_at = retry_at
 
     def __str__(self):
         return f'<RateLimitError(target={self.target},reason={self.reason})>'

--- a/service/worker.py
+++ b/service/worker.py
@@ -1,11 +1,7 @@
 from dataclasses import dataclass
 import logging
 import random
-from threading import Lock
-import time
-from typing import Callable, Iterable, Mapping
-
-from .error import RateLimitError
+from typing import Iterable, Mapping
 
 
 logger = logging.getLogger('Service')
@@ -26,21 +22,21 @@ class WorkerEndpoint:
     enabled: bool = True
 
 
-@dataclass(frozen=True)
-class RateLimitState:
-    first_seen: float
-    retry_at: float
-
-
 class WorkerSelector:
-    """Process-local worker selection and rate-limit cooldown tracking."""
+    """
+    Process-local worker selection.
 
-    def __init__(self, endpoints: Mapping[str, dict], *,
-                 clock: Callable[[], float] = time.monotonic):
-        self._clock = clock
-        self._lock = Lock()
+    Deliberately stateless beyond the parsed config. It used to cool a worker
+    down on a rate limit so another could take over, which assumed the limit is
+    per-worker. Measurement says otherwise: the limit is on request *rate* --
+    roughly 24-30 req/s across the member-card fleet -- so every worker crosses
+    it at the same moment and there is never one with headroom to take over.
+    Five of the six targets run a single worker anyway. Staying under the rate
+    is the fix; taking workers out of the pool never was.
+    """
+
+    def __init__(self, endpoints: Mapping[str, dict]):
         self._workers: dict[str, tuple[WorkerEndpoint, ...]] = {}
-        self._rate_limits: dict[tuple[str, str], RateLimitState] = {}
 
         for target, endpoint_config in endpoints.items():
             raw_workers = endpoint_config.get('workers', [])
@@ -93,63 +89,9 @@ class WorkerSelector:
         return WorkerEndpoint(worker_id, url, platform, weight, enabled)
 
     def select(self, target: str) -> WorkerEndpoint:
-        workers = self._enabled_workers(target)
-        now = self._clock()
-        recovered: list[WorkerEndpoint] = []
-
-        with self._lock:
-            for worker in workers:
-                key = (target, worker.id)
-                state = self._rate_limits.get(key)
-                if state is not None and state.retry_at <= now:
-                    del self._rate_limits[key]
-                    recovered.append(worker)
-            available = tuple(
-                worker for worker in workers
-                if (target, worker.id) not in self._rate_limits)
-            window = self._rate_limit_window(target, workers, now)
-
-        for worker in recovered:
-            logger.info('worker_rate_limit_cleared target=%s worker_id=%s platform=%s',
-                        target, worker.id, worker.platform)
-        if not available:
-            self._raise_rate_limited(target, 'all_workers_rate_limited', window)
-        return random.choice(available)
-
-    def has_failover(self, target: str) -> bool:
-        return len({worker.id for worker in self._enabled_workers(target)}) > 1
-
-    def mark_rate_limited(self, target: str, worker: WorkerEndpoint, *,
-                          reason: str, cooldown_s: int) -> None:
-        workers = self._enabled_workers(target)
-        now = self._clock()
-        retry_at = now + cooldown_s
-        key = (target, worker.id)
-
-        with self._lock:
-            previous = self._rate_limits.get(key)
-            transitioned = previous is None or previous.retry_at <= now
-            first_seen = now if transitioned else previous.first_seen
-            self._rate_limits[key] = RateLimitState(
-                first_seen=first_seen,
-                retry_at=max(previous.retry_at if previous else retry_at,
-                             retry_at))
-            exhausted = all(
-                (state := self._rate_limits.get((target, candidate.id))) is not None
-                and state.retry_at > now for candidate in workers)
-            window = self._rate_limit_window(target, workers, now)
-
-        if transitioned:
-            logger.warning(
-                'worker_rate_limited target=%s worker_id=%s platform=%s reason=%s cooldown_s=%s',
-                target, worker.id, worker.platform, reason, cooldown_s)
-        if exhausted:
-            self._raise_rate_limited(target, reason, window)
-
-    def rate_limit_window(self, target: str) -> tuple[float | None, float | None]:
-        workers = self._enabled_workers(target)
-        with self._lock:
-            return self._rate_limit_window(target, workers, self._clock())
+        # `_weighted` repeats each worker `weight` times, so a uniform choice
+        # here gives the configured weight ratio.
+        return random.choice(self._enabled_workers(target))
 
     def _enabled_workers(self, target: str) -> tuple[WorkerEndpoint, ...]:
         workers = self._workers.get(target, ())
@@ -157,28 +99,6 @@ class WorkerSelector:
             raise WorkerConfigurationError(
                 f'Endpoint {target!r} has no enabled worker configured.')
         return workers
-
-    def _rate_limit_window(
-            self, target: str, workers: Iterable[WorkerEndpoint], now: float
-    ) -> tuple[float | None, float | None]:
-        states = [self._rate_limits[(target, worker.id)]
-                  for worker in workers
-                  if (target, worker.id) in self._rate_limits
-                  and self._rate_limits[(target, worker.id)].retry_at > now]
-        return (min((state.first_seen for state in states), default=None),
-                min((state.retry_at for state in states), default=None))
-
-    def _raise_rate_limited(
-            self, target: str, reason: str,
-            window: tuple[float | None, float | None]) -> None:
-        first_seen, retry_at = window
-        now = self._clock()
-        logger.error(
-            'worker_pool_rate_limited target=%s limited_for_s=%s earliest_retry_in_s=%s',
-            target,
-            None if first_seen is None else max(0, int(now - first_seen)),
-            None if retry_at is None else max(0, int(retry_at - now)))
-        raise RateLimitError(target, reason, first_seen, retry_at)
 
     @staticmethod
     def _weighted(workers: Iterable[WorkerEndpoint]) -> tuple[WorkerEndpoint, ...]:

--- a/service/worker.py
+++ b/service/worker.py
@@ -61,16 +61,21 @@ class WorkerSelector:
             raise WorkerConfigurationError(
                 f'Worker entry for {target!r} must be a URL or object.')
 
-        unknown = set(raw) - {'id', 'url', 'platform', 'weight', 'enabled'}
+        fields = {'id', 'url', 'platform', 'weight', 'enabled'}
+        missing = fields - set(raw)
+        if missing:
+            raise WorkerConfigurationError(
+                f'Missing worker field(s) for {target!r}: {sorted(missing)!r}.')
+        unknown = set(raw) - fields
         if unknown:
             raise WorkerConfigurationError(
                 f'Unknown worker field(s) for {target!r}: {sorted(unknown)!r}.')
 
-        worker_id = raw.get('id')
-        url = raw.get('url')
-        platform = raw.get('platform')
-        weight = raw.get('weight', 1)
-        enabled = raw.get('enabled', True)
+        worker_id = raw['id']
+        url = raw['url']
+        platform = raw['platform']
+        weight = raw['weight']
+        enabled = raw['enabled']
         if not isinstance(worker_id, str) or not worker_id:
             raise WorkerConfigurationError(
                 f'Worker id for {target!r} must be a non-empty string.')

--- a/task/task.py
+++ b/task/task.py
@@ -558,7 +558,7 @@ def add_member(mid: int, service: Service, session: Session, test_exist=True):
     try:
         # special config for get_member_card
         member_card = service.get_member_card(
-            {'mid': mid}, retry=20, timeout=1.5, colddown_factor=0.1)
+            {'mid': mid}, timeout=1.5, colddown_factor=0.1)
     except ServiceError as e:
         raise e
 
@@ -593,7 +593,7 @@ def update_member(mid: int, service: Service, session: Session):
     try:
         # special config for get_member_card
         member_card = service.get_member_card(
-            {'mid': mid}, retry=20, timeout=1.5, colddown_factor=0.1)
+            {'mid': mid}, timeout=1.5, colddown_factor=0.1)
     except CodeError as e:
         # code maybe -404, otherwise anti-crawler triggered, raise error
         if e.code != -404:

--- a/tests/test_api_debug_line.py
+++ b/tests/test_api_debug_line.py
@@ -1,7 +1,7 @@
 import logging
 from unittest import TestCase, mock
 
-from service import Service
+from service import RateLimitError, Service
 
 from test_worker_selector import (ScriptedSession, endpoints_for, response,
                                   worker)
@@ -19,7 +19,7 @@ class ApiDebugLineTest(TestCase):
         service = self.make_service('view', [
             worker('only', 'https://only.invalid/'),
         ], {'https://only.invalid/': [
-            response(412, b'blocked'),
+            response(500, b'upstream failed'),
             response(200, {'code': 0}),
         ]})
 
@@ -29,10 +29,26 @@ class ApiDebugLineTest(TestCase):
 
         api_lines = [line for line in logs.output if 'API target: ' in line]
         self.assertEqual(len(api_lines), 2)
-        self.assertIn('target: view, worker: only, status: 412, result: http_412',
+        self.assertIn('target: view, worker: only, status: 500, result: ok',
                       api_lines[0])
         self.assertIn('target: view, worker: only, status: 200, result: ok',
                       api_lines[1])
+
+    def test_the_line_is_written_before_a_rate_limit_aborts_the_call(self):
+        # the raise happens right after this line, so the reason a call ended
+        # is still on record
+        service = self.make_service('view', [
+            worker('only', 'https://only.invalid/'),
+        ], {'https://only.invalid/': [response(412, b'blocked')]})
+
+        with mock.patch('service.Service.time.sleep'), \
+                self.assertLogs('Service', level=logging.DEBUG) as logs:
+            with self.assertRaises(RateLimitError):
+                service._get('view', 'worker')
+
+        api_lines = [line for line in logs.output if 'API target: ' in line]
+        self.assertEqual(len(api_lines), 1)
+        self.assertIn('status: 412, result: http_412', api_lines[0])
 
     def test_in_body_rate_limit_is_reported_as_the_result(self):
         service = self.make_service('get_member_card', [
@@ -41,7 +57,8 @@ class ApiDebugLineTest(TestCase):
 
         with mock.patch('service.Service.time.sleep'), \
                 self.assertLogs('Service', level=logging.DEBUG) as logs:
-            service._get('get_member_card', 'worker', retry=1)
+            with self.assertRaises(RateLimitError):
+                service._get('get_member_card', 'worker', retry=1)
 
         api_lines = [line for line in logs.output if 'API target: ' in line]
         self.assertEqual(len(api_lines), 1)

--- a/tests/test_api_debug_line.py
+++ b/tests/test_api_debug_line.py
@@ -34,21 +34,20 @@ class ApiDebugLineTest(TestCase):
         self.assertIn('target: view, worker: only, status: 200, result: ok',
                       api_lines[1])
 
-    def test_the_line_is_written_before_a_rate_limit_aborts_the_call(self):
-        # the raise happens right after this line, so the reason a call ended
-        # is still on record
+    def test_every_rate_limited_attempt_gets_its_own_line(self):
         service = self.make_service('view', [
             worker('only', 'https://only.invalid/'),
-        ], {'https://only.invalid/': [response(412, b'blocked')]})
+        ], {'https://only.invalid/': [response(412, b'blocked')] * 3})
 
         with mock.patch('service.Service.time.sleep'), \
                 self.assertLogs('Service', level=logging.DEBUG) as logs:
             with self.assertRaises(RateLimitError):
-                service._get('view', 'worker')
+                service._get('view', 'worker', retry=3)
 
         api_lines = [line for line in logs.output if 'API target: ' in line]
-        self.assertEqual(len(api_lines), 1)
-        self.assertIn('status: 412, result: http_412', api_lines[0])
+        self.assertEqual(len(api_lines), 3)
+        self.assertTrue(all('status: 412, result: http_412' in line
+                            for line in api_lines))
 
     def test_in_body_rate_limit_is_reported_as_the_result(self):
         service = self.make_service('get_member_card', [

--- a/tests/test_update_member_job_rate_limit.py
+++ b/tests/test_update_member_job_rate_limit.py
@@ -27,8 +27,7 @@ class UpdateMemberJobRateLimitTest(TestCase):
         job.stat = JobStat()
         job.logger = logging.getLogger('test.UpdateMemberJob')
 
-        limited = RateLimitError(
-            'get_member_card', 'code_-352', first_seen=95.0, retry_at=105.0)
+        limited = RateLimitError('get_member_card', 'code_-352')
         with mock.patch('job.UpdateMemberJob.update_member',
                         side_effect=[limited, []]) as update, \
                 mock.patch('job.UpdateMemberJob.time.sleep') as sleep, \
@@ -60,9 +59,7 @@ class FetchJobRateLimitTest(TestCase):
         job.stat = JobStat()
         job.logger = logging.getLogger('test.FetchVideoRecordJob')
 
-        limited = RateLimitError(
-            'get_video_view_trimmed', 'http_412',
-            first_seen=95.0, retry_at=105.0)
+        limited = RateLimitError('get_video_view_trimmed', 'http_412')
         with mock.patch('job.FetchVideoRecordJob.fetch_video_record_via_video_view',
                         side_effect=limited):
             job.process()
@@ -84,9 +81,7 @@ class FetchJobRateLimitTest(TestCase):
         job.stat = JobStat()
         job.logger = logging.getLogger('test.FetchMemberFollowerRecordJob')
 
-        limited = RateLimitError(
-            'get_member_relation', 'http_412',
-            first_seen=95.0, retry_at=105.0)
+        limited = RateLimitError('get_member_relation', 'http_412')
         with mock.patch('job.FetchMemberFollowerRecordJob.fetch_member_follower_record',
                         side_effect=[limited, RuntimeError('stop')]) as fetch:
             job.process()

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -1,11 +1,13 @@
 import json
 import logging
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor
 from unittest import TestCase, mock
 
 import requests
 
-from service import (Service, RateLimitError,
+from service import (ResponseError, Service, RateLimitError,
+                     WorkerConfigurationError,
                      WorkerSelector, default_rate_limit, member_card_rate_limit)
 
 
@@ -123,116 +125,66 @@ class WorkerSelectorConfigTest(TestCase):
         with self.assertRaises(ValueError):
             service._worker_selector.select('unused')
 
-    def test_failover_requires_two_distinct_enabled_workers(self):
-        selector = WorkerSelector(endpoints_for('view', [
-            worker('only', 'https://only.invalid/', weight=3),
-            worker('off', 'https://off.invalid/', enabled=False),
-        ]))
-        self.assertFalse(selector.has_failover('view'))
 
-        selector = WorkerSelector(endpoints_for('view', [
-            worker('a', 'https://a.invalid/'),
-            worker('b', 'https://b.invalid/'),
-        ]))
-        self.assertTrue(selector.has_failover('view'))
-
-
-class WorkerSelectorStateTest(TestCase):
+class WorkerSelectorSelectionTest(TestCase):
     def setUp(self):
-        self.clock = FakeClock()
         self.selector = WorkerSelector({
             'view': {'workers': [
-                worker('view-a', 'https://a.invalid/'),
-                worker('view-b', 'https://b.invalid/'),
+                worker('view-a', 'https://a.invalid/', weight=1),
+                worker('view-b', 'https://b.invalid/', weight=2),
+                worker('view-c', 'https://c.invalid/', weight=3),
+                worker('view-off', 'https://off.invalid/', enabled=False),
             ]},
             'card': {'workers': [
                 worker('card-a', 'https://card.invalid/'),
             ]},
-        }, clock=self.clock)
+        })
 
-    def test_rate_limit_is_target_scoped_and_cooldown_restores_directly(self):
-        view_a = next(item for item in self.selector._workers['view']
-                      if item.id == 'view-a')
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
+    def test_weighted_selection_follows_the_configured_ratio(self):
+        picked = Counter()
+        with mock.patch('service.worker.random.choice',
+                        side_effect=lambda items: items[0]) as choose:
+            self.selector.select('view')
+        pool = choose.call_args.args[0]
+        for item in pool:
+            picked[item.id] += 1
+        self.assertEqual(picked, Counter({'view-c': 3, 'view-b': 2, 'view-a': 1}))
 
-        self.assertEqual(self.selector.select('view').id, 'view-b')
-        self.assertEqual(self.selector.select('card').id, 'card-a')
-        self.clock.now += 30
-        with self.assertLogs('Service', logging.INFO) as captured, \
-                mock.patch('service.worker.random.choice', side_effect=lambda items: items[0]):
-            self.assertEqual(self.selector.select('view').id, 'view-a')
-        self.assertIn('worker_rate_limit_cleared', '\n'.join(captured.output))
+    def test_disabled_workers_are_never_selected(self):
+        with mock.patch('service.worker.random.choice',
+                        side_effect=lambda items: items[0]) as choose:
+            self.selector.select('view')
+        self.assertNotIn('view-off',
+                         {item.id for item in choose.call_args.args[0]})
 
     def test_empty_pool_is_reported(self):
-        selected = self.selector.select('card')
-        with self.assertLogs('Service', logging.ERROR) as captured:
-            with self.assertRaises(RateLimitError) as raised:
-                self.selector.mark_rate_limited(
-                    'card', selected, reason='code_-352', cooldown_s=30)
-        self.assertEqual(raised.exception.target, 'card')
-        self.assertEqual(raised.exception.first_seen, 1000.0)
-        self.assertEqual(raised.exception.retry_at, 1030.0)
-        self.assertIn('worker_pool_rate_limited', '\n'.join(captured.output))
+        selector = WorkerSelector({'view': {'workers': []}})
+        with self.assertRaises(WorkerConfigurationError):
+            selector.select('view')
 
-    def test_repeated_rate_limit_preserves_first_seen_and_extends_retry_at(self):
-        view_a = next(item for item in self.selector._workers['view']
-                      if item.id == 'view-a')
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
-        self.clock.now += 10
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
+    def test_a_rate_limit_never_takes_a_worker_out_of_the_pool(self):
+        # the selector is stateless: nothing a response says can shrink the
+        # candidate set, so a limited worker keeps taking its share of traffic
+        seen = {self.selector.select('view').id for _ in range(300)}
+        self.assertEqual(seen, {'view-a', 'view-b', 'view-c'})
 
-        first_seen, retry_at = self.selector.rate_limit_window('view')
-        self.assertEqual(first_seen, 1000.0)
-        self.assertEqual(retry_at, 1040.0)
-
-    def test_expired_other_worker_does_not_cause_pool_exhaustion(self):
-        view_a, view_b = self.selector._workers['view']
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
-        self.clock.now += 31
-
-        self.selector.mark_rate_limited(
-            'view', view_b, reason='http_412', cooldown_s=30)
-
-        self.assertEqual(self.selector.select('view').id, 'view-a')
-
-    def test_selection_uses_state_lock(self):
-        state_lock = mock.MagicMock()
-        self.selector._lock = state_lock
-        self.selector.select('view')
-        state_lock.__enter__.assert_called_once()
-
-    def test_300_threads_select_safely_after_transition(self):
-        view_a = next(item for item in self.selector._workers['view']
-                      if item.id == 'view-a')
-        self.selector.mark_rate_limited(
-            'view', view_a, reason='http_412', cooldown_s=30)
+    def test_300_threads_select_safely(self):
         with ThreadPoolExecutor(max_workers=300) as pool:
-            selected = list(pool.map(lambda _: self.selector.select('view'), range(3000)))
-        self.assertEqual({item.id for item in selected}, {'view-b'})
-
-    def test_50_concurrent_rate_limit_calls_leave_consistent_state(self):
-        view_a = next(item for item in self.selector._workers['view']
-                      if item.id == 'view-a')
-        with ThreadPoolExecutor(max_workers=50) as pool:
-            list(pool.map(lambda _: self.selector.mark_rate_limited(
-                'view', view_a, reason='http_412', cooldown_s=30), range(50)))
-        self.assertEqual(self.selector.select('view').id, 'view-b')
+            selected = list(pool.map(lambda _: self.selector.select('card'),
+                                     range(3000)))
+        self.assertEqual({item.id for item in selected}, {'card-a'})
 
 
 class RateLimitCheckerTest(TestCase):
     def test_default_checker_only_handles_http_412(self):
         limited = default_rate_limit(response(412, b'blocked'))
-        self.assertEqual((limited.reason, limited.cooldown_s), ('http_412', 1800))
+        self.assertEqual(limited.reason, 'http_412')
         self.assertIsNone(default_rate_limit(response(200, {'code': -412})))
         self.assertIsNone(default_rate_limit(response(200, {'code': -352})))
 
     def test_member_card_extends_default_with_json_352(self):
         limited = member_card_rate_limit(response(200, {'code': -352}))
-        self.assertEqual((limited.reason, limited.cooldown_s), ('code_-352', 300))
+        self.assertEqual(limited.reason, 'code_-352')
         self.assertEqual(member_card_rate_limit(response(412, b'blocked')).reason,
                          'http_412')
         self.assertIsNone(member_card_rate_limit(response(200, {'code': -404})))
@@ -248,66 +200,51 @@ class ServiceWorkerRoutingTest(TestCase):
         service._session = ScriptedSession(responses)
         return service
 
-    @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
-    def test_http_412_disables_worker_and_retry_uses_another(self, _choice):
+    def test_412_raises_at_once_and_spends_no_further_trial(self):
+        # a 412 used to cool the worker down and hand the retry to another one.
+        # The limit is on request rate, so retrying only lengthens the wall:
+        # stop on the first one, with 19 trials still unspent.
         service = self.make_service('view', [
             worker('a', 'https://a.invalid/'),
             worker('b', 'https://b.invalid/'),
         ], {
             'https://a.invalid/': [response(412, b'blocked')],
-            'https://b.invalid/': [response(200, {'code': 0})],
+            'https://b.invalid/': [response(412, b'blocked')],
         })
 
-        with mock.patch('service.Service.time.sleep'):
-            result = service._get('view', 'worker')
+        with mock.patch('service.Service.time.sleep'), \
+                mock.patch('service.worker.random.choice',
+                           side_effect=lambda items: items[0]):
+            with self.assertRaises(RateLimitError) as raised:
+                service._get('view', 'worker', retry=20)
 
-        self.assertEqual(result, {'code': 0})
-        self.assertEqual(service._session.calls,
-                         ['https://a.invalid/', 'https://b.invalid/'])
+        self.assertEqual(raised.exception.reason, 'http_412')
+        self.assertEqual(len(service._session.calls), 1)
 
-    def test_http_412_on_single_worker_uses_normal_retry_without_cooldown(self):
+    def test_single_worker_412_also_raises_rather_than_retrying(self):
         service = self.make_service('view', [
             worker('only', 'https://only.invalid/'),
-        ], {
-            'https://only.invalid/': [
-                response(412, b'blocked'),
-                response(412, b'blocked'),
-                response(412, b'blocked'),
-                response(200, {'code': 0}),
-            ],
-        })
+        ], {'https://only.invalid/': [response(412, b'blocked')]})
 
         with mock.patch('service.Service.time.sleep'):
-            self.assertIsNone(service._get('view', 'worker', retry=3))
-            self.assertEqual(service._get('view', 'worker', retry=1),
-                             {'code': 0})
+            with self.assertRaises(RateLimitError):
+                service._get('view', 'worker', retry=3)
 
-        self.assertEqual(service._session.calls,
-                         ['https://only.invalid/'] * 4)
-        self.assertEqual(service._worker_selector.rate_limit_window('view'),
-                         (None, None))
+        self.assertEqual(service._session.calls, ['https://only.invalid/'])
 
-    def test_json_352_on_single_worker_retries_instead_of_returning_body(self):
+    def test_in_body_352_raises_and_is_never_returned_as_a_response(self):
+        # status is 200 here, so without the explicit rate-limit check this
+        # body would be handed back to the caller as valid data
         service = self.make_service('get_member_card', [
             worker('only', 'https://only.invalid/'),
-        ], {
-            'https://only.invalid/': [
-                response(200, {'code': -352}),
-                response(200, {'code': -352}),
-                response(200, {'code': 0}),
-            ],
-        })
+        ], {'https://only.invalid/': [response(200, {'code': -352})]})
 
         with mock.patch('service.Service.time.sleep'):
-            self.assertIsNone(service._get('get_member_card', 'worker', retry=2))
-            self.assertEqual(service._get('get_member_card', 'worker', retry=1),
-                             {'code': 0})
+            with self.assertRaises(RateLimitError) as raised:
+                service._get('get_member_card', 'worker', retry=3)
 
-        self.assertEqual(service._session.calls,
-                         ['https://only.invalid/'] * 3)
-        self.assertEqual(
-            service._worker_selector.rate_limit_window('get_member_card'),
-            (None, None))
+        self.assertEqual(raised.exception.reason, 'code_-352')
+        self.assertEqual(service._session.calls, ['https://only.invalid/'])
 
     @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
     def test_json_352_uses_member_card_checker_without_60_second_sleep(self, _choice):
@@ -320,12 +257,11 @@ class ServiceWorkerRoutingTest(TestCase):
         })
 
         with mock.patch('service.Service.time.sleep') as sleep:
-            result = service._get('get_member_card', 'worker')
+            with self.assertRaises(RateLimitError) as raised:
+                service._get('get_member_card', 'worker')
 
-        self.assertEqual(result, {'code': 0})
+        self.assertEqual(raised.exception.reason, 'code_-352')
         self.assertNotIn(mock.call(60), sleep.mock_calls)
-        self.assertEqual(service._session.calls,
-                         ['https://a.invalid/', 'https://b.invalid/'])
 
     def test_member_card_uses_generic_json_parser_and_retries_non_json(self):
         service = self.make_service('get_member_card', [
@@ -355,15 +291,14 @@ class ServiceWorkerRoutingTest(TestCase):
             worker('a', 'https://a.invalid/'),
             worker('b', 'https://b.invalid/'),
         ], {
-            'https://a.invalid/': [response(200, {'code': -352})],
+            'https://a.invalid/': [response(200, {'code': -352}),
+                                   response(200, valid)],
             'https://b.invalid/': [response(200, valid)],
         })
 
-        with mock.patch('service.Service.time.sleep') as sleep:
-            card = service.get_member_card({'mid': 123})
-
-        self.assertEqual((card.mid, card.name), ('123', 'name'))
-        self.assertNotIn(mock.call(60), sleep.mock_calls)
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(RateLimitError):
+                service.get_member_card({'mid': 123})
 
     def test_ordinary_failure_can_retry_the_same_worker(self):
         service = self.make_service('view', [
@@ -380,6 +315,35 @@ class ServiceWorkerRoutingTest(TestCase):
         self.assertEqual(service._session.calls,
                          ['https://a.invalid/', 'https://a.invalid/'])
 
+    def test_exhaustion_reports_the_last_failure_and_the_trial_count(self):
+        # without this the caller only learns "it failed", and answering what
+        # actually failed means re-running the job with debug logging on
+        service = self.make_service('view', [
+            worker('only', 'https://only.invalid/'),
+        ], {'https://only.invalid/': [response(503, b'unavailable')] * 3})
+
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(ResponseError) as raised:
+                service._get('view', 'worker', retry=3)
+
+        self.assertEqual(raised.exception.reason, 'http_503')
+        self.assertEqual(raised.exception.trials, 3)
+        self.assertEqual(raised.exception.target, 'view')
+
+    def test_exhaustion_reason_tracks_the_last_failure_not_the_first(self):
+        service = self.make_service('view', [
+            worker('only', 'https://only.invalid/'),
+        ], {'https://only.invalid/': [
+            response(502, b'bad gateway'),
+            response(200, b'not json'),
+        ]})
+
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(ResponseError) as raised:
+                service._get('view', 'worker', retry=2)
+
+        self.assertEqual(raised.exception.reason, 'json_error')
+
     def test_direct_rate_limit_does_not_use_selector(self):
         service = Service(mode='direct', endpoints=endpoints_for('view', []))
         service._session = ScriptedSession({
@@ -389,5 +353,4 @@ class ServiceWorkerRoutingTest(TestCase):
             with self.assertRaises(RateLimitError) as raised:
                 service._get('view', 'direct')
         self.assertEqual(raised.exception.reason, 'http_412')
-        self.assertGreater(raised.exception.retry_at, 0)
         select.assert_not_called()

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -86,6 +86,25 @@ class WorkerSelectorConfigTest(TestCase):
             with self.subTest(item=item), self.assertRaises(ValueError):
                 WorkerSelector(endpoints_for('view', [item]))
 
+    def test_every_worker_field_is_required(self):
+        # no defaults: a config that does not say is a config that is wrong
+        complete = worker('a', 'https://a.invalid/')
+        for field in ('id', 'url', 'platform', 'weight', 'enabled'):
+            partial = {k: v for k, v in complete.items() if k != field}
+            with self.assertRaises(WorkerConfigurationError) as raised:
+                WorkerSelector(endpoints_for('view', [partial]))
+            self.assertIn(field, str(raised.exception))
+
+    def test_enabled_false_is_honoured_and_not_mistaken_for_missing(self):
+        selector = WorkerSelector(endpoints_for('view', [
+            worker('on', 'https://on.invalid/'),
+            worker('off', 'https://off.invalid/', enabled=False),
+        ]))
+        with mock.patch('service.worker.random.choice',
+                        side_effect=lambda items: items[0]) as choose:
+            selector.select('view')
+        self.assertEqual({item.id for item in choose.call_args.args[0]}, {'on'})
+
     def test_unknown_new_worker_field_is_rejected(self):
         item = worker('w', 'https://worker.invalid/')
         item['enable'] = False

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -200,51 +200,96 @@ class ServiceWorkerRoutingTest(TestCase):
         service._session = ScriptedSession(responses)
         return service
 
-    def test_412_raises_at_once_and_spends_no_further_trial(self):
-        # a 412 used to cool the worker down and hand the retry to another one.
-        # The limit is on request rate, so retrying only lengthens the wall:
-        # stop on the first one, with 19 trials still unspent.
+    def test_412_that_recovers_on_retry_is_not_an_error_at_all(self):
+        # 7.75% of video-view requests come back 412 and 99% of those succeed
+        # on the next attempt; treating one as fatal on sight would throw the
+        # recoverable majority away
+        service = self.make_service('view', [
+            worker('only', 'https://only.invalid/'),
+        ], {'https://only.invalid/': [
+            response(412, b'blocked'),
+            response(200, {'code': 0}),
+        ]})
+
+        with mock.patch('service.Service.time.sleep'):
+            self.assertEqual(service._get('view', 'worker'), {'code': 0})
+
+        self.assertEqual(len(service._session.calls), 2)
+
+    def test_every_trial_rate_limited_raises_RateLimitError(self):
+        service = self.make_service('view', [
+            worker('only', 'https://only.invalid/'),
+        ], {'https://only.invalid/': [response(412, b'blocked')] * 3})
+
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(RateLimitError) as raised:
+                service._get('view', 'worker', retry=3)
+
+        self.assertEqual(raised.exception.reason, 'http_412')
+        self.assertEqual(len(service._session.calls), 3)
+
+    def test_a_mix_of_failures_is_an_ordinary_exhausted_request(self):
+        # only a run of nothing but rate limits means "wall"; one timeout or
+        # 502 in the mix makes it bad luck, and the caller should not back off
+        # as though it were being throttled
+        service = self.make_service('view', [
+            worker('only', 'https://only.invalid/'),
+        ], {'https://only.invalid/': [
+            response(412, b'blocked'),
+            response(503, b'unavailable'),
+            response(412, b'blocked'),
+        ]})
+
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(ResponseError) as raised:
+                service._get('view', 'worker', retry=3)
+
+        self.assertEqual(raised.exception.reason, 'http_412')
+        self.assertEqual(raised.exception.trials, 3)
+
+    def test_a_rate_limited_worker_keeps_taking_its_share_of_retries(self):
         service = self.make_service('view', [
             worker('a', 'https://a.invalid/'),
             worker('b', 'https://b.invalid/'),
         ], {
-            'https://a.invalid/': [response(412, b'blocked')],
-            'https://b.invalid/': [response(412, b'blocked')],
+            'https://a.invalid/': [response(412, b'blocked')] * 3,
+            'https://b.invalid/': [response(412, b'blocked')] * 3,
         })
 
         with mock.patch('service.Service.time.sleep'), \
                 mock.patch('service.worker.random.choice',
-                           side_effect=lambda items: items[0]):
-            with self.assertRaises(RateLimitError) as raised:
-                service._get('view', 'worker', retry=20)
-
-        self.assertEqual(raised.exception.reason, 'http_412')
-        self.assertEqual(len(service._session.calls), 1)
-
-    def test_single_worker_412_also_raises_rather_than_retrying(self):
-        service = self.make_service('view', [
-            worker('only', 'https://only.invalid/'),
-        ], {'https://only.invalid/': [response(412, b'blocked')]})
-
-        with mock.patch('service.Service.time.sleep'):
+                           side_effect=lambda items: items[0]) as choose:
             with self.assertRaises(RateLimitError):
                 service._get('view', 'worker', retry=3)
 
-        self.assertEqual(service._session.calls, ['https://only.invalid/'])
+        # nothing a response says takes a worker out of the candidate set
+        self.assertEqual({item.id for item in choose.call_args.args[0]},
+                         {'a', 'b'})
 
-    def test_in_body_352_raises_and_is_never_returned_as_a_response(self):
-        # status is 200 here, so without the explicit rate-limit check this
-        # body would be handed back to the caller as valid data
+    def test_in_body_352_is_never_returned_as_a_response(self):
+        # status is 200 and the body is valid JSON, so without the rate-limit
+        # check this would be handed back to the caller as data
         service = self.make_service('get_member_card', [
             worker('only', 'https://only.invalid/'),
-        ], {'https://only.invalid/': [response(200, {'code': -352})]})
+        ], {'https://only.invalid/': [response(200, {'code': -352})] * 3})
 
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(RateLimitError) as raised:
                 service._get('get_member_card', 'worker', retry=3)
 
         self.assertEqual(raised.exception.reason, 'code_-352')
-        self.assertEqual(service._session.calls, ['https://only.invalid/'])
+
+    def test_in_body_352_still_retries_and_can_recover(self):
+        service = self.make_service('get_member_card', [
+            worker('only', 'https://only.invalid/'),
+        ], {'https://only.invalid/': [
+            response(200, {'code': -352}),
+            response(200, {'code': 0}),
+        ]})
+
+        with mock.patch('service.Service.time.sleep'):
+            self.assertEqual(service._get('get_member_card', 'worker'),
+                             {'code': 0})
 
     @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
     def test_json_352_uses_member_card_checker_without_60_second_sleep(self, _choice):
@@ -252,15 +297,15 @@ class ServiceWorkerRoutingTest(TestCase):
             worker('a', 'https://a.invalid/'),
             worker('b', 'https://b.invalid/'),
         ], {
-            'https://a.invalid/': [response(200, {'code': -352})],
+            'https://a.invalid/': [response(200, {'code': -352}),
+                                   response(200, {'code': 0})],
             'https://b.invalid/': [response(200, {'code': 0})],
         })
 
         with mock.patch('service.Service.time.sleep') as sleep:
-            with self.assertRaises(RateLimitError) as raised:
-                service._get('get_member_card', 'worker')
+            result = service._get('get_member_card', 'worker')
 
-        self.assertEqual(raised.exception.reason, 'code_-352')
+        self.assertEqual(result, {'code': 0})
         self.assertNotIn(mock.call(60), sleep.mock_calls)
 
     def test_member_card_uses_generic_json_parser_and_retries_non_json(self):
@@ -297,8 +342,9 @@ class ServiceWorkerRoutingTest(TestCase):
         })
 
         with mock.patch('service.Service.time.sleep'):
-            with self.assertRaises(RateLimitError):
-                service.get_member_card({'mid': 123})
+            card = service.get_member_card({'mid': 123})
+
+        self.assertEqual((card.mid, card.name), ('123', 'name'))
 
     def test_ordinary_failure_can_retry_the_same_worker(self):
         service = self.make_service('view', [
@@ -347,10 +393,11 @@ class ServiceWorkerRoutingTest(TestCase):
     def test_direct_rate_limit_does_not_use_selector(self):
         service = Service(mode='direct', endpoints=endpoints_for('view', []))
         service._session = ScriptedSession({
-            'https://direct.invalid/': [response(412, b'blocked')],
+            'https://direct.invalid/': [response(412, b'blocked')] * 2,
         })
-        with mock.patch.object(service._worker_selector, 'select') as select:
+        with mock.patch('service.Service.time.sleep'), \
+                mock.patch.object(service._worker_selector, 'select') as select:
             with self.assertRaises(RateLimitError) as raised:
-                service._get('view', 'direct')
+                service._get('view', 'direct', retry=2)
         self.assertEqual(raised.exception.reason, 'http_412')
         select.assert_not_called()


### PR DESCRIPTION
The retry loop treated seven failure conditions identically — connection error, body read error, deadline exceeded, rate limit, non-200, undecodable JSON, parser returning `None` — and when the budget ran out it threw the reason away. Callers could not tell a wall from bad luck, and a job's `other_exception` count could not distinguish a timeout from a 502 from an unparseable body.

## What the measurements say

The two rate limits behave oppositely, so no single on-sight policy is right for both:

| | shape | retry outcome |
|---|---|---|
| `http_412` (video-view) | non-200 | 13,199 of 170,217 requests (**7.75%**) hit it; **99.05% recover** on trial 2 or 3, leaving 126 exhausted — exactly that run's `other_exception: 126` |
| `code_-352` (member-card) | 200 + valid JSON | a real wall. The limit is on request **rate**: 24 req/s sustained clean for 60s, 30 req/s tripped at 38s. Once tripped nothing succeeds for ~300s |

Failing a 412 on sight would discard ~13k records an hour. Retrying a `-352` is futile. Both facts are true at once, so the decision cannot be made when the failure is seen.

## Retry first, classify after

A rate limit now retries like any other failure. If the budget is spent and **every** trial was a rate limit, that is a wall and `RateLimitError` says so — which is what lets a job back off, requeue, or slow down. Any other exhaustion, including a mix of causes, is an ordinary `ResponseError`, which now carries `reason` and `trials`. Direct mode follows the same rule; there is no longer a per-mode branch.

A side effect worth having: the 126 exhausted 412s an hour move from `other_exception` to `rate_limited`, so `other_exception` finally means "something else".

## `WorkerSelector` becomes stateless

Cooling a worker down on a rate limit assumed the limit is per-worker. Because it is on rate, every worker crosses it at the same moment — measured across five consecutive cycles, all three member-card workers hit `-352` inside the same 10-second bucket every time, so there was never one with headroom to take over. Five of the six targets run a single worker anyway. Gone with it: the cooldown windows (30 min / 5 min) and the timing fields on `RateLimitError`.

## Two tuning changes that follow from the same numbers

**Retry counts are now the default 3 everywhere.** Eight scripts already used the default, including the highest-volume one; the four `retry=20` overrides were left over from fighting `-352` by hammering. Across 3,966 observed requests no call ever went past trial 3, and no timeout past trial 2.

**`16_` drops from 20 job threads to 2.** Each thread sustains ~1.8 req/s, so 20 of them produced 33–37 req/s against a 24–30 req/s limit — the job had been running ~40% over the threshold, which is what tripped it every cycle and cost 24% of its members to skips. Two threads is ~3.6 req/s, about a seventh of the threshold, and finishes the day's ~25k members in two hours.

Validation:
- `python -m unittest discover -s tests` — 223 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)