### PR TITLE
Persist API stats for 15_ and 16_ jobs

### DIFF
--- a/15_update-video-info.py
+++ b/15_update-video-info.py
@@ -81,11 +81,13 @@ def update_video_info():
         # run-record metrics, keyed by the same label the summary log uses
         # (best-effort; a disabled recorder is a no-op)
         recorder.add_job_stat_metrics('video-update', job_stat_merged)
+        recorder.add_api_stat_metrics(service.stats)
 
         # summary
         logger.info(f'Finish {script_fullname}!')
         logger.info(timer.get_summary())
         logger.info(job_stat_merged.get_summary('video-update'))
+        service.stats.log_summary(logger)
         sc_send_summary(script_fullname, timer, job_stat_merged)
 
 

--- a/16_update-member-info.py
+++ b/16_update-member-info.py
@@ -3,6 +3,7 @@ from util import logging_init, get_week_day, fullname
 from queue import Queue
 from service import Service
 from serverchan import sc_send_summary
+from runrecord import track
 from timer import Timer
 from job import UpdateMemberJob, JobPool
 import logging
@@ -18,67 +19,73 @@ def update_member_info():
     timer = Timer()
     timer.start()
 
-    session = Session()
-    service = Service(mode='worker')
+    with track(script_fullname) as recorder:
+        session = Session()
+        service = Service(mode='worker')
 
-    # get all mids
-    all_mids: list[int] = DBOperation.query_all_member_mids(session)
-    logger.info(f'Total {len(all_mids)} members got.')
+        # get all mids
+        all_mids: list[int] = DBOperation.query_all_member_mids(session)
+        logger.info(f'Total {len(all_mids)} members got.')
 
-    # add latest 1000 mids first
-    mids = all_mids[-1000:]
+        # add latest 1000 mids first
+        mids = all_mids[-1000:]
 
-    # TODO: add top 200 follower mids
+        # TODO: add top 200 follower mids
 
-    # for the rest, add 1 / 7 of them, according to the week day (0-6)
-    week_day = get_week_day()
-    for idx, mid in enumerate(all_mids[:-1000]):
-        if idx % 7 == week_day:
-            mids.append(mid)
+        # for the rest, add 1 / 7 of them, according to the week day (0-6)
+        week_day = get_week_day()
+        for idx, mid in enumerate(all_mids[:-1000]):
+            if idx % 7 == week_day:
+                mids.append(mid)
 
-    logger.info(f'Will update {len(mids)} members info.')
+        logger.info(f'Will update {len(mids)} members info.')
 
-    # put mid into queue
-    mid_queue: Queue[int] = Queue()
-    for mid in mids:
-        mid_queue.put(mid)
-    # one sentinel per worker (UpdateMemberJob is sentinel-terminated)
-    # Shared Service state keeps rate-limited member-card workers out of the
-    # candidate pool. If every worker is limited, each job records that condition
-    # and briefly slows down before moving to the next member.
-    # Concurrency is what sets the request rate here -- a member takes about
-    # 0.7s, so the rate is roughly job_num / 0.7 -- and the member-card
-    # endpoint limits on rate. This is deliberately kept well inside what it
-    # sustains. Raise it only together with a run whose api stat summary shows
-    # the rejection rate staying flat; a rate that survives a short burst is
-    # not necessarily one that survives the whole job.
-    job_num = 10
-    for _ in range(job_num):
-        mid_queue.put(None)
-    logger.info(f'{len(mids)} mids put into queue.')
+        # put mid into queue
+        mid_queue: Queue[int] = Queue()
+        for mid in mids:
+            mid_queue.put(mid)
+        # one sentinel per worker (UpdateMemberJob is sentinel-terminated)
+        # Shared Service state keeps rate-limited member-card workers out of the
+        # candidate pool. If every worker is limited, each job records that condition
+        # and briefly slows down before moving to the next member.
+        # Concurrency is what sets the request rate here -- a member takes about
+        # 0.7s, so the rate is roughly job_num / 0.7 -- and the member-card
+        # endpoint limits on rate. This is deliberately kept well inside what it
+        # sustains. Raise it only together with a run whose api stat summary shows
+        # the rejection rate staying flat; a rate that survives a short burst is
+        # not necessarily one that survives the whole job.
+        job_num = 10
+        for _ in range(job_num):
+            mid_queue.put(None)
+        logger.info(f'{len(mids)} mids put into queue.')
 
