### PR TITLE
fix: rotate the User-Agent per request, and drop the one that is blocked

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -162,8 +162,6 @@ class Service:
             r'Opera/9.80 (Android 2.3.4; Linux; Opera Mobi/build-1107180945; U; en-GB) Presto/2.8.149 Version/11.10',
             # BlackBerry
             r'Mozilla/5.0 (BlackBerry; U; BlackBerry 9800; en) AppleWebKit/534.1+ (KHTML, like Gecko) Version/6.0.0.337 Mobile Safari/534.1+',
-            # Nokia N97
-            r'Mozilla/5.0 (SymbianOS/9.4; Series60/5.0 NokiaN97-1/20.0.019; Profile/MIDP-2.1 Configuration/CLDC-1.1) AppleWebKit/525 (KHTML, like Gecko) BrowserNG/7.1.18124',
             # Android N1
             r'Mozilla/5.0 (Linux; U; Android 2.3.7; en-us; Nexus One Build/FRF91) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1'
         ]
@@ -198,8 +196,11 @@ class Service:
             parser: Optional[Callable[[str], Optional[dict]]] = None
     ) -> dict:
         # assemble headers
+        # copy, don't alias: the User-Agent set below would otherwise be
+        # written into self._headers and every later request would reuse it,
+        # so a process picked one agent at startup and kept it for its whole run
         if headers is None:
-            headers = self._headers
+            headers = dict(self._headers)
         else:
             headers = {**self._headers, **headers}
         # add User-Agent if not exists

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -1,0 +1,69 @@
+import json
+from unittest import TestCase, mock
+
+import requests
+
+from service import Service
+
+from test_worker_selector import endpoints_for, response, worker
+
+
+class RecordingSession:
+    def __init__(self, reply):
+        self.reply = reply
+        self.sent_agents = []
+
+    def get(self, url, **kwargs):
+        self.sent_agents.append(kwargs['headers']['User-Agent'])
+        item = requests.Response()
+        item.status_code = 200
+        item.headers = {}
+        item._content = json.dumps(self.reply).encode()
+        item._content_consumed = True
+        item.url = url
+        return item
+
+
+class UserAgentTest(TestCase):
+    def make_service(self, **kwargs):
+        service = Service(
+            mode='worker', colddown_factor=0,
+            endpoints=endpoints_for('view', [worker('a', 'https://a.invalid/')]),
+            **kwargs)
+        service._session = RecordingSession({'code': 0})
+        return service
+
+    def test_the_agent_is_drawn_again_for_every_request(self):
+        # the agent used to be written into self._headers on the first request,
+        # so a process picked one at startup and sent it for its whole run
+        service = self.make_service()
+        for _ in range(40):
+            service._get('view', 'worker')
+
+        self.assertEqual(len(service._session.sent_agents), 40)
+        self.assertGreater(len(set(service._session.sent_agents)), 1)
+
+    def test_default_headers_are_not_mutated_by_a_request(self):
+        service = self.make_service()
+        service._get('view', 'worker')
+        self.assertEqual(service._headers, {})
+        self.assertEqual(service.get_default_headers(), {})
+
+    def test_configured_headers_survive_and_are_not_mutated(self):
+        service = self.make_service(headers={'Referer': 'https://ref.invalid/'})
+        service._get('view', 'worker')
+        service._get('view', 'worker')
+        self.assertEqual(service._headers, {'Referer': 'https://ref.invalid/'})
+
+    def test_an_explicit_agent_is_left_alone(self):
+        service = self.make_service()
+        for _ in range(5):
+            service._get('view', 'worker', headers={'User-Agent': 'mine/1.0'})
+        self.assertEqual(set(service._session.sent_agents), {'mine/1.0'})
+
+    def test_the_symbian_agent_is_not_offered(self):
+        # measured 20 rejections in 50 requests (40%); every other agent in the
+        # list returned 50/50 clean in the same interleaved run
+        service = self.make_service()
+        self.assertFalse(any('Symbian' in agent for agent in service._ua_list))
+        self.assertFalse(any('NokiaN97' in agent for agent in service._ua_list))


### PR DESCRIPTION
Two independent defects in the same place, worth landing together.

## Rotation never happened

```python
if headers is None:
    headers = self._headers          # aliases the instance dict
...
if 'User-Agent' not in headers:
    headers['User-Agent'] = random.choice(self._ua_list)   # writes into self._headers
```

The agent picked for the first request was written back into `self._headers`, so every later request found one already set and kept it. **A process drew one agent at startup and sent it for its entire run** — tens of thousands of requests on a single agent. Reproduced on a live instance: five consecutive draws returned the same agent, and `self._headers` came back holding it.

Fixed by copying instead of aliasing.

## One agent in the list is blocked

All 18 agents were surveyed against the member-card endpoint, 50 requests each, round-robin at 3 req/s so no agent could be blamed for a bad moment:

| agent | ok | code -352 |
|---|---|---|
| `SymbianOS/9.4 … NokiaN97-1` | 30 | **20 (40%)** |
| the other 17 | 50 | 0 |

Age is not the predictor — MSIE 7, BlackBerry and Android 2.3 all came back clean, so only the Symbian entry is dropped.

## Why together

With the aliasing bug in place a run either drew a clean agent or drew Symbian. Fixing rotation on its own would have spread the blocked agent across 1/18 of every job's requests instead of 1-in-18 runs, which is worse for the runs that would have been lucky.

## What this does not explain

A member job running on one frozen agent showed a steady ~2.7% rejection rate across 2,666 requests, flat over 50 minutes with no upward trend, while short probes at comparable rates showed 0%. Neither of these two changes accounts for that, and it is still open.

Validation:
- `python -m unittest discover -s tests` — 230 passed (5 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)