### PR TITLE
perf: set 16_ concurrency to 10

### DIFF
--- a/16_update-member-info.py
+++ b/16_update-member-info.py
@@ -52,7 +52,7 @@ def update_member_info():
     # sustains. Raise it only together with a run whose api stat summary shows
     # the rejection rate staying flat; a rate that survives a short burst is
     # not necessarily one that survives the whole job.
-    job_num = 20
+    job_num = 10
     for _ in range(job_num):
         mid_queue.put(None)
     logger.info(f'{len(mids)} mids put into queue.')


### PR DESCRIPTION
Master says 20; production has been running 10. This makes them agree.

20 finishes the job sooner but spends more of the run being rejected and retried; 10 costs a few minutes and takes far fewer skips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)