-    # JobPool gives a per-30s PROGRESS heartbeat over the multi-hour run
-    # (previously blind) and merges the workers' stats.
-    pool = JobPool(
-        [UpdateMemberJob(f'job_{i}', mid_queue, service) for i in range(job_num)],
-        progress_total=len(mids),
-        progress_label='member-update',
-        progress_interval_s=30.0,  # very slow job (~25s/member) -- 30s is plenty
-        logger_name=script_id)
-    pool.start()
-    logger.info(f'{job_num} job(s) started.')
-    job_stat_merged = pool.join()
+        # JobPool gives a per-30s PROGRESS heartbeat over the multi-hour run
+        # (previously blind) and merges the workers' stats.
+        pool = JobPool(
+            [UpdateMemberJob(f'job_{i}', mid_queue, service) for i in range(job_num)],
+            progress_total=len(mids),
+            progress_label='member-update',
+            progress_interval_s=30.0,  # very slow job (~25s/member) -- 30s is plenty
+            logger_name=script_id)
+        pool.start()
+        logger.info(f'{job_num} job(s) started.')
+        job_stat_merged = pool.join()
 
-    session.close()
+        session.close()
 
-    timer.stop()
+        timer.stop()
 
-    # summary
-    logger.info(f'Finish {script_fullname}!')
-    logger.info(timer.get_summary())
-    logger.info(job_stat_merged.get_summary('member-update'))
-    service.stats.log_summary(logger)
-    sc_send_summary(script_fullname, timer, job_stat_merged)
+        # run-record metrics, keyed by the same label the summary log uses
+        # (best-effort; a disabled recorder is a no-op)
+        recorder.add_job_stat_metrics('member-update', job_stat_merged)
+        recorder.add_api_stat_metrics(service.stats)
+
+        # summary
+        logger.info(f'Finish {script_fullname}!')
+        logger.info(timer.get_summary())
+        logger.info(job_stat_merged.get_summary('member-update'))
+        service.stats.log_summary(logger)
+        sc_send_summary(script_fullname, timer, job_stat_merged)
 
 
 def main():

