### PR TITLE
Refactor Service request mode per instance

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -131,11 +131,13 @@ class Service:
                     f'An unexpected error occurred when load and parse endpoints.json file. {e}')
                 exit(1)
 
-        try:
-            self._worker_selector = WorkerSelector(self.endpoints)
-        except WorkerConfigurationError as e:
-            logger.critical(f'Invalid worker configuration: {e}')
-            raise SystemExit(1)
+        self._worker_selector = None
+        if self._mode == 'worker':
+            try:
+                self._worker_selector = WorkerSelector(self.endpoints)
+            except WorkerConfigurationError as e:
+                logger.critical(f'Invalid worker configuration: {e}')
+                raise SystemExit(1)
 
         # define User Agent list
         self._ua_list = [
@@ -201,7 +203,7 @@ class Service:
     # default config getters end
 
     def _get(
-            self, target: str, mode: RequestMode,
+            self, target: str,
             params: Optional[dict] = None, headers: Optional[dict] = None,
             retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
             deadline: Optional[float] = None,
@@ -226,16 +228,16 @@ class Service:
         deadline = deadline if deadline is not None else self._deadline
         rate_limit_checker = RATE_LIMIT_CHECKERS.get(target, default_rate_limit)
 
-        if mode == 'direct':
+        if self._mode == 'direct':
             try:
                 direct_url = self.endpoints[target]['direct']
             except KeyError:
                 logger.critical(f'Endpoint "{target}" not found.')
                 raise SystemExit(1)
-        elif mode == 'worker':
+        elif self._mode == 'worker':
             direct_url = None
         else:
-            logger.critical(f'Invalid request mode: {mode}.')
+            logger.critical(f'Invalid request mode: {self._mode}.')
             raise SystemExit(1)
 
         # go request
@@ -254,7 +256,7 @@ class Service:
         for trial in range(1, retry + 1):
             selected_worker = None
             request_url = direct_url
-            if mode == 'worker':
+            if self._mode == 'worker':
                 try:
                     selected_worker = self._worker_selector.select(target)
                 except WorkerConfigurationError as e:
@@ -398,23 +400,14 @@ class Service:
 
     def get_video_view(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,
-            retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
-            mode: Optional[RequestMode] = None
+            retry: Optional[int] = None, timeout: Optional[float] = None,
+            colddown_factor: Optional[float] = None
     ) -> VideoView:
         """
         params: { aid: int }
-        mode: 'direct' | 'worker'
         """
-        # config mode
-        mode = mode if mode is not None else self._mode
-
-        # validate params
-        if mode not in ['direct', 'worker']:
-            logger.critical(f'Invalid request mode: {mode}.')
-            exit(1)
-
         # get response
-        response = self._get('get_video_view', mode, params=params, headers=headers,
+        response = self._get('get_video_view', params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
 
         # validate format
@@ -524,13 +517,11 @@ class Service:
 
     def get_video_view_trimmed(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,
-            retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
-            mode: Optional[RequestMode] = None
+            retry: Optional[int] = None, timeout: Optional[float] = None,
+            colddown_factor: Optional[float] = None
     ) -> VideoViewTrimmed:
         """
         params: { aid: int }
-        mode: 'worker' only
-
         Stat-only variant of get_video_view for record jobs: hits the trimmed
         video_view worker (service/workers/video_view/), whose ~250B response
         avoids shipping the 200KB-2.8MB season/UGC bloat of the full view
@@ -541,18 +532,14 @@ class Service:
         worker URL a valid drop-in workers entry before the trimmed Lambda is
         deployed.
         """
-        # config mode
-        mode = mode if mode is not None else self._mode
-
-        # validate params
-        if mode != 'worker':
+        if self._mode != 'worker':
             logger.critical(f'Endpoint "get_video_view_trimmed" is worker-only '
-                            f'(no direct API serves the trimmed contract), got mode: {mode}. '
+                            f'(no direct API serves the trimmed contract), got mode: {self._mode}. '
                             f'Use get_video_view for direct mode.')
             exit(1)
 
         # get response
-        response = self._get('get_video_view_trimmed', 'worker', params=params, headers=headers,
+        response = self._get('get_video_view_trimmed', params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
 
         # validate format
@@ -609,21 +596,12 @@ class Service:
 
     def get_video_tags(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,
-            retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
-            mode: Optional[RequestMode] = None
+            retry: Optional[int] = None, timeout: Optional[float] = None,
+            colddown_factor: Optional[float] = None
     ) -> VideoTags:
         """
         params: { aid: int }
-        mode: 'direct' | 'worker'
         """
-        # config mode
-        mode = mode if mode is not None else self._mode
-
-        # validate params
-        if mode not in ['direct', 'worker']:
-            logger.critical(f'Invalid request mode: {mode}.')
-            exit(1)
-
         # define parser
         def parser(text: str) -> Optional[dict]:
             logger.debug(
@@ -642,7 +620,7 @@ class Service:
             return parsed_response
 
         # get response
-        response = self._get('get_video_tags', mode, params=params, headers=headers,
+        response = self._get('get_video_tags', params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor,
                              parser=parser)
 
@@ -683,23 +661,14 @@ class Service:
 
     def get_member_card(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,
-            retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
-            mode: Optional[RequestMode] = None
+            retry: Optional[int] = None, timeout: Optional[float] = None,
+            colddown_factor: Optional[float] = None
     ) -> MemberCard:
         """
         params: { mid: int }
-        mode: 'direct' | 'worker'
         """
-        # config mode
-        mode = mode if mode is not None else self._mode
-
-        # validate params
-        if mode not in ['direct', 'worker']:
-            logger.critical(f'Invalid request mode: {mode}.')
-            exit(1)
-
         # get response
-        response = self._get('get_member_card', mode, params=params, headers=headers,
+        response = self._get('get_member_card', params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
 
         # validate format
@@ -742,23 +711,14 @@ class Service:
 
     def get_member_relation(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,
-            retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
-            mode: Optional[RequestMode] = None
+            retry: Optional[int] = None, timeout: Optional[float] = None,
+            colddown_factor: Optional[float] = None
     ) -> MemberRelation:
         """
         params: { vmid: int }
-        mode: 'direct' | 'worker'
         """
-        # config mode
-        mode = mode if mode is not None else self._mode
-
-        # validate params
-        if mode not in ['direct', 'worker']:
-            logger.critical(f'Invalid request mode: {mode}.')
-            exit(1)
-
         # get response
-        response = self._get('get_member_relation', mode, params=params, headers=headers,
+        response = self._get('get_member_relation', params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor)
 
         # validate format
@@ -791,21 +751,12 @@ class Service:
 
     def get_newlist(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,
-            retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
-            mode: Optional[RequestMode] = None
+            retry: Optional[int] = None, timeout: Optional[float] = None,
+            colddown_factor: Optional[float] = None
     ) -> Newlist:
         """
         params: { rid: int, pn: int, ps: int }
-        mode: 'direct' | 'worker'
         """
-        # config mode
-        mode = mode if mode is not None else self._mode
-
-        # validate params
-        if mode not in ['direct', 'worker']:
-            logger.critical(f'Invalid request mode: {mode}.')
-            exit(1)
-
         # get endpoint url
         # define parser
         def parser(text: str) -> Optional[dict]:
@@ -824,7 +775,7 @@ class Service:
             return parsed_response
 
         # get response
-        response = self._get('get_newlist', mode, params=params, headers=headers,
+        response = self._get('get_newlist', params=params, headers=headers,
                              retry=retry, timeout=timeout, colddown_factor=colddown_factor,
                              parser=parser)
 

--- a/service/Service.py
+++ b/service/Service.py
@@ -122,14 +122,14 @@ class Service:
                     self.endpoints = json.load(f)
             except FileNotFoundError:
                 logger.critical("The file 'endpoints.json' was not found.")
-                exit(1)
+                raise SystemExit(1)
             except json.JSONDecodeError:
                 logger.critical('Invalid JSON format in endpoints.json.')
-                exit(1)
+                raise SystemExit(1)
             except Exception as e:
                 logger.critical(
                     f'An unexpected error occurred when load and parse endpoints.json file. {e}')
-                exit(1)
+                raise SystemExit(1)
 
         self._worker_selector = None
         if self._mode == 'worker':
@@ -536,7 +536,7 @@ class Service:
             logger.critical(f'Endpoint "get_video_view_trimmed" is worker-only '
                             f'(no direct API serves the trimmed contract), got mode: {self._mode}. '
                             f'Use get_video_view for direct mode.')
-            exit(1)
+            raise SystemExit(1)
 
         # get response
         response = self._get('get_video_view_trimmed', params=params, headers=headers,

--- a/service/worker.py
+++ b/service/worker.py
@@ -46,7 +46,11 @@ class WorkerSelector:
             if len(worker_ids) != len(set(worker_ids)):
                 raise WorkerConfigurationError(
                     f'Duplicate worker id for {target!r}.')
-            self._workers[target] = self._weighted(workers)
+            weighted = self._weighted(workers)
+            if not weighted:
+                raise WorkerConfigurationError(
+                    f'Endpoint {target!r} has no enabled worker configured.')
+            self._workers[target] = weighted
 
     @staticmethod
     def _parse_worker(target: str, index: int, raw) -> WorkerEndpoint:

--- a/tests/test_api_debug_line.py
+++ b/tests/test_api_debug_line.py
@@ -25,7 +25,7 @@ class ApiDebugLineTest(TestCase):
 
         with mock.patch('service.Service.time.sleep'), \
                 self.assertLogs('Service', level=logging.DEBUG) as logs:
-            service._get('view', 'worker')
+            service._get('view')
 
         api_lines = [line for line in logs.output if 'API target: ' in line]
         self.assertEqual(len(api_lines), 2)
@@ -42,7 +42,7 @@ class ApiDebugLineTest(TestCase):
         with mock.patch('service.Service.time.sleep'), \
                 self.assertLogs('Service', level=logging.DEBUG) as logs:
             with self.assertRaises(RateLimitError):
-                service._get('view', 'worker', retry=3)
+                service._get('view', retry=3)
 
         api_lines = [line for line in logs.output if 'API target: ' in line]
         self.assertEqual(len(api_lines), 3)
@@ -57,7 +57,7 @@ class ApiDebugLineTest(TestCase):
         with mock.patch('service.Service.time.sleep'), \
                 self.assertLogs('Service', level=logging.DEBUG) as logs:
             with self.assertRaises(RateLimitError):
-                service._get('get_member_card', 'worker', retry=1)
+                service._get('get_member_card', retry=1)
 
         api_lines = [line for line in logs.output if 'API target: ' in line]
         self.assertEqual(len(api_lines), 1)
@@ -71,7 +71,7 @@ class ApiDebugLineTest(TestCase):
             {'https://direct.invalid/': [response(200, {'code': 0})]})
 
         with self.assertLogs('Service', level=logging.DEBUG) as logs:
-            service._get('view', 'direct')
+            service._get('view')
 
         api_lines = [line for line in logs.output if 'API target: ' in line]
         self.assertEqual(len(api_lines), 1)

--- a/tests/test_service_api_stat.py
+++ b/tests/test_service_api_stat.py
@@ -51,7 +51,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
     def test_success_on_first_trial_is_recorded_ok(self):
         service = self.make_service('view', [worker('w1', 'https://w1.invalid/')],
                                     {'https://w1.invalid/': [response(200, {'code': 0})]})
-        service._get('view', 'worker')
+        service._get('view')
         self.assertEqual(totals_dict(service.stats),
                          {('api:view:w1', 't1:ok'): 1.0})
 
@@ -59,7 +59,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
         service = self.make_service('view', [worker('w1', 'https://w1.invalid/')], {
             'https://w1.invalid/': [response(412, b'blocked'), response(200, {'code': 0})]})
         with mock.patch('service.Service.time.sleep'):
-            service._get('view', 'worker')
+            service._get('view')
         self.assertEqual(totals_dict(service.stats), {
             ('api:view:w1', 't1:http_412'): 1.0,
             ('api:view:w1', 't2:ok'): 1.0,
@@ -70,7 +70,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
             'https://w1.invalid/': [response(412, b'blocked')] * 3})
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(RateLimitError):
-                service._get('view', 'worker', retry=3)
+                service._get('view', retry=3)
         self.assertEqual(totals_dict(service.stats), {
             ('api:view:w1', 't1:http_412'): 1.0,
             ('api:view:w1', 't2:http_412'): 1.0,
@@ -82,7 +82,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
                                     {'https://c1.invalid/': [response(200, {'code': -352})]})
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(RateLimitError):
-                service._get('get_member_card', 'worker', retry=1)
+                service._get('get_member_card', retry=1)
         self.assertEqual(totals_dict(service.stats),
                          {('api:get_member_card:c1', 't1:code_-352'): 1.0})
 
@@ -91,7 +91,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
                                     {'https://w1.invalid/': [response(500, b'oops')]})
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(ResponseError):
-                service._get('view', 'worker', retry=1)
+                service._get('view', retry=1)
         self.assertEqual(totals_dict(service.stats),
                          {('api:view:w1', 't1:http_500'): 1.0})
 
@@ -100,7 +100,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
                                     {'https://w1.invalid/': [response(200, b'not json')]})
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(ResponseError):
-                service._get('view', 'worker', retry=1)
+                service._get('view', retry=1)
         self.assertEqual(totals_dict(service.stats),
                          {('api:view:w1', 't1:json_error'): 1.0})
 
@@ -114,7 +114,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
         service._session = RaisingSession()
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(ResponseError):
-                service._get('view', 'worker', retry=1)
+                service._get('view', retry=1)
         self.assertEqual(totals_dict(service.stats),
                          {('api:view:w1', 't1:request_exception'): 1.0})
 
@@ -124,7 +124,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
                                          [raising_response(requests.exceptions.ChunkedEncodingError())]})
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(ResponseError):
-                service._get('view', 'worker', retry=1)
+                service._get('view', retry=1)
         self.assertEqual(totals_dict(service.stats),
                          {('api:view:w1', 't1:body_exception'): 1.0})
 
@@ -138,7 +138,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
                 mock.patch('service.Service.time.perf_counter',
                            side_effect=[0.0, 100.0, 100.0]):
             with self.assertRaises(ResponseError):
-                service._get('view', 'worker', retry=1)
+                service._get('view', retry=1)
         self.assertEqual(totals_dict(service.stats),
                          {('api:view:w1', 't1:deadline_exceeded'): 1.0})
 
@@ -147,7 +147,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
                           endpoints=endpoints_for('view', [worker('a', 'https://a.invalid/')]))
         service._session = ScriptedSession(
             {'https://direct.invalid/': [response(200, {'code': 0})]})
-        service._get('view', 'direct')
+        service._get('view')
         self.assertEqual(totals_dict(service.stats),
                          {('api:view:direct', 't1:ok'): 1.0})
 
@@ -157,7 +157,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
                                     {'https://w1.invalid/': [response(200, {'code': 0})]},
                                     stats=False)
         self.assertIsInstance(service.stats, NullApiStatTracker)
-        service._get('view', 'worker')
+        service._get('view')
         self.assertEqual(service.stats.totals(), [])
         service.stats.log_summary()
 
@@ -167,7 +167,7 @@ class ServiceApiStatWiringTest(unittest.TestCase):
                                     {'https://w1.invalid/': [response(200, {'code': 0})]},
                                     stats=shared)
         self.assertIs(service.stats, shared)
-        service._get('view', 'worker')
+        service._get('view')
         self.assertEqual(totals_dict(shared), {('api:view:w1', 't1:ok'): 1.0})
 
     def test_default_service_creates_its_own_tracker(self):

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -38,27 +38,27 @@ class UserAgentTest(TestCase):
         # so a process picked one at startup and sent it for its whole run
         service = self.make_service()
         for _ in range(40):
-            service._get('view', 'worker')
+            service._get('view')
 
         self.assertEqual(len(service._session.sent_agents), 40)
         self.assertGreater(len(set(service._session.sent_agents)), 1)
 
     def test_default_headers_are_not_mutated_by_a_request(self):
         service = self.make_service()
-        service._get('view', 'worker')
+        service._get('view')
         self.assertEqual(service._headers, {})
         self.assertEqual(service.get_default_headers(), {})
 
     def test_configured_headers_survive_and_are_not_mutated(self):
         service = self.make_service(headers={'Referer': 'https://ref.invalid/'})
-        service._get('view', 'worker')
-        service._get('view', 'worker')
+        service._get('view')
+        service._get('view')
         self.assertEqual(service._headers, {'Referer': 'https://ref.invalid/'})
 
     def test_an_explicit_agent_is_left_alone(self):
         service = self.make_service()
         for _ in range(5):
-            service._get('view', 'worker', headers={'User-Agent': 'mine/1.0'})
+            service._get('view', headers={'User-Agent': 'mine/1.0'})
         self.assertEqual(set(service._session.sent_agents), {'mine/1.0'})
 
     def test_the_symbian_agent_is_not_offered(self):

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -1,3 +1,4 @@
+import inspect
 import json
 import logging
 from collections import Counter
@@ -135,14 +136,41 @@ class WorkerSelectorConfigTest(TestCase):
         with self.assertRaises(SystemExit):
             Service(mode='invalid', endpoints={})
 
-    def test_worker_configuration_is_validated_when_target_is_used(self):
-        service = Service(mode='worker', endpoints={
+    def test_worker_configuration_is_validated_at_construction(self):
+        endpoints = {
             'unused': {'workers': []},
             'view': {'workers': [worker('view-a', 'https://a.invalid/')]},
+        }
+        with self.assertRaises(SystemExit):
+            Service(mode='worker', endpoints=endpoints)
+
+    def test_direct_mode_does_not_validate_or_create_a_worker_selector(self):
+        endpoints = {
+            'view': {
+                'direct': 'https://direct.invalid/',
+                'workers': [{'not': 'a valid worker'}],
+            },
+        }
+        service = Service(mode='direct', endpoints=endpoints)
+        self.assertIsNone(service._worker_selector)
+        service._session = ScriptedSession({
+            'https://direct.invalid/': [response(200, {'code': 0})],
         })
-        self.assertEqual(service._worker_selector.select('view').id, 'view-a')
-        with self.assertRaises(ValueError):
-            service._worker_selector.select('unused')
+        self.assertEqual(service._get('view'), {'code': 0})
+
+    def test_request_methods_cannot_override_an_instances_mode(self):
+        methods = [Service._get, Service.get_video_view,
+                   Service.get_video_view_trimmed, Service.get_video_tags,
+                   Service.get_member_card, Service.get_member_relation,
+                   Service.get_newlist]
+        for method in methods:
+            self.assertNotIn('mode', inspect.signature(method).parameters)
+
+    def test_corrupted_private_mode_still_fails_explicitly(self):
+        service = Service(mode='direct', endpoints={})
+        service._mode = 'invalid'
+        with self.assertRaises(SystemExit):
+            service._get('view')
 
 
 class WorkerSelectorSelectionTest(TestCase):
@@ -177,9 +205,8 @@ class WorkerSelectorSelectionTest(TestCase):
                          {item.id for item in choose.call_args.args[0]})
 
     def test_empty_pool_is_reported(self):
-        selector = WorkerSelector({'view': {'workers': []}})
         with self.assertRaises(WorkerConfigurationError):
-            selector.select('view')
+            WorkerSelector({'view': {'workers': []}})
 
     def test_a_rate_limit_never_takes_a_worker_out_of_the_pool(self):
         # the selector is stateless: nothing a response says can shrink the
@@ -231,7 +258,7 @@ class ServiceWorkerRoutingTest(TestCase):
         ]})
 
         with mock.patch('service.Service.time.sleep'):
-            self.assertEqual(service._get('view', 'worker'), {'code': 0})
+            self.assertEqual(service._get('view'), {'code': 0})
 
         self.assertEqual(len(service._session.calls), 2)
 
@@ -242,7 +269,7 @@ class ServiceWorkerRoutingTest(TestCase):
 
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(RateLimitError) as raised:
-                service._get('view', 'worker', retry=3)
+                service._get('view', retry=3)
 
         self.assertEqual(raised.exception.reason, 'http_412')
         self.assertEqual(len(service._session.calls), 3)
@@ -261,7 +288,7 @@ class ServiceWorkerRoutingTest(TestCase):
 
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(ResponseError) as raised:
-                service._get('view', 'worker', retry=3)
+                service._get('view', retry=3)
 
         self.assertEqual(raised.exception.reason, 'http_412')
         self.assertEqual(raised.exception.trials, 3)
@@ -279,7 +306,7 @@ class ServiceWorkerRoutingTest(TestCase):
                 mock.patch('service.worker.random.choice',
                            side_effect=lambda items: items[0]) as choose:
             with self.assertRaises(RateLimitError):
-                service._get('view', 'worker', retry=3)
+                service._get('view', retry=3)
 
         # nothing a response says takes a worker out of the candidate set
         self.assertEqual({item.id for item in choose.call_args.args[0]},
@@ -294,7 +321,7 @@ class ServiceWorkerRoutingTest(TestCase):
 
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(RateLimitError) as raised:
-                service._get('get_member_card', 'worker', retry=3)
+                service._get('get_member_card', retry=3)
 
         self.assertEqual(raised.exception.reason, 'code_-352')
 
@@ -307,7 +334,7 @@ class ServiceWorkerRoutingTest(TestCase):
         ]})
 
         with mock.patch('service.Service.time.sleep'):
-            self.assertEqual(service._get('get_member_card', 'worker'),
+            self.assertEqual(service._get('get_member_card'),
                              {'code': 0})
 
     @mock.patch('service.worker.random.choice', side_effect=lambda items: items[0])
@@ -322,7 +349,7 @@ class ServiceWorkerRoutingTest(TestCase):
         })
 
         with mock.patch('service.Service.time.sleep') as sleep:
-            result = service._get('get_member_card', 'worker')
+            result = service._get('get_member_card')
 
         self.assertEqual(result, {'code': 0})
         self.assertNotIn(mock.call(60), sleep.mock_calls)
@@ -336,7 +363,7 @@ class ServiceWorkerRoutingTest(TestCase):
         ]})
 
         with mock.patch('service.Service.time.sleep'):
