### PR TITLE
Extract member relation endpoint adapter

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -12,6 +12,7 @@ from .error import (ResponseError, RateLimitError,
 from .worker import WorkerConfigurationError, WorkerSelector
 from .apistat import ApiStatTracker, NullApiStatTracker
 from .ua import UA_LIST
+from .endpoints import get_member_relation
 from .response import \
     VideoViewOwner, VideoViewStat, VideoViewStaffItem, VideoView, VideoViewTrimmed, \
     VideoTag, VideoTags, \
@@ -676,40 +677,9 @@ class Service:
             retry: Optional[int] = None, timeout: Optional[float] = None,
             colddown_factor: Optional[float] = None
     ) -> MemberRelation:
-        """
-        params: { vmid: int }
-        """
-        # get response
-        response = self._get('get_member_relation', params=params, headers=headers,
-                             retry=retry, timeout=timeout, colddown_factor=colddown_factor)
-
-        # validate format
-
-        # response should contain keys
-        for key in ['code', 'message', 'ttl']:
-            if key not in response.keys():
-                raise FormatError('member_relation', params,
-                                  response, f'Response should contain key {key}.')
-        # response code should be 0
-        if response['code'] != 0:
-            raise CodeError('member_relation', params,
-                            response, response['code'])
-        # response data should be a dict
-        if type(response['data']) != dict:
-            raise FormatError('member_relation', params,
-                              response, 'Response data should be a dict.')
-        # data should contain keys
-        for key in ['mid', 'following', 'follower']:
-            if key not in response['data'].keys():
-                raise FormatError('member_relation', params, response,
-                                  f'Response data should contain key {key}.')
-
-        # assemble data
-        return MemberRelation(
-            mid=response['data']['mid'],
-            following=response['data']['following'],
-            follower=response['data']['follower']
-        )
+        return get_member_relation.get(
+            self._get, params=params, headers=headers, retry=retry,
+            timeout=timeout, colddown_factor=colddown_factor)
 
     def get_newlist(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,

--- a/service/endpoints/__init__.py
+++ b/service/endpoints/__init__.py
@@ -1,0 +1,1 @@
+from . import get_member_relation

--- a/service/endpoints/get_member_relation.py
+++ b/service/endpoints/get_member_relation.py
@@ -1,0 +1,32 @@
+from typing import Callable, Optional
+
+from ..error import CodeError, FormatError
+from ..response import MemberRelation
+
+TARGET = 'get_member_relation'
+
+
+def get(request: Callable[..., dict], params: Optional[dict] = None,
+        headers: Optional[dict] = None, retry: Optional[int] = None,
+        timeout: Optional[float] = None,
+        colddown_factor: Optional[float] = None) -> MemberRelation:
+    response = request(
+        TARGET, params=params, headers=headers, retry=retry, timeout=timeout,
+        colddown_factor=colddown_factor)
+    for key in ['code', 'message', 'ttl']:
+        if key not in response:
+            raise FormatError('member_relation', params, response,
+                              f'Response should contain key {key}.')
+    if response['code'] != 0:
+        raise CodeError('member_relation', params, response, response['code'])
+    if not isinstance(response['data'], dict):
+        raise FormatError('member_relation', params, response,
+                          'Response data should be a dict.')
+    for key in ['mid', 'following', 'follower']:
+        if key not in response['data']:
+            raise FormatError('member_relation', params, response,
+                              f'Response data should contain key {key}.')
+    return MemberRelation(
+        mid=response['data']['mid'],
+        following=response['data']['following'],
+        follower=response['data']['follower'])

--- a/tests/test_endpoint_get_member_relation.py
+++ b/tests/test_endpoint_get_member_relation.py
@@ -1,0 +1,64 @@
+import unittest
+from unittest import mock
+
+from service import CodeError, FormatError, MemberRelation, Service
+from service.endpoints import get_member_relation
+
+
+def valid_response():
+    return {
+        'code': 0,
+        'message': '0',
+        'ttl': 1,
+        'data': {'mid': 7, 'following': 11, 'follower': 13},
+    }
+
+
+class GetMemberRelationEndpointTest(unittest.TestCase):
+    def test_adapts_a_valid_response_and_passes_request_options(self):
+        request = mock.Mock(return_value=valid_response())
+
+        result = get_member_relation.get(
+            request, params={'vmid': 7}, headers={'X-Test': 'yes'}, retry=2,
+            timeout=3.0, colddown_factor=0.0)
+
+        self.assertEqual(result, MemberRelation(7, 11, 13))
+        request.assert_called_once_with(
+            'get_member_relation', params={'vmid': 7}, headers={'X-Test': 'yes'},
+            retry=2, timeout=3.0, colddown_factor=0.0)
+
+    def test_nonzero_api_code_keeps_the_existing_business_error(self):
+        response = valid_response()
+        response['code'] = -404
+
+        with self.assertRaises(CodeError) as raised:
+            get_member_relation.get(lambda *args, **kwargs: response,
+                                    params={'vmid': 7})
+
+        self.assertEqual((raised.exception.target, raised.exception.code),
+                         ('member_relation', -404))
+
+    def test_invalid_shape_keeps_the_existing_format_error(self):
+        response = valid_response()
+        del response['data']['follower']
+
+        with self.assertRaises(FormatError) as raised:
+            get_member_relation.get(lambda *args, **kwargs: response,
+                                    params={'vmid': 7})
+
+        self.assertEqual(raised.exception.target, 'member_relation')
+
+    def test_service_public_method_delegates_to_the_adapter(self):
+        service = Service(mode='direct', endpoints={})
+        service._get = mock.Mock(return_value=valid_response())
+
+        result = service.get_member_relation({'vmid': 7})
+
+        self.assertEqual(result, MemberRelation(7, 11, 13))
+        service._get.assert_called_once_with(
+            'get_member_relation', params={'vmid': 7}, headers=None,
+            retry=None, timeout=None, colddown_factor=None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- move only the member-relation response adapter into its target-named endpoint module
- retain Service as the public facade and keep request mode, User-Agent selection, retry handling, worker routing, and API statistics unchanged

## Verification
- focused member-relation, User-Agent, worker, and API-statistics unittest coverage passed (60 tests)