### PR TITLE
style: raise SystemExit for intentional script exits

### DIFF
--- a/01_add-all-videos-with-tid-30.py
+++ b/01_add-all-videos-with-tid-30.py
@@ -32,7 +32,7 @@ def add_all_video_with_tid_30():
     except Exception as e:
         logger.critical(
             f'Fail to get newlist. rid: 30, pn: 1, ps: 50, error: {e}')
-        exit(1)
+        raise SystemExit(1)
     page_total = math.ceil(newlist.page.count / 50)
     logging.info(f'Found {page_total} page(s) in total.')
 

--- a/18_member-total-stat-update.py
+++ b/18_member-total-stat-update.py
@@ -69,7 +69,7 @@ def member_total_stat_update():
             sc_send_critical(script_fullname, message, __file__, get_current_line_no())
             session.rollback()
             session.close()
-            exit(1)
+            raise SystemExit(1)
 
         session.close()
 

--- a/51_hourly-video-record-add.py
+++ b/51_hourly-video-record-add.py
@@ -818,7 +818,7 @@ def hourly_video_record_add():
         recorder.finish('failed')
         sc_send_critical(script_fullname, message,
                          __file__, get_current_line_no())
-        exit(1)
+        raise SystemExit(1)
 
     recorder.finish('succeeded')
 

--- a/62_add-evocalrank-video.py
+++ b/62_add-evocalrank-video.py
@@ -64,9 +64,9 @@ def add_evocalrank_video(ranknum: int):
         except Exception as e:
             logger.critical(
                 f'Failed to get evocalrank data from {url}, error: {e}')
-            # exit() raises SystemExit(1): `track` closes the run as 'failed'
+            # raise SystemExit(1): `track` closes the run as 'failed'
             # before it propagates, so this stays distinct from a killed run.
-            exit(1)
+            raise SystemExit(1)
         logger.info(f'Evocalrank data loaded successfully!')
 
         # load avid from evocalrank_data

--- a/72_add-sprint-daily.py
+++ b/72_add-sprint-daily.py
@@ -126,7 +126,7 @@ def add_sprint_daily():
             sc_send_critical(script_fullname, message, __file__, get_current_line_no())
             session.rollback()
             session.close()
-            exit(1)
+            raise SystemExit(1)
 
         session.close()
 

--- a/tests/test_remaining_script_run_records.py
+++ b/tests/test_remaining_script_run_records.py
@@ -11,7 +11,7 @@ for a failing run. The assertions are:
 
 * a ``run`` row is written, keyed by the canonical ``script_id_script_name``;
 * it ends ``succeeded`` on a normal run and ``failed`` when the body raises and
-  the script's own ``except`` calls ``exit(1)``;
+  the script's own ``except`` raises ``SystemExit(1)``;
 * only the plain counts each script already computes land in ``run_metric``
   (no fabricated JobStat, no message text);
 * ``sc_send`` / ``sc_send_critical`` are still called exactly as before.

--- a/tests/test_run_record_track.py
+++ b/tests/test_run_record_track.py
@@ -68,11 +68,11 @@ class TrackLifecycleTest(unittest.TestCase):
         self.assertTrue(finished_at)
 
     def test_exit_nonzero_records_failed_and_propagates(self):
-        # 62_ calls exit(1) when the evocalrank fetch fails -- SystemExit(1),
+        # 62_ raises SystemExit(1) when the evocalrank fetch fails,
         # which must still close the run as 'failed', not leave it 'running'.
         with self.assertRaises(SystemExit) as ctx:
             with track('62_add-evocalrank-video', db_path=self.path):
-                exit(1)
+                raise SystemExit(1)
         self.assertEqual(ctx.exception.code, 1)
         self.assertEqual(self._status()[0], 'failed')
 


### PR DESCRIPTION
## Summary
- Replace the interactive `exit(1)` alias with `raise SystemExit(1)` in the scheduled production scripts that terminate on failure.
- Leave CLI `sys.exit(main())` wrappers and existing Service `raise SystemExit` paths unchanged.
- Update tests and comments only where they described those script exits.

## Test plan
- [x] `python -m unittest discover -s tests` (262 OK)
- [x] No remaining `exit(1)` calls in maintained Python source
- [ ] Spot-check a failing scheduled-job path still logs, notifies, and records failed


Made with [Cursor](https://cursor.com)