-            result = service._get('get_member_card', 'worker')
+            result = service._get('get_member_card')
 
         self.assertEqual(result, {'code': 0})
         self.assertEqual(service._session.calls,
@@ -374,7 +401,7 @@ class ServiceWorkerRoutingTest(TestCase):
         ]})
 
         with mock.patch('service.Service.time.sleep'):
-            result = service._get('view', 'worker')
+            result = service._get('view')
 
         self.assertEqual(result, {'code': 0})
         self.assertEqual(service._session.calls,
@@ -389,7 +416,7 @@ class ServiceWorkerRoutingTest(TestCase):
 
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(ResponseError) as raised:
-                service._get('view', 'worker', retry=3)
+                service._get('view', retry=3)
 
         self.assertEqual(raised.exception.reason, 'http_503')
         self.assertEqual(raised.exception.trials, 3)
@@ -405,7 +432,7 @@ class ServiceWorkerRoutingTest(TestCase):
 
         with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(ResponseError) as raised:
-                service._get('view', 'worker', retry=2)
+                service._get('view', retry=2)
 
         self.assertEqual(raised.exception.reason, 'json_error')
 
@@ -414,9 +441,8 @@ class ServiceWorkerRoutingTest(TestCase):
         service._session = ScriptedSession({
             'https://direct.invalid/': [response(412, b'blocked')] * 2,
         })
-        with mock.patch('service.Service.time.sleep'), \
-                mock.patch.object(service._worker_selector, 'select') as select:
+        with mock.patch('service.Service.time.sleep'):
             with self.assertRaises(RateLimitError) as raised:
-                service._get('view', 'direct', retry=2)
+                service._get('view', retry=2)
         self.assertEqual(raised.exception.reason, 'http_412')
-        select.assert_not_called()
+        self.assertIsNone(service._worker_selector)


### PR DESCRIPTION
## Summary
- fix request mode when a Service instance is constructed
- validate worker configuration only for worker-mode instances
- keep direct mode independent of worker configuration

## Testing
- `/Users/bunnyxt/Projects/tdd-spider/venv-3.11/bin/python -m unittest discover -s tests`