### PR TITLE
refactor: extract member card endpoint adapter

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -12,7 +12,7 @@ from .error import (ResponseError, RateLimitError,
 from .worker import WorkerConfigurationError, WorkerSelector
 from .apistat import ApiStatTracker, NullApiStatTracker
 from .ua import UA_LIST
-from .endpoints import get_member_relation
+from .endpoints import get_member_card, get_member_relation
 from .response import \
     VideoViewOwner, VideoViewStat, VideoViewStaffItem, VideoView, VideoViewTrimmed, \
     VideoTag, VideoTags, \
@@ -628,50 +628,9 @@ class Service:
             retry: Optional[int] = None, timeout: Optional[float] = None,
             colddown_factor: Optional[float] = None
     ) -> MemberCard:
-        """
-        params: { mid: int }
-        """
-        # get response
-        response = self._get('get_member_card', params=params, headers=headers,
-                             retry=retry, timeout=timeout, colddown_factor=colddown_factor)
-
-        # validate format
-
-        # response should contain keys
-        for key in ['code', 'message', 'ttl']:
-            if key not in response.keys():
-                raise FormatError('get_member_card', MemberCard, params, response,
-                                  f'Response should contain key {key}.')
-        # response code should be 0
-        if response['code'] != 0:
-            raise CodeError('get_member_card', MemberCard, params, response, response['code'])
-        # response data should be a dict
-        if type(response['data']) != dict:
-            raise FormatError('get_member_card', MemberCard, params, response,
-                              'Response data should be a dict.')
-        # data should contain keys
-        for key in ['card']:
-            if key not in response['data'].keys():
-                raise FormatError('get_member_card', MemberCard, params, response,
-                                  f'Response data should contain key {key}.')
-        # data card should be a dict
-        if type(response['data']['card']) != dict:
-            raise FormatError('get_member_card', MemberCard, params, response,
-                              'Response data card should be a dict.')
-        # data card should contain keys
-        for key in ['mid', 'name', 'sex', 'face', 'sign']:
-            if key not in response['data']['card'].keys():
-                raise FormatError('get_member_card', MemberCard, params, response,
-                                  f'Response data card should contain key {key}.')
-
-        # assemble data
-        return MemberCard(
-            mid=response['data']['card']['mid'],
-            name=response['data']['card']['name'],
-            sex=response['data']['card']['sex'],
-            face=response['data']['card']['face'],
-            sign=response['data']['card']['sign']
-        )
+        return get_member_card.get(
+            self._get, params=params, headers=headers, retry=retry,
+            timeout=timeout, colddown_factor=colddown_factor)
 
     def get_member_relation(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,

--- a/service/endpoints/__init__.py
+++ b/service/endpoints/__init__.py
@@ -1,1 +1,1 @@
-from . import get_member_relation
+from . import get_member_card, get_member_relation

--- a/service/endpoints/get_member_card.py
+++ b/service/endpoints/get_member_card.py
@@ -1,0 +1,41 @@
+from typing import Callable, Optional
+
+from ..error import CodeError, FormatError
+from ..response import MemberCard
+
+ENDPOINT = 'get_member_card'
+RESULT_TYPE = MemberCard
+
+
+def get(request: Callable[..., dict], params: Optional[dict] = None,
+        headers: Optional[dict] = None, retry: Optional[int] = None,
+        timeout: Optional[float] = None,
+        colddown_factor: Optional[float] = None) -> MemberCard:
+    response = request(
+        ENDPOINT, params=params, headers=headers, retry=retry, timeout=timeout,
+        colddown_factor=colddown_factor)
+    for key in ['code', 'message', 'ttl']:
+        if key not in response:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response should contain key {key}.')
+    if response['code'] != 0:
+        raise CodeError(ENDPOINT, RESULT_TYPE, params, response, response['code'])
+    if type(response['data']) != dict:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data should be a dict.')
+    if 'card' not in response['data']:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data should contain key card.')
+    if type(response['data']['card']) != dict:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data card should be a dict.')
+    for key in ['mid', 'name', 'sex', 'face', 'sign']:
+        if key not in response['data']['card']:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response data card should contain key {key}.')
+    return MemberCard(
+        mid=response['data']['card']['mid'],
+        name=response['data']['card']['name'],
+        sex=response['data']['card']['sex'],
+        face=response['data']['card']['face'],
+        sign=response['data']['card']['sign'])

--- a/tests/test_endpoint_get_member_card.py
+++ b/tests/test_endpoint_get_member_card.py
@@ -1,0 +1,74 @@
+import unittest
+from unittest import mock
+
+from service import CodeError, FormatError, MemberCard, Service
+from service.endpoints import get_member_card
+
+
+def valid_response():
+    return {
+        'code': 0,
+        'message': '0',
+        'ttl': 1,
+        'data': {
+            'card': {
+                'mid': 7,
+                'name': 'name',
+                'sex': '保密',
+                'face': 'face-url',
+                'sign': 'sign',
+            },
+        },
+    }
+
+
+class GetMemberCardEndpointTest(unittest.TestCase):
+    def test_adapts_a_valid_response_and_passes_request_options(self):
+        request = mock.Mock(return_value=valid_response())
+
+        result = get_member_card.get(
+            request, params={'mid': 7}, headers={'X-Test': 'yes'}, retry=2,
+            timeout=3.0, colddown_factor=0.0)
+
+        self.assertEqual(result, MemberCard(7, 'name', '保密', 'face-url', 'sign'))
+        request.assert_called_once_with(
+            'get_member_card', params={'mid': 7}, headers={'X-Test': 'yes'},
+            retry=2, timeout=3.0, colddown_factor=0.0)
+
+    def test_nonzero_api_code_keeps_the_existing_business_error(self):
+        response = valid_response()
+        response['code'] = -404
+
+        with self.assertRaises(CodeError) as raised:
+            get_member_card.get(lambda *args, **kwargs: response,
+                                params={'mid': 7})
+
+        self.assertEqual((raised.exception.endpoint, raised.exception.result_type,
+                          raised.exception.code),
+                         ('get_member_card', MemberCard, -404))
+
+    def test_invalid_shape_keeps_the_existing_format_error(self):
+        response = valid_response()
+        del response['data']['card']['face']
+
+        with self.assertRaises(FormatError) as raised:
+            get_member_card.get(lambda *args, **kwargs: response,
+                                params={'mid': 7})
+
+        self.assertEqual(raised.exception.endpoint, 'get_member_card')
+        self.assertIs(raised.exception.result_type, MemberCard)
+
+    def test_service_public_method_delegates_to_the_adapter(self):
+        service = Service(mode='direct', endpoints={})
+        service._get = mock.Mock(return_value=valid_response())
+
+        result = service.get_member_card({'mid': 7})
+
+        self.assertEqual(result, MemberCard(7, 'name', '保密', 'face-url', 'sign'))
+        service._get.assert_called_once_with(
+            'get_member_card', params={'mid': 7}, headers=None,
+            retry=None, timeout=None, colddown_factor=None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- move member-card response validation and `MemberCard` conversion into its endpoint adapter
- keep the `Service.get_member_card` public facade and shared request path unchanged
- add adapter-level contract tests

## Tests
- `venv-3.11/bin/python -m unittest tests.test_endpoint_get_member_card`
- `venv-3.11/bin/python -m unittest discover -s tests`