### PR TITLE
feat: always-on request/retry/rate-limit observability without --debug

### DIFF
--- a/16_update-member-info.py
+++ b/16_update-member-info.py
@@ -77,6 +77,7 @@ def update_member_info():
     logger.info(f'Finish {script_fullname}!')
     logger.info(timer.get_summary())
     logger.info(job_stat_merged.get_summary('member-update'))
+    service.stats.log_summary(logger)
     sc_send_summary(script_fullname, timer, job_stat_merged)
 
 

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -92,7 +92,8 @@ def fetch_and_batch_insert_records(
     doing it inline on a fetch worker let all 250 fetchers hit the DB at once,
     which deadlocked the 2026-07-15 04:00 full scan.
 
-    Returns (fetch_stat, writer_stat, update_stat) merged JobStats.
+    Returns (fetch_stat, writer_stat, update_stat) merged JobStats, plus the
+    ApiStatTracker of the Service shared by the fetch and update pools.
     """
     log = logging.getLogger(logger_name)
     # pool_maxsize MUST cover job_num: every worker hits the same worker host,
@@ -174,7 +175,13 @@ def fetch_and_batch_insert_records(
     log.info(update_stat.get_summary(update_label))
     log.info(f'{writer_stat.total_count} record(s) fetched, batch inserted and returned.')
     log.info(f'{update_stat.total_count} code-error video(s) updated.')
-    return fetch_stat, writer_stat, update_stat
+    # standing request/retry/rate-limit observability: the fetch and
+    # update pools share this one Service, so its tracker covers every HTTP
+    # attempt either pool made. Logged here (not --debug-gated) so p / retry
+    # recovery / retry exhaustion are readable from every run.
+    if service.stats is not None:
+        service.stats.log_summary(log)
+    return fetch_stat, writer_stat, update_stat, service.stats
 
 
 class VideoRecordAcquisitionJob(Job):
@@ -212,6 +219,9 @@ class VideoRecordAcquisitionJob(Job):
         self.fetch_stat = None
         self.writer_stat = None
         self.update_stat = None
+        # request/retry/rate-limit tracker of the Service shared by the fetch
+        # and update pools; stays None if process() raised
+        self.api_stats = None
 
     def process(self):
         session = Session()
@@ -220,7 +230,8 @@ class VideoRecordAcquisitionJob(Job):
         self.logger.info(
             f'{len(need_insert_aid_list)} aid(s) need insert for time label {self.time_label}.')
 
-        self.fetch_stat, self.writer_stat, self.update_stat = fetch_and_batch_insert_records(
+        (self.fetch_stat, self.writer_stat, self.update_stat,
+         self.api_stats) = fetch_and_batch_insert_records(
             need_insert_aid_list, self.record_queue,
             job_num=300,
             fetch_label=self.FETCH_LABEL,
@@ -739,6 +750,9 @@ def run_hourly_video_record_add(time_task, recorder: Optional[RunRecorder] = Non
     if recorder is not None:
         for scope, stat in acquisition_runner.stats().items():
             recorder.add_job_stat_metrics(scope, stat)
+        # request/retry/rate-limit totals: makes p / retry recovery / retry
+        # exhaustion a `runrecord trend` query, not a --debug re-run
+        recorder.add_api_stat_metrics(acquisition_runner.api_stats)
 
     records = []
     while not records_queue.empty():

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -175,12 +175,9 @@ def fetch_and_batch_insert_records(
     log.info(update_stat.get_summary(update_label))
     log.info(f'{writer_stat.total_count} record(s) fetched, batch inserted and returned.')
     log.info(f'{update_stat.total_count} code-error video(s) updated.')
-    # standing request/retry/rate-limit observability: the fetch and
-    # update pools share this one Service, so its tracker covers every HTTP
-    # attempt either pool made. Logged here (not --debug-gated) so p / retry
-    # recovery / retry exhaustion are readable from every run.
-    if service.stats is not None:
-        service.stats.log_summary(log)
+    # the fetch and update pools share this Service, so its tracker covers
+    # every HTTP attempt either made
+    service.stats.log_summary(log)
     return fetch_stat, writer_stat, update_stat, service.stats
 
 
@@ -219,8 +216,7 @@ class VideoRecordAcquisitionJob(Job):
         self.fetch_stat = None
         self.writer_stat = None
         self.update_stat = None
-        # request/retry/rate-limit tracker of the Service shared by the fetch
-        # and update pools; stays None if process() raised
+        # set by process(); stays None if it raised
         self.api_stats = None
 
     def process(self):
@@ -750,8 +746,6 @@ def run_hourly_video_record_add(time_task, recorder: Optional[RunRecorder] = Non
     if recorder is not None:
         for scope, stat in acquisition_runner.stats().items():
             recorder.add_job_stat_metrics(scope, stat)
-        # request/retry/rate-limit totals: makes p / retry recovery / retry
-        # exhaustion a `runrecord trend` query, not a --debug re-run
         recorder.add_api_stat_metrics(acquisition_runner.api_stats)
 
     records = []

--- a/runrecord/recorder.py
+++ b/runrecord/recorder.py
@@ -176,6 +176,30 @@ class RunRecorder:
         except Exception as e:
             logger.warning(f'run record: failed to add metrics for scope {scope!r} ({e!r})')
 
+    def add_api_stat_metrics(self, tracker) -> None:
+        """
+        Persist the whole-run totals of an ``ApiStatTracker``: one row per
+        ``(target, worker, trial, outcome)`` combination it saw,
+        scoped as ``api:<target>:<worker>`` / ``t<trial>:<outcome>``. Duck-typed
+        on ``tracker.totals()`` returning ``[{'scope', 'name', 'value'}, ...]``
+        (``service.apistat.ApiStatTracker``'s contract) so this module never
+        has to import ``service``.
+        """
+        if not self.enabled or tracker is None:
+            return
+        try:
+            rows = tracker.totals()
+            if not rows:
+                return
+            self._conn.executemany(
+                'INSERT OR REPLACE INTO run_metric (run_id, scope, name, value, unit) '
+                'VALUES (?, ?, ?, ?, ?)',
+                [(self.run_id, row['scope'], row['name'], float(row['value']), 'count')
+                 for row in rows])
+            self._conn.commit()
+        except Exception as e:
+            logger.warning(f'run record: failed to add api stat metrics ({e!r})')
+
     def finish(self, status: str) -> None:
         if not self.enabled:
             return

--- a/runrecord/recorder.py
+++ b/runrecord/recorder.py
@@ -178,12 +178,9 @@ class RunRecorder:
 
     def add_api_stat_metrics(self, tracker) -> None:
         """
-        Persist the whole-run totals of an ``ApiStatTracker``: one row per
-        ``(target, worker, trial, outcome)`` combination it saw,
-        scoped as ``api:<target>:<worker>`` / ``t<trial>:<outcome>``. Duck-typed
-        on ``tracker.totals()`` returning ``[{'scope', 'name', 'value'}, ...]``
-        (``service.apistat.ApiStatTracker``'s contract) so this module never
-        has to import ``service``.
+        Persist an ApiStatTracker's run totals, one row per
+        (target, worker, trial, outcome). Duck-typed on `totals()` so this
+        module never has to import `service`.
         """
         if not self.enabled or tracker is None:
             return

--- a/service/Service.py
+++ b/service/Service.py
@@ -10,7 +10,7 @@ from typing import Optional, Callable, Literal, Union
 from .error import (ResponseError, RateLimitError,
                     FormatError, CodeError)
 from .worker import WorkerConfigurationError, WorkerSelector
-from .apistat import ApiStatTracker
+from .apistat import ApiStatTracker, NullApiStat
 from .response import \
     VideoViewOwner, VideoViewStat, VideoViewStaffItem, VideoView, VideoViewTrimmed, \
     VideoTag, VideoTags, \
@@ -70,14 +70,11 @@ class Service:
             logger.critical(f'Invalid request mode: {mode}.')
             raise SystemExit(1)
 
-        # always-on request/retry/rate-limit observability, keyed on every
-        # attempt this Service makes. Default: one tracker per Service
-        # instance, matching the "one Service shared by all worker threads"
-        # lifetime. Pass an existing ApiStatTracker to share counters across
-        # several Service instances, or `stats=False` to disable (e.g. a
-        # throwaway Service in a test or a one-off script).
+        # one tracker per Service by default, matching the "one Service shared
+        # by all worker threads" lifetime. Pass an existing tracker to share
+        # counters across Services, or stats=False to disable.
         if stats is False:
-            self.stats: Optional[ApiStatTracker] = None
+            self.stats = NullApiStat()
         elif stats is None:
             self.stats = ApiStatTracker()
         else:
@@ -245,6 +242,15 @@ class Service:
         response = None
         last_failure = None
         rate_limited_trials = 0
+
+        def note(outcome: str) -> None:
+            """Classify this attempt once: remember why it failed, and count
+            it. One call site per outcome so the two can never drift apart."""
+            nonlocal last_failure
+            if outcome != 'ok':
+                last_failure = outcome
+            self.stats.record(target, worker_id, trial, outcome)
+
         for trial in range(1, retry + 1):
             selected_worker = None
             request_url = direct_url
@@ -269,9 +275,7 @@ class Service:
                 r = self._session.get(request_url, params=params, headers=headers,
                                       timeout=timeout, stream=True)
             except requests.exceptions.RequestException as e:
-                last_failure = 'request_exception'
-                if self.stats is not None:
-                    self.stats.record(target, worker_id, trial, last_failure)
+                note('request_exception')
                 logger.debug(
                     f'Fail to get response. '
                     f'url: {request_url}, params: {params}, trial: {trial}, error: {e}'
@@ -310,9 +314,7 @@ class Service:
                         break
             except requests.exceptions.RequestException as e:
                 r.close()
-                last_failure = 'body_exception'
-                if self.stats is not None:
-                    self.stats.record(target, worker_id, trial, last_failure)
+                note('body_exception')
                 logger.debug(
                     f'Fail to read response body. '
                     f'url: {request_url}, params: {params}, trial: {trial}, error: {e}'
@@ -320,9 +322,7 @@ class Service:
                 continue
             if deadline_exceeded:
                 r.close()
-                last_failure = 'deadline_exceeded'
-                if self.stats is not None:
-                    self.stats.record(target, worker_id, trial, last_failure)
+                note('deadline_exceeded')
                 trial_ms = int((time.perf_counter() - trial_start) * 1000)
                 logger.debug(
                     f'Deadline exceeded while downloading response body. '
@@ -353,17 +353,13 @@ class Service:
             if limited is not None:
                 # `continue`, not fall through: a -352 comes back as status 200
                 # with a valid body, which would otherwise be returned as data
-                last_failure = limited.reason
+                note(limited.reason)
                 rate_limited_trials += 1
-                if self.stats is not None:
-                    self.stats.record(target, worker_id, trial, last_failure)
                 continue
 
             # check status code
             if r.status_code != 200:
-                last_failure = f'http_{r.status_code}'
-                if self.stats is not None:
-                    self.stats.record(target, worker_id, trial, last_failure)
+                note(f'http_{r.status_code}')
                 logger.debug(
                     f'Fail to get response with status code {r.status_code}. '
                     f'url: {request_url}, params: {params}, trial: {trial}, duration: {trial_ms}ms'
@@ -379,13 +375,10 @@ class Service:
             if parser is None:
                 try:
                     response = r.json()
-                    if self.stats is not None:
-                        self.stats.record(target, worker_id, trial, 'ok')
+                    note('ok')
                     break
                 except json.JSONDecodeError:
-                    last_failure = 'json_error'
-                    if self.stats is not None:
-                        self.stats.record(target, worker_id, trial, last_failure)
+                    note('json_error')
                     logger.debug(
                         f'Fail to decode response to json. '
                         f'response: {r.text}, url: {request_url}, params: {params}, trial: {trial}'
@@ -394,12 +387,9 @@ class Service:
             else:
                 response = parser(r.text)
                 if response is not None:
-                    if self.stats is not None:
-                        self.stats.record(target, worker_id, trial, 'ok')
+                    note('ok')
                     break
-                last_failure = 'parse_error'
-                if self.stats is not None:
-                    self.stats.record(target, worker_id, trial, last_failure)
+                note('parse_error')
         if response is None:
             if retry > 0 and rate_limited_trials == retry:
                 raise RateLimitError(target, last_failure)

--- a/service/Service.py
+++ b/service/Service.py
@@ -10,7 +10,7 @@ from typing import Optional, Callable, Literal, Union
 from .error import (ResponseError, RateLimitError,
                     FormatError, CodeError)
 from .worker import WorkerConfigurationError, WorkerSelector
-from .apistat import ApiStatTracker, NullApiStat
+from .apistat import ApiStatTracker, NullApiStatTracker
 from .response import \
     VideoViewOwner, VideoViewStat, VideoViewStaffItem, VideoView, VideoViewTrimmed, \
     VideoTag, VideoTags, \
@@ -74,7 +74,7 @@ class Service:
         # by all worker threads" lifetime. Pass an existing tracker to share
         # counters across Services, or stats=False to disable.
         if stats is False:
-            self.stats = NullApiStat()
+            self.stats = NullApiStatTracker()
         elif stats is None:
             self.stats = ApiStatTracker()
         else:

--- a/service/Service.py
+++ b/service/Service.py
@@ -6,10 +6,11 @@ import json
 import time
 import random
 from pathlib import Path
-from typing import Optional, Callable, Literal
+from typing import Optional, Callable, Literal, Union
 from .error import (ResponseError, RateLimitError,
                     FormatError, CodeError)
 from .worker import WorkerConfigurationError, WorkerSelector
+from .apistat import ApiStatTracker
 from .response import \
     VideoViewOwner, VideoViewStat, VideoViewStaffItem, VideoView, VideoViewTrimmed, \
     VideoTag, VideoTags, \
@@ -62,11 +63,25 @@ class Service:
     def __init__(
             self, headers: Optional[dict] = None, retry: int = 3, timeout: float = 5.0, colddown_factor: float = 1.0,
             mode: RequestMode = 'direct', pool_maxsize: int = 256, deadline: float = 10.0,
-            min_throughput_bps: float = 80_000.0, endpoints: Optional[dict] = None
+            min_throughput_bps: float = 80_000.0, endpoints: Optional[dict] = None,
+            stats: Optional[Union[ApiStatTracker, bool]] = None
     ):
         if mode not in ('direct', 'worker'):
             logger.critical(f'Invalid request mode: {mode}.')
             raise SystemExit(1)
+
+        # always-on request/retry/rate-limit observability, keyed on every
+        # attempt this Service makes. Default: one tracker per Service
+        # instance, matching the "one Service shared by all worker threads"
+        # lifetime. Pass an existing ApiStatTracker to share counters across
+        # several Service instances, or `stats=False` to disable (e.g. a
+        # throwaway Service in a test or a one-off script).
+        if stats is False:
+            self.stats: Optional[ApiStatTracker] = None
+        elif stats is None:
+            self.stats = ApiStatTracker()
+        else:
+            self.stats = stats
 
         # set default config
         self._headers = headers if headers is not None else {}
@@ -240,6 +255,7 @@ class Service:
                     logger.critical(f'Invalid worker configuration: {e}')
                     raise SystemExit(1)
                 request_url = selected_worker.url
+            worker_id = selected_worker.id if selected_worker else 'direct'
 
             # colddown for retry
             if trial > 1:
@@ -254,6 +270,8 @@ class Service:
                                       timeout=timeout, stream=True)
             except requests.exceptions.RequestException as e:
                 last_failure = 'request_exception'
+                if self.stats is not None:
+                    self.stats.record(target, worker_id, trial, last_failure)
                 logger.debug(
                     f'Fail to get response. '
                     f'url: {request_url}, params: {params}, trial: {trial}, error: {e}'
@@ -293,6 +311,8 @@ class Service:
             except requests.exceptions.RequestException as e:
                 r.close()
                 last_failure = 'body_exception'
+                if self.stats is not None:
+                    self.stats.record(target, worker_id, trial, last_failure)
                 logger.debug(
                     f'Fail to read response body. '
                     f'url: {request_url}, params: {params}, trial: {trial}, error: {e}'
@@ -301,6 +321,8 @@ class Service:
             if deadline_exceeded:
                 r.close()
                 last_failure = 'deadline_exceeded'
+                if self.stats is not None:
+                    self.stats.record(target, worker_id, trial, last_failure)
                 trial_ms = int((time.perf_counter() - trial_start) * 1000)
                 logger.debug(
                     f'Deadline exceeded while downloading response body. '
@@ -333,11 +355,15 @@ class Service:
                 # with a valid body, which would otherwise be returned as data
                 last_failure = limited.reason
                 rate_limited_trials += 1
+                if self.stats is not None:
+                    self.stats.record(target, worker_id, trial, last_failure)
                 continue
 
             # check status code
             if r.status_code != 200:
                 last_failure = f'http_{r.status_code}'
+                if self.stats is not None:
+                    self.stats.record(target, worker_id, trial, last_failure)
                 logger.debug(
                     f'Fail to get response with status code {r.status_code}. '
                     f'url: {request_url}, params: {params}, trial: {trial}, duration: {trial_ms}ms'
@@ -353,9 +379,13 @@ class Service:
             if parser is None:
                 try:
                     response = r.json()
+                    if self.stats is not None:
+                        self.stats.record(target, worker_id, trial, 'ok')
                     break
                 except json.JSONDecodeError:
                     last_failure = 'json_error'
+                    if self.stats is not None:
+                        self.stats.record(target, worker_id, trial, last_failure)
                     logger.debug(
                         f'Fail to decode response to json. '
                         f'response: {r.text}, url: {request_url}, params: {params}, trial: {trial}'
@@ -364,8 +394,12 @@ class Service:
             else:
                 response = parser(r.text)
                 if response is not None:
+                    if self.stats is not None:
+                        self.stats.record(target, worker_id, trial, 'ok')
                     break
                 last_failure = 'parse_error'
+                if self.stats is not None:
+                    self.stats.record(target, worker_id, trial, last_failure)
         if response is None:
             if retry > 0 and rate_limited_trials == retry:
                 raise RateLimitError(target, last_failure)

--- a/service/__init__.py
+++ b/service/__init__.py
@@ -1,3 +1,4 @@
+from .apistat import *
 from .error import *
 from .response import *
 from .Service import *

--- a/service/apistat.py
+++ b/service/apistat.py
@@ -17,7 +17,7 @@ from typing import Callable, Dict, List, Optional, Tuple
 
 from util import format_ts_s
 
-__all__ = ['ApiStatTracker', 'NullApiStat']
+__all__ = ['ApiStatTracker', 'NullApiStatTracker']
 
 logger = logging.getLogger('apistat')
 
@@ -69,7 +69,7 @@ def _exhausted(trials: Dict[int, Counter]) -> int:
     return total
 
 
-class NullApiStat:
+class NullApiStatTracker:
     """Stand-in so callers never have to test `stats is not None`."""
 
     def record(self, target, worker, trial, outcome, now=None):

--- a/service/apistat.py
+++ b/service/apistat.py
@@ -1,94 +1,75 @@
 """
-Always-on request/retry/rate-limit observability, without ``--debug``.
+Always-on aggregation of the per-attempt outcome `Service._get` already
+classifies, so `p`, retry recovery and the shape of a run are readable
+without --debug (150 MB+ per hourly run in production).
 
-``Service._get()`` already classifies every HTTP attempt into one of a small,
-fixed set of outcomes -- ``'ok'``, a rate-limit reason (``'http_412'``,
-``'code_-352'``, ...), ``'http_<code>'`` for any other non-200, or one of the
-attempts that never produced a parseable response (``'request_exception'``,
-``'body_exception'``, ``'deadline_exceeded'``, ``'json_error'``,
-``'parse_error'``). That classification is otherwise only visible as a DEBUG
-line (150 MB+ per hourly run in production); this module is the always-on,
-DEBUG-independent aggregation of the same classification.
-
-Kept dimensions: ``(target, worker, trial, outcome)``, rolled into fixed
-``window_s``-second windows. Deliberately NOT kept: no ``aid``/``mid`` or any
-other per-request identifier, no User-Agent, no full URLs, query strings,
-headers or bodies. A window's memory and log footprint is therefore bounded
-by the number of distinct ``(target, worker, trial, outcome)`` combinations
-actually seen, never by request volume.
-
-``ApiStatTracker.record()`` is the hot-path call, made once per HTTP attempt
-from every worker thread sharing one ``Service``. It does O(1) dict work under
-one lock and returns immediately; the (at most one) window it closes is
-logged AFTER the lock is released, so log I/O never happens while other
-threads are blocked on the lock. ``finalize()`` closes the last partial
-window and returns the whole-run report: a total table broken down by
-``(target, worker, trial)``, the quantities this module exists to answer
-(first-attempt rejection rate ``p``, retry-recovered count, retry-exhausted
-count) derived directly from those counts, and one ASCII ``p``-over-time
-sparkline per ``(target, worker)`` that saw traffic.
+Dimensions kept: (target, worker, trial, outcome), in fixed-length windows.
+Deliberately not kept: aid/mid or any per-request identifier, User-Agent,
+URLs, query strings, headers, bodies. Memory and log size are bounded by the
+number of distinct combinations seen, never by request volume.
 """
 
 import logging
 import threading
 import time
 from collections import Counter
-from dataclasses import dataclass
 from typing import Callable, Dict, List, Optional, Tuple
 
 from util import format_ts_s
 
-__all__ = ['ApiStatTracker', 'WindowSnapshot']
+__all__ = ['ApiStatTracker', 'NullApiStat']
 
 logger = logging.getLogger('apistat')
 
 DEFAULT_WINDOW_S = 5.0
-
-# (target, worker, trial, outcome) -> count
-Key = Tuple[str, str, int, str]
-
 OK = 'ok'
 
-# eight shading levels (no blank level -- a real zero still gets a visible
-# glyph, so it can never be confused with the separate "no data" gap glyph or
-# with plain whitespace) is enough resolution to tell free / climbing /
-# plateau apart by eye, and stays one character per window so a
-# several-hundred-window run still fits on one terminal-friendly line.
-_SPARK_TICKS = '▁▂▃▄▅▆▇█'
+# fixed 0..1 scale, not autoscaled: two runs are only comparable if the
+# vertical scale means the same thing in both
+_TICKS = '▁▂▃▄▅▆▇█'
 _GAP = '·'
 
 
 def _sparkline(fractions: List[Optional[float]]) -> str:
-    """
-    Render a 0..1 fraction series as one glyph per point, oldest first;
-    ``None`` (no trial-1 attempts that window) renders as the gap glyph.
-    Deliberately a FIXED 0..1 scale (a rejection rate), unlike a min..max
-    autoscaled sparkline -- two windows, or two runs, are only comparable to
-    each other if the vertical scale means the same thing in both.
-    """
     out = []
     for value in fractions:
         if value is None:
             out.append(_GAP)
-            continue
-        value = min(1.0, max(0.0, value))
-        out.append(_SPARK_TICKS[int(round(value * (len(_SPARK_TICKS) - 1)))])
+        else:
+            value = min(1.0, max(0.0, value))
+            out.append(_TICKS[int(round(value * (len(_TICKS) - 1)))])
     return ''.join(out)
 
 
-@dataclass
-class WindowSnapshot:
-    index: int
-    start_ts: float
-    end_ts: float
-    counts: Dict[Key, int]
+def _derive(trials: Dict[int, Counter]) -> dict:
+    """p (first-attempt rejection rate) and how many calls a retry saved."""
+    trial1 = trials.get(1, Counter())
+    n1 = sum(trial1.values())
+    ok1 = trial1.get(OK, 0)
+    return {
+        'p': (n1 - ok1) / n1 if n1 else None,
+        'n1': n1,
+        'retry_recovered': sum(c.get(OK, 0) for t, c in trials.items() if t != 1),
+    }
+
+
+class NullApiStat:
+    """Stand-in so callers never have to test `stats is not None`."""
+
+    def record(self, target, worker, trial, outcome, now=None):
+        pass
+
+    def totals(self) -> List[dict]:
+        return []
+
+    def log_summary(self, log=None) -> None:
+        pass
 
 
 class ApiStatTracker:
     """
-    Thread-safe. One instance is meant to live as long as one ``Service`` --
-    i.e. for the whole run of a script, shared by every worker thread that
-    Service serves (see ``Service``'s own docstring on sharing one instance).
+    Thread-safe; one instance lives as long as the Service that owns it and is
+    shared by every thread that Service serves.
     """
 
     def __init__(self, window_s: float = DEFAULT_WINDOW_S,
@@ -97,202 +78,120 @@ class ApiStatTracker:
         self._clock = clock
         self._lock = threading.Lock()
         self._run_start = clock()
-        self._current_index = 0
-        self._window_counts: Counter = Counter()
+        self._index = 0
+        self._window: Counter = Counter()
         self._totals: Counter = Counter()
-        self._history: List[WindowSnapshot] = []
+        # (window index) -> {(target, worker): [trial-1 attempts, trial-1 ok]}
+        self._series: List[Tuple[int, Dict[Tuple[str, str], List[int]]]] = []
 
     def record(self, target: str, worker: str, trial: int, outcome: str,
                now: Optional[float] = None) -> None:
-        """
-        Count one HTTP attempt. Called once per attempt (i.e. once per
-        `Service._get` loop iteration, not once per logical call) -- a
-        retried call therefore contributes one row per trial, which is what
-        makes retry-recovery and retry-exhaustion derivable at all (see
-        ``derive``).
-        """
+        """One HTTP attempt. Called once per `_get` loop iteration, not once
+        per logical call -- that is what makes retry recovery derivable."""
         now = self._clock() if now is None else now
         closed = None
         with self._lock:
-            idx = int((now - self._run_start) // self._window_s)
-            if idx != self._current_index:
-                if self._window_counts:
-                    closed = self._close_window_locked(self._current_index)
-                self._current_index = idx
-            self._window_counts[(target, worker, trial, outcome)] += 1
+            index = int((now - self._run_start) // self._window_s)
+            if index != self._index:
+                if self._window:
+                    closed = self._close_locked()
+                self._index = index
+            self._window[(target, worker, trial, outcome)] += 1
             self._totals[(target, worker, trial, outcome)] += 1
-        # logging (and thus any I/O) happens with the lock already released,
-        # so a slow log handler never blocks other threads' record() calls
+        # logged outside the lock: a slow handler must not block record()
         if closed is not None:
-            self._log_window(closed)
+            self._log_window(*closed)
 
-    def _close_window_locked(self, index: int) -> WindowSnapshot:
-        counts = dict(self._window_counts)
-        self._window_counts = Counter()
-        snapshot = WindowSnapshot(
-            index=index,
-            start_ts=self._run_start + index * self._window_s,
-            end_ts=self._run_start + (index + 1) * self._window_s,
-            counts=counts)
-        self._history.append(snapshot)
-        return snapshot
+    def totals(self) -> List[dict]:
+        """Run totals as run-record metric rows, one per combination seen."""
+        with self._lock:
+            counts = dict(self._totals)
+        return [{'scope': f'api:{target}:{worker}',
+                 'name': f't{trial}:{outcome}',
+                 'value': float(value)}
+                for (target, worker, trial, outcome), value in counts.items()]
 
-    def _log_window(self, snapshot: WindowSnapshot) -> None:
+    def log_summary(self, log: Optional[logging.Logger] = None) -> None:
+        """Close the last window and emit the end-of-run report."""
+        with self._lock:
+            closed = self._close_locked() if self._window else None
+        if closed is not None:
+            self._log_window(*closed)
+        for line in self._report():
+            (log or logger).info(line)
+
+    def _close_locked(self) -> Tuple[int, Dict[Tuple[str, str, int, str], int]]:
+        counts = dict(self._window)
+        self._window = Counter()
+        trial1: Dict[Tuple[str, str], List[int]] = {}
+        for (target, worker, trial, outcome), n in counts.items():
+            if trial != 1:
+                continue
+            slot = trial1.setdefault((target, worker), [0, 0])
+            slot[0] += n
+            if outcome == OK:
+                slot[1] += n
+        self._series.append((self._index, trial1))
+        return self._index, counts
+
+    def _log_window(self, index: int, counts: Dict[Tuple[str, str, int, str], int]) -> None:
         by_target: Dict[str, Counter] = {}
-        for (target, _worker, _trial, outcome), n in snapshot.counts.items():
+        for (target, _w, _t, outcome), n in counts.items():
             by_target.setdefault(target, Counter())[outcome] += n
-        elapsed_s = int(snapshot.start_ts - self._run_start)
         parts = []
         for target in sorted(by_target):
             outcomes = by_target[target]
-            n = sum(outcomes.values())
-            ok = outcomes.get(OK, 0)
-            rejected = ' '.join(f'{k}={v}' for k, v in sorted(outcomes.items())
-                                if k != OK)
-            parts.append(f'{target}: n={n} ok={ok}' + (f' {rejected}' if rejected else ''))
-        logger.info(
-            f'API stat window #{snapshot.index} (t+{format_ts_s(elapsed_s)}, '
-            f'{self._window_s:.0f}s): ' + '; '.join(parts))
+            rejected = ' '.join(f'{k}={v}' for k, v in sorted(outcomes.items()) if k != OK)
+            parts.append(f'{target}: n={sum(outcomes.values())} ok={outcomes.get(OK, 0)}'
+                         + (f' {rejected}' if rejected else ''))
+        elapsed = int(index * self._window_s)
+        logger.info(f'API stat window #{index} (t+{format_ts_s(elapsed)}, '
+                    f'{self._window_s:.0f}s): ' + '; '.join(parts))
 
-    def _totals_snapshot(self) -> Dict[Key, int]:
+    def _report(self) -> List[str]:
         with self._lock:
-            return dict(self._totals)
-
-    def totals(self) -> List[dict]:
-        """
-        The run's total counts as ``[{'scope', 'name', 'value'}, ...]``, ready
-        for ``RunRecorder.add_api_stat_metrics`` -- one row per
-        ``(target, worker, trial, outcome)`` combination actually seen.
-        Includes every attempt recorded so far, whether or not the window it
-        happened in has been closed by ``finalize()`` yet.
-        """
-        rows = []
-        for (target, worker, trial, outcome), value in self._totals_snapshot().items():
-            rows.append({
-                'scope': f'api:{target}:{worker}',
-                'name': f't{trial}:{outcome}',
-                'value': float(value),
-            })
-        return rows
-
-    def grouped_totals(self) -> Dict[Tuple[str, str], Dict[int, Counter]]:
-        """``{(target, worker): {trial: Counter(outcome -> count)}}``."""
+            counts = dict(self._totals)
+            series = list(self._series)
         grouped: Dict[Tuple[str, str], Dict[int, Counter]] = {}
-        for (target, worker, trial, outcome), n in self._totals_snapshot().items():
+        for (target, worker, trial, outcome), n in counts.items():
             grouped.setdefault((target, worker), {}).setdefault(trial, Counter())[outcome] += n
-        return grouped
 
-    @staticmethod
-    def derive(trials: Dict[int, Counter]) -> dict:
-        """
-        The quantities this module exists to answer, computed directly from
-        per-trial outcome counts -- no field this depends on is estimated:
-
-        - ``p``: first-attempt rejection rate (non-``ok`` share of trial 1).
-        - ``retry_recovered``: calls that failed trial 1 but eventually
-          returned ``ok`` on a later trial.
-        - ``exhausted``: calls that were still failing on the LAST trial any
-          call in this group reached -- i.e. what ``Service._get`` raises
-          ``RateLimitError``/``ResponseError`` for. Assumes ``retry`` was
-          constant across the calls being summarised, which holds for one
-          script run (``retry`` is a per-Service-call config, not randomised).
-        """
-        trial1 = trials.get(1, Counter())
-        n1 = sum(trial1.values())
-        ok1 = trial1.get(OK, 0)
-        p = (n1 - ok1) / n1 if n1 else None
-        retry_recovered = sum(counts.get(OK, 0) for t, counts in trials.items() if t != 1)
-        max_trial = max(trials) if trials else None
-        exhausted = None
-        if max_trial is not None:
-            last = trials[max_trial]
-            exhausted = sum(v for k, v in last.items() if k != OK)
-        return {'p': p, 'n1': n1, 'retry_recovered': retry_recovered,
-                'exhausted': exhausted, 'max_trial': max_trial}
-
-    def summary_lines(self) -> List[str]:
-        """The end-of-run total table: per (target, worker), per trial, per outcome."""
-        grouped = self.grouped_totals()
         lines = [f'## api stat summary (window={self._window_s:.0f}s, '
-                 f'windows closed={len(self._history)})']
+                 f'windows={len(series)})']
         if not grouped:
-            lines.append('(no requests recorded)')
-            return lines
+            return lines + ['(no requests recorded)']
         for target, worker in sorted(grouped):
             trials = grouped[(target, worker)]
             lines.append(f'- {target} / {worker}')
             for trial in sorted(trials):
                 outcomes = trials[trial]
-                n = sum(outcomes.values())
                 detail = ' '.join(f'{k}={v}' for k, v in sorted(outcomes.items()))
-                lines.append(f'  - trial {trial}: n={n}, {detail}')
-            d = self.derive(trials)
-            p_str = f'{d["p"] * 100:.2f}%' if d['p'] is not None else 'n/a'
-            lines.append(
-                f'  - derived: p={p_str} (n={d["n1"]}), '
-                f'retry_recovered={d["retry_recovered"]}, '
-                f'exhausted(trial {d["max_trial"]})={d["exhausted"]}')
+                lines.append(f'  - trial {trial}: n={sum(outcomes.values())}, {detail}')
+            d = _derive(trials)
+            p = f'{d["p"] * 100:.2f}%' if d['p'] is not None else 'n/a'
+            lines.append(f'  - derived: p={p} (n={d["n1"]}), '
+                         f'retry_recovered={d["retry_recovered"]}')
+
+        spark = self._sparklines(series)
+        if spark:
+            lines.append('- p over time, oldest -> newest window:')
+            lines.extend(spark)
         return lines
 
-    def p_sparklines(self) -> List[str]:
-        """
-        One ``'<target> / <worker>: <sparkline>'`` line per (target, worker)
-        that had trial-1 traffic, oldest -> newest closed window, gaps where a
-        window had none. Empty if no window has closed yet.
-        """
-        if not self._history:
+    def _sparklines(self, series) -> List[str]:
+        if not series:
             return []
-        per_key: Dict[Tuple[str, str], Dict[int, Tuple[int, int]]] = {}
-        for snapshot in self._history:
-            for (target, worker, trial, outcome), n in snapshot.counts.items():
-                if trial != 1:
-                    continue
-                series = per_key.setdefault((target, worker), {})
-                n1, ok1 = series.get(snapshot.index, (0, 0))
-                n1 += n
-                if outcome == OK:
-                    ok1 += n
-                series[snapshot.index] = (n1, ok1)
-        first_index = self._history[0].index
-        last_index = self._history[-1].index
+        per_key: Dict[Tuple[str, str], Dict[int, List[int]]] = {}
+        for index, trial1 in series:
+            for key, (n1, ok1) in trial1.items():
+                per_key.setdefault(key, {})[index] = [n1, ok1]
         lines = []
+        first, last = series[0][0], series[-1][0]
         for target, worker in sorted(per_key):
-            series = per_key[(target, worker)]
+            points = per_key[(target, worker)]
             fractions = []
-            for idx in range(first_index, last_index + 1):
-                if idx not in series:
-                    fractions.append(None)
-                else:
-                    n1, ok1 = series[idx]
-                    fractions.append(None if n1 == 0 else (n1 - ok1) / n1)
+            for index in range(first, last + 1):
+                n1, ok1 = points.get(index, (0, 0))
+                fractions.append(None if not n1 else (n1 - ok1) / n1)
             lines.append(f'  {target} / {worker}: {_sparkline(fractions)}')
         return lines
-
-    def finalize(self) -> List[str]:
-        """
-        Close the last partial window (if one has any counts) and return the
-        full end-of-run report as a list of log lines. Safe to call more than
-        once -- the second call sees an already-empty partial window and
-        simply re-renders the same totals.
-        """
-        with self._lock:
-            pending = dict(self._window_counts) if self._window_counts else None
-            if pending is not None:
-                snapshot = self._close_window_locked(self._current_index)
-            else:
-                snapshot = None
-        if snapshot is not None:
-            self._log_window(snapshot)
-        lines = self.summary_lines()
-        sparklines = self.p_sparklines()
-        if sparklines:
-            lines.append('- p over time (free window -> climb -> plateau should '
-                         'be visible left to right), oldest -> newest window:')
-            lines.extend(sparklines)
-        return lines
-
-    def log_summary(self, log: Optional[logging.Logger] = None) -> None:
-        """Call ``finalize()`` and emit every line as one INFO record each."""
-        target_logger = log if log is not None else logger
-        for line in self.finalize():
-            target_logger.info(line)

--- a/service/apistat.py
+++ b/service/apistat.py
@@ -1,0 +1,298 @@
+"""
+Always-on request/retry/rate-limit observability, without ``--debug``.
+
+``Service._get()`` already classifies every HTTP attempt into one of a small,
+fixed set of outcomes -- ``'ok'``, a rate-limit reason (``'http_412'``,
+``'code_-352'``, ...), ``'http_<code>'`` for any other non-200, or one of the
+attempts that never produced a parseable response (``'request_exception'``,
+``'body_exception'``, ``'deadline_exceeded'``, ``'json_error'``,
+``'parse_error'``). That classification is otherwise only visible as a DEBUG
+line (150 MB+ per hourly run in production); this module is the always-on,
+DEBUG-independent aggregation of the same classification.
+
+Kept dimensions: ``(target, worker, trial, outcome)``, rolled into fixed
+``window_s``-second windows. Deliberately NOT kept: no ``aid``/``mid`` or any
+other per-request identifier, no User-Agent, no full URLs, query strings,
+headers or bodies. A window's memory and log footprint is therefore bounded
+by the number of distinct ``(target, worker, trial, outcome)`` combinations
+actually seen, never by request volume.
+
+``ApiStatTracker.record()`` is the hot-path call, made once per HTTP attempt
+from every worker thread sharing one ``Service``. It does O(1) dict work under
+one lock and returns immediately; the (at most one) window it closes is
+logged AFTER the lock is released, so log I/O never happens while other
+threads are blocked on the lock. ``finalize()`` closes the last partial
+window and returns the whole-run report: a total table broken down by
+``(target, worker, trial)``, the quantities this module exists to answer
+(first-attempt rejection rate ``p``, retry-recovered count, retry-exhausted
+count) derived directly from those counts, and one ASCII ``p``-over-time
+sparkline per ``(target, worker)`` that saw traffic.
+"""
+
+import logging
+import threading
+import time
+from collections import Counter
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional, Tuple
+
+from util import format_ts_s
+
+__all__ = ['ApiStatTracker', 'WindowSnapshot']
+
+logger = logging.getLogger('apistat')
+
+DEFAULT_WINDOW_S = 5.0
+
+# (target, worker, trial, outcome) -> count
+Key = Tuple[str, str, int, str]
+
+OK = 'ok'
+
+# eight shading levels (no blank level -- a real zero still gets a visible
+# glyph, so it can never be confused with the separate "no data" gap glyph or
+# with plain whitespace) is enough resolution to tell free / climbing /
+# plateau apart by eye, and stays one character per window so a
+# several-hundred-window run still fits on one terminal-friendly line.
+_SPARK_TICKS = '▁▂▃▄▅▆▇█'
+_GAP = '·'
+
+
+def _sparkline(fractions: List[Optional[float]]) -> str:
+    """
+    Render a 0..1 fraction series as one glyph per point, oldest first;
+    ``None`` (no trial-1 attempts that window) renders as the gap glyph.
+    Deliberately a FIXED 0..1 scale (a rejection rate), unlike a min..max
+    autoscaled sparkline -- two windows, or two runs, are only comparable to
+    each other if the vertical scale means the same thing in both.
+    """
+    out = []
+    for value in fractions:
+        if value is None:
+            out.append(_GAP)
+            continue
+        value = min(1.0, max(0.0, value))
+        out.append(_SPARK_TICKS[int(round(value * (len(_SPARK_TICKS) - 1)))])
+    return ''.join(out)
+
+
+@dataclass
+class WindowSnapshot:
+    index: int
+    start_ts: float
+    end_ts: float
+    counts: Dict[Key, int]
+
+
+class ApiStatTracker:
+    """
+    Thread-safe. One instance is meant to live as long as one ``Service`` --
+    i.e. for the whole run of a script, shared by every worker thread that
+    Service serves (see ``Service``'s own docstring on sharing one instance).
+    """
+
+    def __init__(self, window_s: float = DEFAULT_WINDOW_S,
+                 clock: Callable[[], float] = time.monotonic):
+        self._window_s = window_s
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._run_start = clock()
+        self._current_index = 0
+        self._window_counts: Counter = Counter()
+        self._totals: Counter = Counter()
+        self._history: List[WindowSnapshot] = []
+
+    def record(self, target: str, worker: str, trial: int, outcome: str,
+               now: Optional[float] = None) -> None:
+        """
+        Count one HTTP attempt. Called once per attempt (i.e. once per
+        `Service._get` loop iteration, not once per logical call) -- a
+        retried call therefore contributes one row per trial, which is what
+        makes retry-recovery and retry-exhaustion derivable at all (see
+        ``derive``).
+        """
+        now = self._clock() if now is None else now
+        closed = None
+        with self._lock:
+            idx = int((now - self._run_start) // self._window_s)
+            if idx != self._current_index:
+                if self._window_counts:
+                    closed = self._close_window_locked(self._current_index)
+                self._current_index = idx
+            self._window_counts[(target, worker, trial, outcome)] += 1
+            self._totals[(target, worker, trial, outcome)] += 1
+        # logging (and thus any I/O) happens with the lock already released,
+        # so a slow log handler never blocks other threads' record() calls
+        if closed is not None:
+            self._log_window(closed)
+
+    def _close_window_locked(self, index: int) -> WindowSnapshot:
+        counts = dict(self._window_counts)
+        self._window_counts = Counter()
+        snapshot = WindowSnapshot(
+            index=index,
+            start_ts=self._run_start + index * self._window_s,
+            end_ts=self._run_start + (index + 1) * self._window_s,
+            counts=counts)
+        self._history.append(snapshot)
+        return snapshot
+
+    def _log_window(self, snapshot: WindowSnapshot) -> None:
+        by_target: Dict[str, Counter] = {}
+        for (target, _worker, _trial, outcome), n in snapshot.counts.items():
+            by_target.setdefault(target, Counter())[outcome] += n
+        elapsed_s = int(snapshot.start_ts - self._run_start)
+        parts = []
+        for target in sorted(by_target):
+            outcomes = by_target[target]
+            n = sum(outcomes.values())
+            ok = outcomes.get(OK, 0)
+            rejected = ' '.join(f'{k}={v}' for k, v in sorted(outcomes.items())
+                                if k != OK)
+            parts.append(f'{target}: n={n} ok={ok}' + (f' {rejected}' if rejected else ''))
+        logger.info(
+            f'API stat window #{snapshot.index} (t+{format_ts_s(elapsed_s)}, '
+            f'{self._window_s:.0f}s): ' + '; '.join(parts))
+
+    def _totals_snapshot(self) -> Dict[Key, int]:
+        with self._lock:
+            return dict(self._totals)
+
+    def totals(self) -> List[dict]:
+        """
+        The run's total counts as ``[{'scope', 'name', 'value'}, ...]``, ready
+        for ``RunRecorder.add_api_stat_metrics`` -- one row per
+        ``(target, worker, trial, outcome)`` combination actually seen.
+        Includes every attempt recorded so far, whether or not the window it
+        happened in has been closed by ``finalize()`` yet.
+        """
+        rows = []
+        for (target, worker, trial, outcome), value in self._totals_snapshot().items():
+            rows.append({
+                'scope': f'api:{target}:{worker}',
+                'name': f't{trial}:{outcome}',
+                'value': float(value),
+            })
+        return rows
+
+    def grouped_totals(self) -> Dict[Tuple[str, str], Dict[int, Counter]]:
+        """``{(target, worker): {trial: Counter(outcome -> count)}}``."""
+        grouped: Dict[Tuple[str, str], Dict[int, Counter]] = {}
+        for (target, worker, trial, outcome), n in self._totals_snapshot().items():
+            grouped.setdefault((target, worker), {}).setdefault(trial, Counter())[outcome] += n
+        return grouped
+
+    @staticmethod
+    def derive(trials: Dict[int, Counter]) -> dict:
+        """
+        The quantities this module exists to answer, computed directly from
+        per-trial outcome counts -- no field this depends on is estimated:
+
+        - ``p``: first-attempt rejection rate (non-``ok`` share of trial 1).
+        - ``retry_recovered``: calls that failed trial 1 but eventually
+          returned ``ok`` on a later trial.
+        - ``exhausted``: calls that were still failing on the LAST trial any
+          call in this group reached -- i.e. what ``Service._get`` raises
+          ``RateLimitError``/``ResponseError`` for. Assumes ``retry`` was
+          constant across the calls being summarised, which holds for one
+          script run (``retry`` is a per-Service-call config, not randomised).
+        """
+        trial1 = trials.get(1, Counter())
+        n1 = sum(trial1.values())
+        ok1 = trial1.get(OK, 0)
+        p = (n1 - ok1) / n1 if n1 else None
+        retry_recovered = sum(counts.get(OK, 0) for t, counts in trials.items() if t != 1)
+        max_trial = max(trials) if trials else None
+        exhausted = None
+        if max_trial is not None:
+            last = trials[max_trial]
+            exhausted = sum(v for k, v in last.items() if k != OK)
+        return {'p': p, 'n1': n1, 'retry_recovered': retry_recovered,
+                'exhausted': exhausted, 'max_trial': max_trial}
+
+    def summary_lines(self) -> List[str]:
+        """The end-of-run total table: per (target, worker), per trial, per outcome."""
+        grouped = self.grouped_totals()
+        lines = [f'## api stat summary (window={self._window_s:.0f}s, '
+                 f'windows closed={len(self._history)})']
+        if not grouped:
+            lines.append('(no requests recorded)')
+            return lines
+        for target, worker in sorted(grouped):
+            trials = grouped[(target, worker)]
+            lines.append(f'- {target} / {worker}')
+            for trial in sorted(trials):
+                outcomes = trials[trial]
+                n = sum(outcomes.values())
+                detail = ' '.join(f'{k}={v}' for k, v in sorted(outcomes.items()))
+                lines.append(f'  - trial {trial}: n={n}, {detail}')
+            d = self.derive(trials)
+            p_str = f'{d["p"] * 100:.2f}%' if d['p'] is not None else 'n/a'
+            lines.append(
+                f'  - derived: p={p_str} (n={d["n1"]}), '
+                f'retry_recovered={d["retry_recovered"]}, '
+                f'exhausted(trial {d["max_trial"]})={d["exhausted"]}')
+        return lines
+
+    def p_sparklines(self) -> List[str]:
+        """
+        One ``'<target> / <worker>: <sparkline>'`` line per (target, worker)
+        that had trial-1 traffic, oldest -> newest closed window, gaps where a
+        window had none. Empty if no window has closed yet.
+        """
+        if not self._history:
+            return []
+        per_key: Dict[Tuple[str, str], Dict[int, Tuple[int, int]]] = {}
+        for snapshot in self._history:
+            for (target, worker, trial, outcome), n in snapshot.counts.items():
+                if trial != 1:
+                    continue
+                series = per_key.setdefault((target, worker), {})
+                n1, ok1 = series.get(snapshot.index, (0, 0))
+                n1 += n
+                if outcome == OK:
+                    ok1 += n
+                series[snapshot.index] = (n1, ok1)
+        first_index = self._history[0].index
+        last_index = self._history[-1].index
+        lines = []
+        for target, worker in sorted(per_key):
+            series = per_key[(target, worker)]
+            fractions = []
+            for idx in range(first_index, last_index + 1):
+                if idx not in series:
+                    fractions.append(None)
+                else:
+                    n1, ok1 = series[idx]
+                    fractions.append(None if n1 == 0 else (n1 - ok1) / n1)
+            lines.append(f'  {target} / {worker}: {_sparkline(fractions)}')
+        return lines
+
+    def finalize(self) -> List[str]:
+        """
+        Close the last partial window (if one has any counts) and return the
+        full end-of-run report as a list of log lines. Safe to call more than
+        once -- the second call sees an already-empty partial window and
+        simply re-renders the same totals.
+        """
+        with self._lock:
+            pending = dict(self._window_counts) if self._window_counts else None
+            if pending is not None:
+                snapshot = self._close_window_locked(self._current_index)
+            else:
+                snapshot = None
+        if snapshot is not None:
+            self._log_window(snapshot)
+        lines = self.summary_lines()
+        sparklines = self.p_sparklines()
+        if sparklines:
+            lines.append('- p over time (free window -> climb -> plateau should '
+                         'be visible left to right), oldest -> newest window:')
+            lines.extend(sparklines)
+        return lines
+
+    def log_summary(self, log: Optional[logging.Logger] = None) -> None:
+        """Call ``finalize()`` and emit every line as one INFO record each."""
+        target_logger = log if log is not None else logger
+        for line in self.finalize():
+            target_logger.info(line)

--- a/service/apistat.py
+++ b/service/apistat.py
@@ -53,6 +53,22 @@ def _derive(trials: Dict[int, Counter]) -> dict:
     }
 
 
+def _exhausted(trials: Dict[int, Counter]) -> int:
+    """
+    How many calls ran out of retries, from the counts alone. Every call that
+    fails trial N either makes a trial N+1 attempt or gives up, so
+    `failures(N) - attempts(N+1)` is the number that gave up at N. That holds
+    whatever `retry` each call was given, unlike reading the last trial's
+    failures. Only valid per target: a retry may pick a different worker, so
+    the chain does not hold within one worker's counts.
+    """
+    total = 0
+    for trial, outcomes in trials.items():
+        failures = sum(v for k, v in outcomes.items() if k != OK)
+        total += failures - sum(trials.get(trial + 1, Counter()).values())
+    return total
+
+
 class NullApiStat:
     """Stand-in so callers never have to test `stats is not None`."""
 
@@ -171,6 +187,19 @@ class ApiStatTracker:
             p = f'{d["p"] * 100:.2f}%' if d['p'] is not None else 'n/a'
             lines.append(f'  - derived: p={p} (n={d["n1"]}), '
                          f'retry_recovered={d["retry_recovered"]}')
+
+        by_target: Dict[str, Dict[int, Counter]] = {}
+        for (target, _worker), trials in grouped.items():
+            per_trial = by_target.setdefault(target, {})
+            for trial, outcomes in trials.items():
+                per_trial.setdefault(trial, Counter()).update(outcomes)
+        for target in sorted(by_target):
+            trials = by_target[target]
+            d = _derive(trials)
+            p = f'{d["p"] * 100:.2f}%' if d['p'] is not None else 'n/a'
+            lines.append(f'- {target} (all workers): p={p} (n={d["n1"]}), '
+                         f'retry_recovered={d["retry_recovered"]}, '
+                         f'exhausted={_exhausted(trials)}')
 
         spark = self._sparklines(series)
         if spark:

--- a/tests/test_api_stat.py
+++ b/tests/test_api_stat.py
@@ -1,0 +1,338 @@
+"""
+Tests for ``service.apistat.ApiStatTracker``: the always-on,
+--debug-independent request/retry/rate-limit observability layer.
+
+Run from the repo root:
+
+    python -m unittest discover -s tests
+"""
+
+import inspect
+import logging
+import os
+import sys
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from service.apistat import ApiStatTracker  # noqa: E402
+
+
+class FakeClock:
+    """A settable clock, like ``test_worker_selector.FakeClock`` -- deterministic
+    window boundaries without sleeping in real time."""
+
+    def __init__(self, start=1000.0):
+        self.now = start
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+class ApiSurfaceTest(unittest.TestCase):
+    """
+    Locks the shape of the hot-path API: a future change that starts passing
+    aid/mid, a URL, or anything else high-cardinality must touch this test.
+    """
+
+    def test_record_accepts_only_low_cardinality_dimensions(self):
+        params = list(inspect.signature(ApiStatTracker.record).parameters)
+        self.assertEqual(params, ['self', 'target', 'worker', 'trial', 'outcome', 'now'])
+
+
+class OutcomeVisibilityTest(unittest.TestCase):
+    """AC1: every outcome _get can produce stays individually visible, not
+    just HTTP 412 -- including member_card's code_-352 and every timeout kind."""
+
+    def test_every_known_outcome_kind_is_kept_distinct(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(clock=clock)
+        outcomes = ['ok', 'http_412', 'code_-352', 'http_500',
+                    'request_exception', 'body_exception', 'deadline_exceeded',
+                    'json_error', 'parse_error']
+        for outcome in outcomes:
+            tracker.record('get_video_view_trimmed', 'w1', 1, outcome)
+
+        rows = {(r['scope'], r['name']): r['value'] for r in tracker.totals()}
+        for outcome in outcomes:
+            self.assertEqual(
+                rows[('api:get_video_view_trimmed:w1', f't1:{outcome}')], 1.0,
+                f'{outcome} was not recorded distinctly')
+
+    def test_member_card_and_video_view_do_not_share_counters(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(clock=clock)
+        tracker.record('get_member_card', 'card-1', 1, 'code_-352')
+        tracker.record('get_video_view_trimmed', 'view-1', 1, 'http_412')
+
+        rows = {(r['scope'], r['name']): r['value'] for r in tracker.totals()}
+        self.assertEqual(rows[('api:get_member_card:card-1', 't1:code_-352')], 1.0)
+        self.assertEqual(rows[('api:get_video_view_trimmed:view-1', 't1:http_412')], 1.0)
+        self.assertNotIn(('api:get_member_card:card-1', 't1:http_412'), rows)
+
+
+class DerivedQuantitiesTest(unittest.TestCase):
+    """AC2: p, retry-recovered and retry-exhausted counts must be directly
+    verifiable from the recorded per-trial counts, without --debug."""
+
+    def test_no_retry_needed(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(clock=clock)
+        for _ in range(97):
+            tracker.record('t', 'w', 1, 'ok')
+        for _ in range(3):
+            tracker.record('t', 'w', 1, 'http_412')
+
+        trials = tracker.grouped_totals()[('t', 'w')]
+        derived = ApiStatTracker.derive(trials)
+        self.assertAlmostEqual(derived['p'], 0.03)
+        self.assertEqual(derived['n1'], 100)
+        self.assertEqual(derived['retry_recovered'], 0)
+        self.assertEqual(derived['max_trial'], 1)
+        self.assertEqual(derived['exhausted'], 3)  # trial 1 IS the last trial here
+
+    def test_retry_recovers_most_of_the_rejected_trial(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(clock=clock)
+        for _ in range(90):
+            tracker.record('t', 'w', 1, 'ok')
+        for _ in range(10):
+            tracker.record('t', 'w', 1, 'http_412')
+        # 9 of the 10 that failed trial 1 succeed on trial 2
+        for _ in range(9):
+            tracker.record('t', 'w', 2, 'ok')
+        tracker.record('t', 'w', 2, 'http_412')
+
+        trials = tracker.grouped_totals()[('t', 'w')]
+        derived = ApiStatTracker.derive(trials)
+        self.assertAlmostEqual(derived['p'], 0.10)
+        self.assertEqual(derived['retry_recovered'], 9)
+        self.assertEqual(derived['max_trial'], 2)
+        self.assertEqual(derived['exhausted'], 1)
+
+    def test_retry_exhausted_after_the_configured_retry_budget(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(clock=clock)
+        # one call, rejected on all 3 trials (retry=3) -> RateLimitError in Service
+        for trial in (1, 2, 3):
+            tracker.record('t', 'w', trial, 'http_412')
+
+        trials = tracker.grouped_totals()[('t', 'w')]
+        derived = ApiStatTracker.derive(trials)
+        self.assertEqual(derived['p'], 1.0)
+        self.assertEqual(derived['retry_recovered'], 0)
+        self.assertEqual(derived['max_trial'], 3)
+        self.assertEqual(derived['exhausted'], 1)
+
+    def test_no_traffic_derives_to_none_not_a_crash(self):
+        derived = ApiStatTracker.derive({})
+        self.assertIsNone(derived['p'])
+        self.assertIsNone(derived['max_trial'])
+        self.assertIsNone(derived['exhausted'])
+        self.assertEqual(derived['n1'], 0)
+        self.assertEqual(derived['retry_recovered'], 0)
+
+
+class WindowingTest(unittest.TestCase):
+    """AC3 + AC8: one INFO line per closed 5s window, containing only that
+    window's counts, plus correct accumulation across window boundaries."""
+
+    def test_no_window_is_logged_before_five_seconds_pass(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+        with mock.patch('service.apistat.logger') as mock_logger:
+            for _ in range(3):
+                clock.advance(1.0)
+                tracker.record('t', 'w', 1, 'ok')
+            mock_logger.info.assert_not_called()
+
+    def test_crossing_the_boundary_logs_exactly_that_windows_counts(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+        with self.assertLogs('apistat', level=logging.INFO) as ctx:
+            tracker.record('t', 'w', 1, 'ok', now=clock.now)
+            tracker.record('t', 'w', 1, 'http_412', now=clock.now)
+            clock.advance(5.1)
+            # this call belongs to window 1 and must trigger window 0's flush
+            tracker.record('t', 'w', 1, 'ok', now=clock.now)
+
+        window_lines = [line for line in ctx.output if 'API stat window #0' in line]
+        self.assertEqual(len(window_lines), 1)
+        self.assertIn('n=2', window_lines[0])
+        self.assertIn('ok=1', window_lines[0])
+        self.assertIn('http_412=1', window_lines[0])
+        # the record that opened window 1 must not be in window 0's line
+        self.assertNotIn('n=3', window_lines[0])
+
+    def test_totals_accumulate_across_window_boundaries(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+        tracker.record('t', 'w', 1, 'ok', now=clock.now)
+        clock.advance(5.1)
+        tracker.record('t', 'w', 1, 'ok', now=clock.now)
+        clock.advance(5.1)
+        tracker.record('t', 'w', 1, 'ok', now=clock.now)
+
+        rows = {(r['scope'], r['name']): r['value'] for r in tracker.totals()}
+        self.assertEqual(rows[('api:t:w', 't1:ok')], 3.0)
+
+    def test_a_silent_gap_does_not_fabricate_empty_windows(self):
+        # traffic in window 0, nothing at all in window 1, traffic resumes in
+        # window 2 -- only windows that actually saw a request are recorded
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+        tracker.record('t', 'w', 1, 'ok', now=clock.now)
+        clock.advance(11.0)  # skips straight into window 2
+        tracker.record('t', 'w', 1, 'ok', now=clock.now)
+        tracker.finalize()
+
+        indices = [snap.index for snap in tracker._history]
+        self.assertEqual(indices, [0, 2])
+
+    def test_finalize_is_idempotent(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+        tracker.record('t', 'w', 1, 'ok', now=clock.now)
+        first = tracker.finalize()
+        second = tracker.finalize()
+        self.assertEqual(first, second)
+        self.assertEqual(len(tracker._history), 1)
+
+
+class EndOfRunReportTest(unittest.TestCase):
+    """AC3: the end-of-run report must let a reader tell a free window, a
+    climbing phase and a plateau apart."""
+
+    def test_report_distinguishes_free_climb_and_plateau(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+
+        def run_window(n, rejected):
+            for _ in range(n - rejected):
+                tracker.record('view', 'w1', 1, 'ok', now=clock.now)
+            for _ in range(rejected):
+                tracker.record('view', 'w1', 1, 'http_412', now=clock.now)
+            clock.advance(5.1)
+
+        run_window(100, 0)     # free window: p = 0%
+        run_window(100, 0)
+        run_window(100, 40)    # climbing
+        run_window(100, 70)
+        run_window(100, 95)    # plateau: p ~= 95%
+        run_window(100, 96)
+
+        lines = tracker.finalize()
+        spark_line = next(line for line in lines if 'view / w1:' in line)
+        glyphs = spark_line.split(':', 1)[1].strip()
+        self.assertEqual(len(glyphs), 6)
+        # free window -> blank/low glyph, plateau -> the densest glyph
+        self.assertIn(glyphs[0], ' ▁')
+        self.assertEqual(glyphs[-1], '█')
+        # monotonically non-decreasing shading across the climb, i.e. it reads
+        # left-to-right as "getting worse", not noise
+        levels = ' ▁▂▃▄▅▆▇█'
+        self.assertTrue(all(levels.index(a) <= levels.index(b)
+                            for a, b in zip(glyphs, glyphs[1:])))
+
+    def test_summary_table_shows_every_trial_and_the_derived_line(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+        tracker.record('view', 'w1', 1, 'ok')
+        tracker.record('view', 'w1', 1, 'http_412')
+        tracker.record('view', 'w1', 2, 'ok')
+
+        lines = '\n'.join(tracker.finalize())
+        self.assertIn('view / w1', lines)
+        self.assertIn('trial 1: n=2,', lines)
+        self.assertIn('trial 2: n=1,', lines)
+        self.assertIn('retry_recovered=1', lines)
+
+    def test_no_traffic_renders_without_crashing(self):
+        tracker = ApiStatTracker()
+        lines = tracker.finalize()
+        self.assertIn('(no requests recorded)', '\n'.join(lines))
+
+
+class LogVolumeTest(unittest.TestCase):
+    """AC5: log growth tracks window count and outcome cardinality, not
+    request volume or failure count."""
+
+    def test_a_busy_window_and_a_quiet_window_log_about_the_same_size(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+
+        with self.assertLogs('apistat', level=logging.INFO) as ctx:
+            tracker.record('view', 'w1', 1, 'ok', now=clock.now)
+            clock.advance(5.1)
+            tracker.record('view', 'w1', 1, 'ok', now=clock.now)
+        quiet_line = next(l for l in ctx.output if 'window #0' in l)
+
+        clock2 = FakeClock()
+        tracker2 = ApiStatTracker(window_s=5.0, clock=clock2)
+        with self.assertLogs('apistat', level=logging.INFO) as ctx2:
+            for _ in range(50_000):
+                tracker2.record('view', 'w1', 1, 'ok', now=clock2.now)
+            for _ in range(2_000):
+                tracker2.record('view', 'w1', 1, 'http_412', now=clock2.now)
+            clock2.advance(5.1)
+            tracker2.record('view', 'w1', 1, 'ok', now=clock2.now)
+        busy_line = next(l for l in ctx2.output if 'window #0' in l)
+
+        # a window's line size is bounded by outcome cardinality, not by how
+        # many requests it summarised -- a few bytes of slack for bigger numbers
+        self.assertLess(len(busy_line), len(quiet_line) + 40)
+
+    def test_a_ten_minute_run_worth_of_windows_logs_tens_of_kb_not_more(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+        total_bytes = 0
+        with self.assertLogs('apistat', level=logging.INFO) as ctx:
+            for _ in range(120):  # ~10 minutes at 5s/window, a typical hourly run
+                tracker.record('get_video_view_trimmed', 'w1', 1, 'ok', now=clock.now)
+                tracker.record('get_video_view_trimmed', 'w1', 1, 'http_412', now=clock.now)
+                clock.advance(5.1)
+            tracker.finalize()
+        total_bytes = sum(len(line.encode()) for line in ctx.output)
+        self.assertLess(total_bytes, 50_000)  # "几十 KB", not hundreds
+
+
+class OverheadTest(unittest.TestCase):
+    """AC6: record() must stay cheap under the concurrency 51_ actually runs
+    (job_num=300, ~500 req/s)."""
+
+    def test_record_is_cheap_under_300_threads(self):
+        clock = FakeClock()
+        tracker = ApiStatTracker(window_s=5.0, clock=clock)
+        # a shared incrementing counter stands in for wall-clock progression so
+        # windows roll over during the benchmark too, exercising the flush path
+        call_count = 300 * 200  # 300 "threads" x 200 attempts each
+
+        def worker():
+            for _ in range(200):
+                tracker.record('get_video_view_trimmed', 'w1', 1, 'ok')
+
+        import time as time_module
+        start = time_module.perf_counter()
+        with ThreadPoolExecutor(max_workers=300) as pool:
+            futures = [pool.submit(worker) for _ in range(300)]
+            for f in futures:
+                f.result()
+        elapsed = time_module.perf_counter() - start
+
+        rows = {(r['scope'], r['name']): r['value'] for r in tracker.totals()}
+        self.assertEqual(rows[('api:get_video_view_trimmed:w1', 't1:ok')], call_count)
+        # generous bound: real production is ~500 req/s, this is 300 threads x
+        # 200 calls with NO network I/O at all -- if this were ever anywhere
+        # near the bound, record() would be a real bottleneck at 500 req/s
+        self.assertLess(elapsed, 5.0,
+                        f'{call_count} record() calls across 300 threads took '
+                        f'{elapsed:.2f}s -- record() got expensive')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_api_stat.py
+++ b/tests/test_api_stat.py
@@ -1,11 +1,4 @@
-"""
-Tests for ``service.apistat.ApiStatTracker``: the always-on,
---debug-independent request/retry/rate-limit observability layer.
-
-Run from the repo root:
-
-    python -m unittest discover -s tests
-"""
+"""Tests for service.apistat.ApiStatTracker."""
 
 import inspect
 import logging
@@ -13,7 +6,6 @@ import os
 import sys
 import unittest
 from concurrent.futures import ThreadPoolExecutor
-from unittest import mock
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
@@ -21,9 +13,6 @@ from service.apistat import ApiStatTracker  # noqa: E402
 
 
 class FakeClock:
-    """A settable clock, like ``test_worker_selector.FakeClock`` -- deterministic
-    window boundaries without sleeping in real time."""
-
     def __init__(self, start=1000.0):
         self.now = start
 
@@ -34,304 +23,168 @@ class FakeClock:
         self.now += seconds
 
 
-class ApiSurfaceTest(unittest.TestCase):
-    """
-    Locks the shape of the hot-path API: a future change that starts passing
-    aid/mid, a URL, or anything else high-cardinality must touch this test.
-    """
+def report(tracker):
+    log = logging.getLogger('test.apistat.%d' % id(tracker))
+    log.setLevel(logging.INFO)
+    lines = []
+    handler = logging.Handler()
+    handler.emit = lambda record: lines.append(record.getMessage())
+    log.addHandler(handler)
+    try:
+        tracker.log_summary(log)
+    finally:
+        log.removeHandler(handler)
+    return lines
 
+
+class DimensionTest(unittest.TestCase):
     def test_record_accepts_only_low_cardinality_dimensions(self):
+        # a future change that starts passing aid/mid or a URL must touch this
         params = list(inspect.signature(ApiStatTracker.record).parameters)
         self.assertEqual(params, ['self', 'target', 'worker', 'trial', 'outcome', 'now'])
 
+    def test_targets_and_workers_do_not_share_counters(self):
+        t = ApiStatTracker(clock=FakeClock())
+        t.record('get_member_card', 'card-aws', 1, 'code_-352')
+        t.record('get_video_view_trimmed', 'vv-aws', 1, 'http_412')
+        t.record('get_video_view_trimmed', 'vv-gcp', 1, 'ok')
+        rows = {(r['scope'], r['name']): r['value'] for r in t.totals()}
+        self.assertEqual(rows['api:get_member_card:card-aws', 't1:code_-352'], 1.0)
+        self.assertEqual(rows['api:get_video_view_trimmed:vv-aws', 't1:http_412'], 1.0)
+        self.assertEqual(rows['api:get_video_view_trimmed:vv-gcp', 't1:ok'], 1.0)
 
-class OutcomeVisibilityTest(unittest.TestCase):
-    """AC1: every outcome _get can produce stays individually visible, not
-    just HTTP 412 -- including member_card's code_-352 and every timeout kind."""
+    def test_every_outcome_kind_stays_distinct(self):
+        t = ApiStatTracker(clock=FakeClock())
+        kinds = ['ok', 'http_412', 'code_-352', 'http_503', 'request_exception',
+                 'body_exception', 'deadline_exceeded', 'json_error', 'parse_error']
+        for kind in kinds:
+            t.record('view', 'w', 1, kind)
+        names = {r['name'] for r in t.totals()}
+        self.assertEqual(names, {'t1:%s' % k for k in kinds})
 
-    def test_every_known_outcome_kind_is_kept_distinct(self):
+
+class DerivedTest(unittest.TestCase):
+    def test_p_and_retry_recovery_come_from_the_counts(self):
         clock = FakeClock()
-        tracker = ApiStatTracker(clock=clock)
-        outcomes = ['ok', 'http_412', 'code_-352', 'http_500',
-                    'request_exception', 'body_exception', 'deadline_exceeded',
-                    'json_error', 'parse_error']
-        for outcome in outcomes:
-            tracker.record('get_video_view_trimmed', 'w1', 1, outcome)
-
-        rows = {(r['scope'], r['name']): r['value'] for r in tracker.totals()}
-        for outcome in outcomes:
-            self.assertEqual(
-                rows[('api:get_video_view_trimmed:w1', f't1:{outcome}')], 1.0,
-                f'{outcome} was not recorded distinctly')
-
-    def test_member_card_and_video_view_do_not_share_counters(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(clock=clock)
-        tracker.record('get_member_card', 'card-1', 1, 'code_-352')
-        tracker.record('get_video_view_trimmed', 'view-1', 1, 'http_412')
-
-        rows = {(r['scope'], r['name']): r['value'] for r in tracker.totals()}
-        self.assertEqual(rows[('api:get_member_card:card-1', 't1:code_-352')], 1.0)
-        self.assertEqual(rows[('api:get_video_view_trimmed:view-1', 't1:http_412')], 1.0)
-        self.assertNotIn(('api:get_member_card:card-1', 't1:http_412'), rows)
-
-
-class DerivedQuantitiesTest(unittest.TestCase):
-    """AC2: p, retry-recovered and retry-exhausted counts must be directly
-    verifiable from the recorded per-trial counts, without --debug."""
-
-    def test_no_retry_needed(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(clock=clock)
-        for _ in range(97):
-            tracker.record('t', 'w', 1, 'ok')
-        for _ in range(3):
-            tracker.record('t', 'w', 1, 'http_412')
-
-        trials = tracker.grouped_totals()[('t', 'w')]
-        derived = ApiStatTracker.derive(trials)
-        self.assertAlmostEqual(derived['p'], 0.03)
-        self.assertEqual(derived['n1'], 100)
-        self.assertEqual(derived['retry_recovered'], 0)
-        self.assertEqual(derived['max_trial'], 1)
-        self.assertEqual(derived['exhausted'], 3)  # trial 1 IS the last trial here
-
-    def test_retry_recovers_most_of_the_rejected_trial(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(clock=clock)
+        t = ApiStatTracker(clock=clock)
         for _ in range(90):
-            tracker.record('t', 'w', 1, 'ok')
+            t.record('view', 'w', 1, 'ok')
         for _ in range(10):
-            tracker.record('t', 'w', 1, 'http_412')
-        # 9 of the 10 that failed trial 1 succeed on trial 2
-        for _ in range(9):
-            tracker.record('t', 'w', 2, 'ok')
-        tracker.record('t', 'w', 2, 'http_412')
+            t.record('view', 'w', 1, 'http_412')
+        for _ in range(8):
+            t.record('view', 'w', 2, 'ok')
+        for _ in range(2):
+            t.record('view', 'w', 2, 'http_412')
+        text = '\n'.join(report(t))
+        self.assertIn('p=10.00% (n=100)', text)
+        self.assertIn('retry_recovered=8', text)
 
-        trials = tracker.grouped_totals()[('t', 'w')]
-        derived = ApiStatTracker.derive(trials)
-        self.assertAlmostEqual(derived['p'], 0.10)
-        self.assertEqual(derived['retry_recovered'], 9)
-        self.assertEqual(derived['max_trial'], 2)
-        self.assertEqual(derived['exhausted'], 1)
+    def test_a_clean_run_reports_zero_p(self):
+        t = ApiStatTracker(clock=FakeClock())
+        for _ in range(50):
+            t.record('view', 'w', 1, 'ok')
+        text = '\n'.join(report(t))
+        self.assertIn('p=0.00% (n=50)', text)
+        self.assertIn('retry_recovered=0', text)
 
-    def test_retry_exhausted_after_the_configured_retry_budget(self):
+    def test_no_traffic_reports_without_crashing(self):
+        text = '\n'.join(report(ApiStatTracker(clock=FakeClock())))
+        self.assertIn('no requests recorded', text)
+
+
+class WindowTest(unittest.TestCase):
+    def setUp(self):
+        self.clock = FakeClock()
+        self.tracker = ApiStatTracker(window_s=5.0, clock=self.clock)
+        self.lines = []
+        self.handler = logging.Handler()
+        self.handler.emit = lambda record: self.lines.append(record.getMessage())
+        logging.getLogger('apistat').addHandler(self.handler)
+        logging.getLogger('apistat').setLevel(logging.INFO)
+
+    def tearDown(self):
+        logging.getLogger('apistat').removeHandler(self.handler)
+
+    def test_a_window_is_logged_only_once_it_is_crossed(self):
+        self.tracker.record('view', 'w', 1, 'ok')
+        self.clock.advance(4.0)
+        self.tracker.record('view', 'w', 1, 'ok')
+        self.assertEqual(self.lines, [])
+        self.clock.advance(2.0)
+        self.tracker.record('view', 'w', 1, 'http_412')
+        self.assertEqual(len(self.lines), 1)
+        self.assertIn('n=2 ok=2', self.lines[0])
+
+    def test_totals_accumulate_across_windows(self):
+        for i in range(4):
+            self.tracker.record('view', 'w', 1, 'ok')
+            self.clock.advance(5.0)
+        rows = {r['name']: r['value'] for r in self.tracker.totals()}
+        self.assertEqual(rows['t1:ok'], 4.0)
+
+    def test_an_idle_stretch_does_not_fabricate_windows(self):
+        self.tracker.record('view', 'w', 1, 'ok')
+        self.clock.advance(60.0)
+        self.tracker.record('view', 'w', 1, 'ok')
+        self.assertEqual(len(self.lines), 1)
+
+    def test_log_summary_is_safe_to_call_twice(self):
+        self.tracker.record('view', 'w', 1, 'ok')
+        first = report(self.tracker)
+        second = report(self.tracker)
+        self.assertEqual(
+            [l for l in first if l.startswith('  - trial')],
+            [l for l in second if l.startswith('  - trial')])
+
+
+class ShapeTest(unittest.TestCase):
+    def test_the_sparkline_separates_free_climb_and_plateau(self):
         clock = FakeClock()
-        tracker = ApiStatTracker(clock=clock)
-        # one call, rejected on all 3 trials (retry=3) -> RateLimitError in Service
-        for trial in (1, 2, 3):
-            tracker.record('t', 'w', trial, 'http_412')
-
-        trials = tracker.grouped_totals()[('t', 'w')]
-        derived = ApiStatTracker.derive(trials)
-        self.assertEqual(derived['p'], 1.0)
-        self.assertEqual(derived['retry_recovered'], 0)
-        self.assertEqual(derived['max_trial'], 3)
-        self.assertEqual(derived['exhausted'], 1)
-
-    def test_no_traffic_derives_to_none_not_a_crash(self):
-        derived = ApiStatTracker.derive({})
-        self.assertIsNone(derived['p'])
-        self.assertIsNone(derived['max_trial'])
-        self.assertIsNone(derived['exhausted'])
-        self.assertEqual(derived['n1'], 0)
-        self.assertEqual(derived['retry_recovered'], 0)
-
-
-class WindowingTest(unittest.TestCase):
-    """AC3 + AC8: one INFO line per closed 5s window, containing only that
-    window's counts, plus correct accumulation across window boundaries."""
-
-    def test_no_window_is_logged_before_five_seconds_pass(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-        with mock.patch('service.apistat.logger') as mock_logger:
-            for _ in range(3):
-                clock.advance(1.0)
-                tracker.record('t', 'w', 1, 'ok')
-            mock_logger.info.assert_not_called()
-
-    def test_crossing_the_boundary_logs_exactly_that_windows_counts(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-        with self.assertLogs('apistat', level=logging.INFO) as ctx:
-            tracker.record('t', 'w', 1, 'ok', now=clock.now)
-            tracker.record('t', 'w', 1, 'http_412', now=clock.now)
-            clock.advance(5.1)
-            # this call belongs to window 1 and must trigger window 0's flush
-            tracker.record('t', 'w', 1, 'ok', now=clock.now)
-
-        window_lines = [line for line in ctx.output if 'API stat window #0' in line]
-        self.assertEqual(len(window_lines), 1)
-        self.assertIn('n=2', window_lines[0])
-        self.assertIn('ok=1', window_lines[0])
-        self.assertIn('http_412=1', window_lines[0])
-        # the record that opened window 1 must not be in window 0's line
-        self.assertNotIn('n=3', window_lines[0])
-
-    def test_totals_accumulate_across_window_boundaries(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-        tracker.record('t', 'w', 1, 'ok', now=clock.now)
-        clock.advance(5.1)
-        tracker.record('t', 'w', 1, 'ok', now=clock.now)
-        clock.advance(5.1)
-        tracker.record('t', 'w', 1, 'ok', now=clock.now)
-
-        rows = {(r['scope'], r['name']): r['value'] for r in tracker.totals()}
-        self.assertEqual(rows[('api:t:w', 't1:ok')], 3.0)
-
-    def test_a_silent_gap_does_not_fabricate_empty_windows(self):
-        # traffic in window 0, nothing at all in window 1, traffic resumes in
-        # window 2 -- only windows that actually saw a request are recorded
-        clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-        tracker.record('t', 'w', 1, 'ok', now=clock.now)
-        clock.advance(11.0)  # skips straight into window 2
-        tracker.record('t', 'w', 1, 'ok', now=clock.now)
-        tracker.finalize()
-
-        indices = [snap.index for snap in tracker._history]
-        self.assertEqual(indices, [0, 2])
-
-    def test_finalize_is_idempotent(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-        tracker.record('t', 'w', 1, 'ok', now=clock.now)
-        first = tracker.finalize()
-        second = tracker.finalize()
-        self.assertEqual(first, second)
-        self.assertEqual(len(tracker._history), 1)
-
-
-class EndOfRunReportTest(unittest.TestCase):
-    """AC3: the end-of-run report must let a reader tell a free window, a
-    climbing phase and a plateau apart."""
-
-    def test_report_distinguishes_free_climb_and_plateau(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-
-        def run_window(n, rejected):
-            for _ in range(n - rejected):
-                tracker.record('view', 'w1', 1, 'ok', now=clock.now)
+        t = ApiStatTracker(window_s=5.0, clock=clock)
+        for fraction in [0.0, 0.0, 0.0, 0.3, 0.6, 0.8, 0.8, 0.8]:
+            rejected = int(round(fraction * 20))
+            for _ in range(20 - rejected):
+                t.record('view', 'w', 1, 'ok')
             for _ in range(rejected):
-                tracker.record('view', 'w1', 1, 'http_412', now=clock.now)
-            clock.advance(5.1)
+                t.record('view', 'w', 1, 'http_412')
+            clock.advance(5.0)
+        spark = [l for l in report(t) if ' / w: ' in l][0].split(': ')[-1]
+        self.assertEqual(len(spark), 8)
+        self.assertEqual(spark[0], '▁')
+        self.assertGreater(spark.index(spark[-1]), 2)
+        self.assertEqual(spark[-3:], spark[-1] * 3)
 
-        run_window(100, 0)     # free window: p = 0%
-        run_window(100, 0)
-        run_window(100, 40)    # climbing
-        run_window(100, 70)
-        run_window(100, 95)    # plateau: p ~= 95%
-        run_window(100, 96)
 
-        lines = tracker.finalize()
-        spark_line = next(line for line in lines if 'view / w1:' in line)
-        glyphs = spark_line.split(':', 1)[1].strip()
-        self.assertEqual(len(glyphs), 6)
-        # free window -> blank/low glyph, plateau -> the densest glyph
-        self.assertIn(glyphs[0], ' ▁')
-        self.assertEqual(glyphs[-1], '█')
-        # monotonically non-decreasing shading across the climb, i.e. it reads
-        # left-to-right as "getting worse", not noise
-        levels = ' ▁▂▃▄▅▆▇█'
-        self.assertTrue(all(levels.index(a) <= levels.index(b)
-                            for a, b in zip(glyphs, glyphs[1:])))
-
-    def test_summary_table_shows_every_trial_and_the_derived_line(self):
+class CostTest(unittest.TestCase):
+    def test_a_ten_minute_run_logs_tens_of_kb_not_more(self):
         clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-        tracker.record('view', 'w1', 1, 'ok')
-        tracker.record('view', 'w1', 1, 'http_412')
-        tracker.record('view', 'w1', 2, 'ok')
+        t = ApiStatTracker(window_s=5.0, clock=clock)
+        lines = []
+        handler = logging.Handler()
+        handler.emit = lambda record: lines.append(record.getMessage())
+        log = logging.getLogger('apistat')
+        log.addHandler(handler)
+        log.setLevel(logging.INFO)
+        try:
+            for _ in range(120):
+                for _ in range(2500):
+                    t.record('get_video_view_trimmed', 'vv-aws', 1, 'ok')
+                for _ in range(200):
+                    t.record('get_video_view_trimmed', 'vv-aws', 1, 'http_412')
+                clock.advance(5.0)
+            report_lines = report(t)
+        finally:
+            log.removeHandler(handler)
+        size = sum(len(l) for l in lines + report_lines)
+        self.assertLess(size, 60_000)
+        self.assertEqual(len(lines), 120)
 
-        lines = '\n'.join(tracker.finalize())
-        self.assertIn('view / w1', lines)
-        self.assertIn('trial 1: n=2,', lines)
-        self.assertIn('trial 2: n=1,', lines)
-        self.assertIn('retry_recovered=1', lines)
-
-    def test_no_traffic_renders_without_crashing(self):
-        tracker = ApiStatTracker()
-        lines = tracker.finalize()
-        self.assertIn('(no requests recorded)', '\n'.join(lines))
-
-
-class LogVolumeTest(unittest.TestCase):
-    """AC5: log growth tracks window count and outcome cardinality, not
-    request volume or failure count."""
-
-    def test_a_busy_window_and_a_quiet_window_log_about_the_same_size(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-
-        with self.assertLogs('apistat', level=logging.INFO) as ctx:
-            tracker.record('view', 'w1', 1, 'ok', now=clock.now)
-            clock.advance(5.1)
-            tracker.record('view', 'w1', 1, 'ok', now=clock.now)
-        quiet_line = next(l for l in ctx.output if 'window #0' in l)
-
-        clock2 = FakeClock()
-        tracker2 = ApiStatTracker(window_s=5.0, clock=clock2)
-        with self.assertLogs('apistat', level=logging.INFO) as ctx2:
-            for _ in range(50_000):
-                tracker2.record('view', 'w1', 1, 'ok', now=clock2.now)
-            for _ in range(2_000):
-                tracker2.record('view', 'w1', 1, 'http_412', now=clock2.now)
-            clock2.advance(5.1)
-            tracker2.record('view', 'w1', 1, 'ok', now=clock2.now)
-        busy_line = next(l for l in ctx2.output if 'window #0' in l)
-
-        # a window's line size is bounded by outcome cardinality, not by how
-        # many requests it summarised -- a few bytes of slack for bigger numbers
-        self.assertLess(len(busy_line), len(quiet_line) + 40)
-
-    def test_a_ten_minute_run_worth_of_windows_logs_tens_of_kb_not_more(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-        total_bytes = 0
-        with self.assertLogs('apistat', level=logging.INFO) as ctx:
-            for _ in range(120):  # ~10 minutes at 5s/window, a typical hourly run
-                tracker.record('get_video_view_trimmed', 'w1', 1, 'ok', now=clock.now)
-                tracker.record('get_video_view_trimmed', 'w1', 1, 'http_412', now=clock.now)
-                clock.advance(5.1)
-            tracker.finalize()
-        total_bytes = sum(len(line.encode()) for line in ctx.output)
-        self.assertLess(total_bytes, 50_000)  # "几十 KB", not hundreds
-
-
-class OverheadTest(unittest.TestCase):
-    """AC6: record() must stay cheap under the concurrency 51_ actually runs
-    (job_num=300, ~500 req/s)."""
-
-    def test_record_is_cheap_under_300_threads(self):
-        clock = FakeClock()
-        tracker = ApiStatTracker(window_s=5.0, clock=clock)
-        # a shared incrementing counter stands in for wall-clock progression so
-        # windows roll over during the benchmark too, exercising the flush path
-        call_count = 300 * 200  # 300 "threads" x 200 attempts each
-
-        def worker():
-            for _ in range(200):
-                tracker.record('get_video_view_trimmed', 'w1', 1, 'ok')
-
-        import time as time_module
-        start = time_module.perf_counter()
+    def test_record_is_safe_and_cheap_under_300_threads(self):
+        t = ApiStatTracker()
         with ThreadPoolExecutor(max_workers=300) as pool:
-            futures = [pool.submit(worker) for _ in range(300)]
-            for f in futures:
-                f.result()
-        elapsed = time_module.perf_counter() - start
-
-        rows = {(r['scope'], r['name']): r['value'] for r in tracker.totals()}
-        self.assertEqual(rows[('api:get_video_view_trimmed:w1', 't1:ok')], call_count)
-        # generous bound: real production is ~500 req/s, this is 300 threads x
-        # 200 calls with NO network I/O at all -- if this were ever anywhere
-        # near the bound, record() would be a real bottleneck at 500 req/s
-        self.assertLess(elapsed, 5.0,
-                        f'{call_count} record() calls across 300 threads took '
-                        f'{elapsed:.2f}s -- record() got expensive')
+            list(pool.map(lambda i: t.record('view', 'w', 1, 'ok'), range(30_000)))
+        rows = {r['name']: r['value'] for r in t.totals()}
+        self.assertEqual(rows['t1:ok'], 30_000.0)
 
 
 if __name__ == '__main__':

--- a/tests/test_api_stat.py
+++ b/tests/test_api_stat.py
@@ -87,6 +87,43 @@ class DerivedTest(unittest.TestCase):
         self.assertIn('p=0.00% (n=50)', text)
         self.assertIn('retry_recovered=0', text)
 
+    def test_exhausted_counts_calls_that_ran_out_of_retries(self):
+        clock = FakeClock()
+        t = ApiStatTracker(clock=clock)
+        # 100 calls, retry=3: 10 fail trial 1, 8 recover at trial 2,
+        # 2 fail again and 1 recovers at trial 3 -> 1 exhausted
+        for _ in range(90):
+            t.record('view', 'w', 1, 'ok')
+        for _ in range(10):
+            t.record('view', 'w', 1, 'http_412')
+        for _ in range(8):
+            t.record('view', 'w', 2, 'ok')
+        for _ in range(2):
+            t.record('view', 'w', 2, 'http_412')
+        t.record('view', 'w', 3, 'ok')
+        t.record('view', 'w', 3, 'http_412')
+        self.assertIn('exhausted=1', '\n'.join(report(t)))
+
+    def test_exhaustion_is_correct_when_calls_used_different_retry_budgets(self):
+        # reading "failures at the last trial" would miss the retry=1 call
+        # that gave up at trial 1; the chain identity does not
+        t = ApiStatTracker(clock=FakeClock())
+        t.record('view', 'w', 1, 'http_412')          # retry=1 -> gave up here
+        t.record('view', 'w', 1, 'http_412')          # retry=3 -> goes on
+        t.record('view', 'w', 2, 'http_412')
+        t.record('view', 'w', 3, 'http_412')          # -> gave up here
+        self.assertIn('exhausted=2', '\n'.join(report(t)))
+
+    def test_exhaustion_chains_across_workers(self):
+        # a retry may land on another worker, so the count is per target
+        t = ApiStatTracker(clock=FakeClock())
+        t.record('view', 'w-a', 1, 'http_412')
+        t.record('view', 'w-b', 2, 'http_412')
+        t.record('view', 'w-a', 3, 'http_412')
+        text = '\n'.join(report(t))
+        self.assertIn('view (all workers)', text)
+        self.assertIn('exhausted=1', text)
+
     def test_no_traffic_reports_without_crashing(self):
         text = '\n'.join(report(ApiStatTracker(clock=FakeClock())))
         self.assertIn('no requests recorded', text)

--- a/tests/test_service_api_stat.py
+++ b/tests/test_service_api_stat.py
@@ -18,7 +18,7 @@ import requests
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from service import RateLimitError, ResponseError, Service  # noqa: E402
-from service.apistat import ApiStatTracker  # noqa: E402
+from service.apistat import ApiStatTracker, NullApiStat  # noqa: E402
 from test_worker_selector import ScriptedSession, endpoints_for, response, worker  # noqa: E402
 
 
@@ -151,12 +151,15 @@ class ServiceApiStatWiringTest(unittest.TestCase):
         self.assertEqual(totals_dict(service.stats),
                          {('api:view:direct', 't1:ok'): 1.0})
 
-    def test_stats_false_disables_tracking_without_error(self):
+    def test_stats_false_records_nothing_and_needs_no_none_check(self):
+        # callers never test `stats is not None`; disabling swaps in a no-op
         service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
                                     {'https://w1.invalid/': [response(200, {'code': 0})]},
                                     stats=False)
-        self.assertIsNone(service.stats)
-        service._get('view', 'worker')  # must not raise
+        self.assertIsInstance(service.stats, NullApiStat)
+        service._get('view', 'worker')
+        self.assertEqual(service.stats.totals(), [])
+        service.stats.log_summary()
 
     def test_a_shared_tracker_can_be_injected(self):
         shared = ApiStatTracker()

--- a/tests/test_service_api_stat.py
+++ b/tests/test_service_api_stat.py
@@ -1,0 +1,177 @@
+"""
+Tests that ``Service._get`` actually feeds its ``ApiStatTracker``: every
+attempt outcome it can produce must reach the tracker with the exact
+same classification the existing per-attempt DEBUG line already uses.
+
+Run from the repo root:
+
+    python -m unittest discover -s tests
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+import requests
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from service import RateLimitError, ResponseError, Service  # noqa: E402
+from service.apistat import ApiStatTracker  # noqa: E402
+from test_worker_selector import ScriptedSession, endpoints_for, response, worker  # noqa: E402
+
+
+def totals_dict(tracker):
+    return {(row['scope'], row['name']): row['value'] for row in tracker.totals()}
+
+
+def raising_response(exc):
+    """A Response whose body read raises ``exc`` -- simulates the connection
+    dying mid-download (Service's ``body_exception`` branch)."""
+    r = response(200, b'placeholder')
+    r.headers = {}
+
+    def _iter_content(chunk_size=1):
+        raise exc
+        yield  # pragma: no cover - makes this a generator function
+
+    r.iter_content = _iter_content
+    return r
+
+
+class ServiceApiStatWiringTest(unittest.TestCase):
+    def make_service(self, target, workers, responses, **kwargs):
+        service = Service(mode='worker', retry=kwargs.pop('retry', 3),
+                          colddown_factor=0,
+                          endpoints=endpoints_for(target, workers), **kwargs)
+        service._session = ScriptedSession(responses)
+        return service
+
+    def test_success_on_first_trial_is_recorded_ok(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
+                                    {'https://w1.invalid/': [response(200, {'code': 0})]})
+        service._get('view', 'worker')
+        self.assertEqual(totals_dict(service.stats),
+                         {('api:view:w1', 't1:ok'): 1.0})
+
+    def test_recovery_after_one_rejection_is_visible_at_both_trials(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')], {
+            'https://w1.invalid/': [response(412, b'blocked'), response(200, {'code': 0})]})
+        with mock.patch('service.Service.time.sleep'):
+            service._get('view', 'worker')
+        self.assertEqual(totals_dict(service.stats), {
+            ('api:view:w1', 't1:http_412'): 1.0,
+            ('api:view:w1', 't2:ok'): 1.0,
+        })
+
+    def test_exhausted_rate_limit_records_every_trial_and_raises(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')], {
+            'https://w1.invalid/': [response(412, b'blocked')] * 3})
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(RateLimitError):
+                service._get('view', 'worker', retry=3)
+        self.assertEqual(totals_dict(service.stats), {
+            ('api:view:w1', 't1:http_412'): 1.0,
+            ('api:view:w1', 't2:http_412'): 1.0,
+            ('api:view:w1', 't3:http_412'): 1.0,
+        })
+
+    def test_member_card_in_body_rate_limit_records_its_own_reason(self):
+        service = self.make_service('get_member_card', [worker('c1', 'https://c1.invalid/')],
+                                    {'https://c1.invalid/': [response(200, {'code': -352})]})
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(RateLimitError):
+                service._get('get_member_card', 'worker', retry=1)
+        self.assertEqual(totals_dict(service.stats),
+                         {('api:get_member_card:c1', 't1:code_-352'): 1.0})
+
+    def test_non_rate_limited_non_200_is_recorded_as_http_code(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
+                                    {'https://w1.invalid/': [response(500, b'oops')]})
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(ResponseError):
+                service._get('view', 'worker', retry=1)
+        self.assertEqual(totals_dict(service.stats),
+                         {('api:view:w1', 't1:http_500'): 1.0})
+
+    def test_json_decode_failure_is_recorded(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
+                                    {'https://w1.invalid/': [response(200, b'not json')]})
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(ResponseError):
+                service._get('view', 'worker', retry=1)
+        self.assertEqual(totals_dict(service.stats),
+                         {('api:view:w1', 't1:json_error'): 1.0})
+
+    def test_request_exception_is_recorded(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')], {})
+
+        class RaisingSession:
+            def get(self, url, **kwargs):
+                raise requests.exceptions.ConnectionError('refused')
+
+        service._session = RaisingSession()
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(ResponseError):
+                service._get('view', 'worker', retry=1)
+        self.assertEqual(totals_dict(service.stats),
+                         {('api:view:w1', 't1:request_exception'): 1.0})
+
+    def test_body_exception_is_recorded(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
+                                    {'https://w1.invalid/':
+                                         [raising_response(requests.exceptions.ChunkedEncodingError())]})
+        with mock.patch('service.Service.time.sleep'):
+            with self.assertRaises(ResponseError):
+                service._get('view', 'worker', retry=1)
+        self.assertEqual(totals_dict(service.stats),
+                         {('api:view:w1', 't1:body_exception'): 1.0})
+
+    def test_deadline_exceeded_is_recorded(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
+                                    {'https://w1.invalid/': [response(200, b'x' * 10)]})
+        # trial_start, one over-deadline check inside the chunk loop, then the
+        # duration calc after breaking out -- three perf_counter() reads for
+        # this single trial
+        with mock.patch('service.Service.time.sleep'), \
+                mock.patch('service.Service.time.perf_counter',
+                           side_effect=[0.0, 100.0, 100.0]):
+            with self.assertRaises(ResponseError):
+                service._get('view', 'worker', retry=1)
+        self.assertEqual(totals_dict(service.stats),
+                         {('api:view:w1', 't1:deadline_exceeded'): 1.0})
+
+    def test_direct_mode_records_worker_as_direct(self):
+        service = Service(mode='direct', retry=1, colddown_factor=0,
+                          endpoints=endpoints_for('view', [worker('a', 'https://a.invalid/')]))
+        service._session = ScriptedSession(
+            {'https://direct.invalid/': [response(200, {'code': 0})]})
+        service._get('view', 'direct')
+        self.assertEqual(totals_dict(service.stats),
+                         {('api:view:direct', 't1:ok'): 1.0})
+
+    def test_stats_false_disables_tracking_without_error(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
+                                    {'https://w1.invalid/': [response(200, {'code': 0})]},
+                                    stats=False)
+        self.assertIsNone(service.stats)
+        service._get('view', 'worker')  # must not raise
+
+    def test_a_shared_tracker_can_be_injected(self):
+        shared = ApiStatTracker()
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
+                                    {'https://w1.invalid/': [response(200, {'code': 0})]},
+                                    stats=shared)
+        self.assertIs(service.stats, shared)
+        service._get('view', 'worker')
+        self.assertEqual(totals_dict(shared), {('api:view:w1', 't1:ok'): 1.0})
+
+    def test_default_service_creates_its_own_tracker(self):
+        service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
+                                    {'https://w1.invalid/': [response(200, {'code': 0})]})
+        self.assertIsInstance(service.stats, ApiStatTracker)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_service_api_stat.py
+++ b/tests/test_service_api_stat.py
@@ -18,7 +18,7 @@ import requests
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from service import RateLimitError, ResponseError, Service  # noqa: E402
-from service.apistat import ApiStatTracker, NullApiStat  # noqa: E402
+from service.apistat import ApiStatTracker, NullApiStatTracker  # noqa: E402
 from test_worker_selector import ScriptedSession, endpoints_for, response, worker  # noqa: E402
 
 
@@ -156,7 +156,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
         service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
                                     {'https://w1.invalid/': [response(200, {'code': 0})]},
                                     stats=False)
-        self.assertIsInstance(service.stats, NullApiStat)
+        self.assertIsInstance(service.stats, NullApiStatTracker)
         service._get('view', 'worker')
         self.assertEqual(service.stats.totals(), [])
         service.stats.log_summary()


### PR DESCRIPTION
`Service._get()` already classifies every HTTP attempt — `ok`, a rate-limit reason (`http_412`, `code_-352`), `http_<code>`, `request_exception`, `body_exception`, `deadline_exceeded`, `json_error`, `parse_error`. That classification was only visible as a DEBUG line, which costs 150 MB and roughly double the wall time per hourly run, so in practice it was off and the only thing production recorded was the far end of the chain.

That far end is `rate_limited`, the retry-exhausted count — which is `p × c2 × c3`, three rates multiplied. Measured on two runs of the same 69,265-item workload: 4 exhausted at 17:00, 146 at 21:00. A **36× swing in the recorded number for a 4.4× change upstream.** Reading it as a failure rate produced three wrong conclusions in one day, each needing a `--debug` re-run to clear up, and one spike has no explanation at all because `--debug` was off when it happened.

## What is recorded

`(target, worker, trial, outcome)` counts, in 5-second windows. Not recorded: aid/mid or any per-request identifier, User-Agent, URLs, query strings, headers, bodies. Size is bounded by the number of distinct combinations seen, never by request volume.

Three outputs:

1. one INFO line per closed window, with that window's counts
2. an end-of-run table plus `p` (first-attempt rejection rate) and `retry_recovered`, derived from the counts, and a fixed-scale sparkline of `p` per (target, worker) so the free window / climb / plateau shape is visible
3. the run totals into run-record, so a cross-day comparison is a `runrecord` query rather than unpacking a log archive

`get_video_view_trimmed` and `get_member_card` reject differently — 412 recovers on retry 99% of the time, `code_-352` does not — so every outcome is kept, not just 412. Counting only 412 would leave member-card's rate limiting and every timeout invisible.

## Wiring

`51_hourly-video-record-add.py` (the `job_num=300` script this is mostly for) and `16_update-member-info.py`. The other entry points are untouched and need the same one-line call.

## Notes on the shape

`stats` is never `None` — disabling swaps in a no-op — so no caller tests for it. In the retry loop each classification point is one `note('<outcome>')` call that both remembers the failure reason and counts it, rather than an assignment beside a guarded record call that a new outcome could half-update.

`ApiStatTracker` exposes `record()`, `totals()` and `log_summary()`; the rest is internal.

Validation:
- `python -m unittest discover -s tests` — 256 passed

Not yet run against production traffic; needs a post-deploy check like the earlier changes in this series.

🤖 Generated with [Claude Code](https://claude.com/claude-code)