### PR TITLE
chore: stop writing a DEBUG log from the member-update job

### DIFF
--- a/16_update-member-info.py
+++ b/16_update-member-info.py
@@ -86,6 +86,5 @@ def main():
 
 
 if __name__ == '__main__':
-    # debug=True writes 16_DEBUG.log with the per-attempt API lines to grep
-    logging_init(file_prefix=script_id, debug=True)
+    logging_init(file_prefix=script_id)
     main()


### PR DESCRIPTION
`debug=True` was added to `16_` while investigating the `-352` wall, when the per-attempt `API target` line was the only way to see a rejection rate at all.

apistat now records the same classification always-on. The flag costs ~48 MB per run (measured on today's 2h25m run) for information the INFO log already carries:

```
- get_member_card / get_member_card-aws     trial 1: n=8412  ok=8406  request_exception=6     p=0.07%
- get_member_card / get_member_card-azure   trial 1: n=8209  ok=8076  request_exception=133   p=1.62%
- get_member_card / get_member_card-gcp     trial 1: n=8321  ok=8310  request_exception=11    p=0.13%
- get_member_card (all workers): p=0.60% (n=24942), retry_recovered=149, exhausted=1
```

Turn it back on for a single run when a specific member has to be traced to individual requests — that is what it is for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)