--- a/tests/test_summary_script_run_records.py
+++ b/tests/test_summary_script_run_records.py
@@ -1,7 +1,7 @@
 """
-Per-entry-point verification that the five ``sc_send_summary`` production
-scripts (12_/15_/17_/62_/71_) now open, populate and close a run record without
-changing their Timer / JobStat summary or ServerChan behaviour.
+Per-entry-point verification that the six ``sc_send_summary`` production
+scripts (12_/15_/16_/17_/62_/71_) now open, populate and close a run record
+without changing their Timer / JobStat summary or ServerChan behaviour.
 
 Each script is imported by file path; its collaborators (Service, Session, the
 Job classes / JobPool, ``requests``) are replaced with inert fakes and its
@@ -96,6 +96,27 @@ from service.apistat import NullApiStatTracker  # noqa: E402
 class _FakeService:
     def __init__(self, *a, **kw):
         self.stats = NullApiStatTracker()
+
+
+class _FakeApiStats:
+    def __init__(self):
+        self.log_calls = []
+
+    def totals(self):
+        return [
+            {'scope': 'api:test_target:test_worker', 'name': 't1:ok',
+             'value': 90.0},
+            {'scope': 'api:test_target:test_worker', 'name': 't1:http_412',
+             'value': 10.0},
+        ]
+
+    def log_summary(self, log=None):
+        self.log_calls.append(log)
+
+
+class _FakeServiceWithApiStats:
+    def __init__(self, *a, **kw):
+        self.stats = _FakeApiStats()
 
 
 class _FakeSession:
@@ -208,8 +229,9 @@ class SummaryScriptRunRecordTest(unittest.TestCase):
     def test_15_update_video_info(self):
         m = _load('15_update-video-info.py')
         merged = _stat(120, **{'0_update': 118, 'update_exception': 2})
+        service = _FakeServiceWithApiStats()
 
-        with mock.patch.object(m, 'Service', _FakeService), \
+        with mock.patch.object(m, 'Service', return_value=service), \
              mock.patch.object(m, 'Session', _FakeSession), \
              mock.patch.object(m.DBOperation, 'query_all_video_bvids',
                                staticmethod(lambda s: [])), \
@@ -224,11 +246,61 @@ class SummaryScriptRunRecordTest(unittest.TestCase):
         metrics = self._metrics(run_id)
         self.assertEqual(metrics['video-update']['total_count'], 120.0)
         self.assertEqual(metrics['video-update']['update_exception'], 2.0)
+        self.assertEqual(metrics['api:test_target:test_worker']['t1:ok'], 90.0)
+        self.assertEqual(
+            metrics['api:test_target:test_worker']['t1:http_412'], 10.0)
+        self.assertEqual(service.stats.log_calls, [m.logger])
         # 15_ sends unconditionally; same (name, timer, merged stat) as before
         sc.assert_called_once()
         args = sc.call_args.args
         self.assertEqual(args[0], '15_update-video-info')
         self.assertIs(args[2], merged)
+
+    # ----------------------------------------------------------------- 16_ ---
+    def test_16_update_member_info(self):
+        m = _load('16_update-member-info.py')
+        merged = _stat(100, **{'0_update': 98, 'update_exception': 2})
+        service = _FakeServiceWithApiStats()
+
+        with mock.patch.object(m, 'Service', return_value=service), \
+             mock.patch.object(m, 'Session', _FakeSession), \
+             mock.patch.object(m.DBOperation, 'query_all_member_mids',
+                               staticmethod(lambda s: [])), \
+             mock.patch.object(m, 'JobPool', lambda *a, **kw: _FakePool(merged)), \
+             mock.patch.object(m, 'sc_send_summary') as sc:
+            m.update_member_info()
+
+        (run_id, script_name, status, finished_at), = self._runs()
+        self.assertEqual(script_name, '16_update-member-info')
+        self.assertEqual(status, 'succeeded')
+        self.assertTrue(finished_at)
+        metrics = self._metrics(run_id)
+        self.assertEqual(metrics['member-update']['total_count'], 100.0)
+        self.assertEqual(metrics['member-update']['update_exception'], 2.0)
+        self.assertEqual(metrics['api:test_target:test_worker']['t1:ok'], 90.0)
+        self.assertEqual(
+            metrics['api:test_target:test_worker']['t1:http_412'], 10.0)
+        self.assertEqual(service.stats.log_calls, [m.logger])
+        sc.assert_called_once()
+        args = sc.call_args.args
+        self.assertEqual(args[0], '16_update-member-info')
+        self.assertIs(args[2], merged)
+
+    def test_16_failure_is_recorded(self):
+        m = _load('16_update-member-info.py')
+
+        with mock.patch.object(m, 'Service', _FakeService), \
+             mock.patch.object(m, 'Session', _FakeSession), \
+             mock.patch.object(m.DBOperation, 'query_all_member_mids',
+                               side_effect=RuntimeError('boom')), \
+             mock.patch.object(m, 'sc_send_summary'):
+            with self.assertRaises(RuntimeError):
+                m.update_member_info()
+
+        (_, script_name, status, finished_at), = self._runs()
+        self.assertEqual(script_name, '16_update-member-info')
+        self.assertEqual(status, 'failed')
+        self.assertTrue(finished_at)
 
     # ----------------------------------------------------------------- 17_ ---
     def test_17_add_member_follower_record(self):


### PR DESCRIPTION
## Summary
- persist per-attempt API statistics for the daily video update job and emit its end-of-run API summary
- add the daily member update job to the run-record lifecycle, including job and API metrics
- cover successful metric persistence, summary logging, and failed-run recording

## Testing
- venv-3.11/bin/python -m unittest tests.test_summary_script_run_records -v
- venv-3.11/bin/python -m unittest discover -s tests (271 tests)