### PR TITLE
feat: record api stats from the follower-record job

### DIFF
--- a/17_add-member-follower-record.py
+++ b/17_add-member-follower-record.py
@@ -75,12 +75,14 @@ def add_member_follower_record():
         # summary log uses (best-effort; a disabled recorder is a no-op)
         recorder.add_job_stat_metrics('follower-fetch', fetch_stat)
         recorder.add_job_stat_metrics('follower-db-writer', writer_stat)
+        recorder.add_api_stat_metrics(service.stats)
 
         # summary
         logger.info(f'Finish {script_fullname}!')
         logger.info(timer.get_summary())
         logger.info(fetch_stat.get_summary('follower-fetch'))
         logger.info(writer_stat.get_summary('follower-db-writer'))
+        service.stats.log_summary(logger)
         logger.info(f'{writer_stat.total_count} follower record(s) fetched and inserted.')
         sc_send_summary(script_fullname, timer, fetch_stat)
 

--- a/tests/test_summary_script_run_records.py
+++ b/tests/test_summary_script_run_records.py
@@ -90,9 +90,12 @@ def _stat(total_count=0, **conditions):
     return s
 
 
+from service.apistat import NullApiStatTracker  # noqa: E402
+
+
 class _FakeService:
     def __init__(self, *a, **kw):
-        pass
+        self.stats = NullApiStatTracker()
 
 
 class _FakeSession:


### PR DESCRIPTION
`17_` is the third-largest caller of `Service` after `51_` and `16_`: one `get_member_relation` call per member, 50 fetch workers, ~168k members per run. It has never had a measured rejection rate — `get_member_relation` is the one target we have no numbers for at all.

Two lines, matching what `51_` already does:

```python
recorder.add_api_stat_metrics(service.stats)
...
service.stats.log_summary(logger)
```

The `_FakeService` in the summary-script tests gains a `stats` attribute — it was standing in for a `Service` without modelling that part of the contract, so it broke as soon as a script under test used it. It now holds a `NullApiStatTracker`, which is what a real `Service(stats=False)` holds.

Validation:
- `python -m unittest discover -s tests` — 262 passed

`17_` runs at 11:20 daily, so a deploy before then gets today's numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)