### PR TITLE
refactor: distinguish service endpoints and result types

### DIFF
--- a/job/FetchMemberFollowerRecordJob.py
+++ b/job/FetchMemberFollowerRecordJob.py
@@ -67,7 +67,7 @@ class FetchMemberFollowerRecordJob(Job):
             except RateLimitError as e:
                 self.logger.warning(
                     f'Member follower API rate limited; skipping current mid. '
-                    f'mid: {mid}, target: {e.target}, reason: {e.reason}')
+                    f'mid: {mid}, endpoint: {e.endpoint}, reason: {e.reason}')
                 self.stat.condition['rate_limited'] += 1
             except ServiceError as e:
                 self.logger.error(f'Fail to fetch member follower record. mid: {mid}, error: {e}')

--- a/job/FetchVideoRecordJob.py
+++ b/job/FetchVideoRecordJob.py
@@ -90,7 +90,7 @@ class FetchVideoRecordJob(Job):
             except RateLimitError as e:
                 self.logger.warning(
                     f'Video API rate limited; skipping current aid. '
-                    f'aid: {aid}, target: {e.target}, reason: {e.reason}')
+                    f'aid: {aid}, endpoint: {e.endpoint}, reason: {e.reason}')
                 self.stat.condition['rate_limited'] += 1
             except CodeError as e:
                 # hand off to the UpdateVideoJob pool: refreshing tdd_video.code

--- a/job/UpdateMemberJob.py
+++ b/job/UpdateMemberJob.py
@@ -50,7 +50,7 @@ class UpdateMemberJob(Job):
             except RateLimitError as e:
                 self.logger.warning(
                     f'Member API rate limited; sleep {RATE_LIMIT_SLEEP_S}s before next member. '
-                    f'mid: {mid}, target: {e.target}, reason: {e.reason}')
+                    f'mid: {mid}, endpoint: {e.endpoint}, reason: {e.reason}')
                 self.stat.condition['rate_limited'] += 1
                 time.sleep(RATE_LIMIT_SLEEP_S)
             except Exception as e:

--- a/service/Service.py
+++ b/service/Service.py
@@ -165,7 +165,7 @@ class Service:
     # default config getters end
 
     def _get(
-            self, target: str,
+            self, endpoint: str,
             params: Optional[dict] = None, headers: Optional[dict] = None,
             retry: Optional[int] = None, timeout: Optional[float] = None, colddown_factor: Optional[float] = None,
             deadline: Optional[float] = None,
@@ -179,20 +179,20 @@ class Service:
         else:
             headers = {**self._headers, **headers}
         ua_given_by_caller = 'User-Agent' in headers
-        ua_pool = self.endpoints.get(target, {}).get('user_agents') or UA_LIST
+        ua_pool = self.endpoints.get(endpoint, {}).get('user_agents') or UA_LIST
 
         # config
         retry = retry if retry is not None else self._retry
         timeout = timeout if timeout is not None else self._timeout
         colddown_factor = colddown_factor if colddown_factor is not None else self._colddown_factor
         deadline = deadline if deadline is not None else self._deadline
-        rate_limit_checker = RATE_LIMIT_CHECKERS.get(target, default_rate_limit)
+        rate_limit_checker = RATE_LIMIT_CHECKERS.get(endpoint, default_rate_limit)
 
         if self._mode == 'direct':
             try:
-                direct_url = self.endpoints[target]['direct']
+                direct_url = self.endpoints[endpoint]['direct']
             except KeyError:
-                logger.critical(f'Endpoint "{target}" not found.')
+                logger.critical(f'Endpoint "{endpoint}" not found.')
                 raise SystemExit(1)
         elif self._mode == 'worker':
             direct_url = None
@@ -211,7 +211,7 @@ class Service:
             nonlocal last_failure
             if outcome != 'ok':
                 last_failure = outcome
-            self.stats.record(target, worker_id, trial, outcome)
+            self.stats.record(endpoint, worker_id, trial, outcome)
 
         for trial in range(1, retry + 1):
             if not ua_given_by_caller:
@@ -221,7 +221,7 @@ class Service:
             request_url = direct_url
             if self._mode == 'worker':
                 try:
-                    selected_worker = self._worker_selector.select(target)
+                    selected_worker = self._worker_selector.select(endpoint)
                 except WorkerConfigurationError as e:
                     logger.critical(f'Invalid worker configuration: {e}')
                     raise SystemExit(1)
@@ -309,7 +309,7 @@ class Service:
             # a response (network error, deadline) log their own line above.
             limited = rate_limit_checker(r)
             logger.debug(
-                f'API target: {target}, '
+                f'API endpoint: {endpoint}, '
                 f'worker: {selected_worker.id if selected_worker else "direct"}, '
                 f'status: {r.status_code}, '
                 f'result: {limited.reason if limited else "ok"}, '
@@ -357,8 +357,8 @@ class Service:
                 note('parse_error')
         if response is None:
             if retry > 0 and rate_limited_trials == retry:
-                raise RateLimitError(target, last_failure)
-            raise ResponseError(target, params or {}, last_failure, retry)
+                raise RateLimitError(endpoint, last_failure)
+            raise ResponseError(endpoint, params or {}, last_failure, retry)
         return response
 
     def get_video_view(
@@ -378,54 +378,55 @@ class Service:
         # response should contain keys
         for key in ['code', 'message', 'ttl']:
             if key not in response.keys():
-                raise FormatError('video_view', params, response,
+                raise FormatError('get_video_view', VideoView, params, response,
                                   f'Response should contain key {key}.')
         # response code should be 0
         if response['code'] != 0:
-            raise CodeError('video_view', params, response, response['code'])
+            raise CodeError('get_video_view', VideoView, params, response, response['code'])
         # response data should be a dict
         if type(response['data']) != dict:
-            raise FormatError('video_view', params, response,
+            raise FormatError('get_video_view', VideoView, params, response,
                               'Response data should be a dict.')
         # data should contain keys
         for key in ['bvid', 'aid', 'videos', 'tid', 'tname', 'copyright', 'pic', 'title', 'pubdate', 'ctime', 'desc',
                     'state', 'duration', 'owner', 'stat']:
             if key not in response['data'].keys():
-                raise FormatError('video_view', params, response,
+                raise FormatError('get_video_view', VideoView, params, response,
                                   f'Response data should contain key {key}.')
         # response data owner should be a dict
         if type(response['data']['owner']) != dict:
-            raise FormatError('video_view', params, response,
+            raise FormatError('get_video_view', VideoView, params, response,
                               'Response data owner should be a dict.')
         # data owner should contain keys
         for key in ['mid', 'name', 'face']:
             if key not in response['data']['owner'].keys():
-                raise FormatError('video_view', params, response,
+                raise FormatError('get_video_view', VideoView, params, response,
                                   f'Response data owner should contain key {key}.')
         # response data stat should be a dict
         if type(response['data']['stat']) != dict:
-            raise FormatError('video_view', params, response,
+            raise FormatError('get_video_view', VideoView, params, response,
                               'Response data stat should be a dict.')
         # data stat should contain keys
         for key in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share', 'now_rank', 'his_rank', 'like',
                     'dislike']:
             if key not in response['data']['stat'].keys():
-                raise FormatError('video_view', params, response,
+                raise FormatError('get_video_view', VideoView, params, response,
                                   f'Response data stat should contain key {key}.')
         # response data staff should be a list if exists
         if 'staff' in response['data'].keys():
             if type(response['data']['staff']) != list:
-                raise FormatError('video_view', params, response,
+                raise FormatError('get_video_view', VideoView, params, response,
                                   'Response data staff should be a list.')
             # staff item should be a dict
             for staff_item in response['data']['staff']:
                 if type(staff_item) != dict:
                     raise FormatError(
-                        'video_view', params, response, 'Response data staff item should be a dict.')
+                        'get_video_view', VideoView, params, response,
+                        'Response data staff item should be a dict.')
                 # staff item should contain keys
                 for key in ['mid', 'title', 'name', 'face']:
                     if key not in staff_item.keys():
-                        raise FormatError('video_view', params, response,
+                        raise FormatError('get_video_view', VideoView, params, response,
                                           f'Response data staff item should contain key {key}.')
 
         # assemble data
@@ -510,30 +511,30 @@ class Service:
         # response should contain keys
         for key in ['code', 'message', 'ttl']:
             if key not in response.keys():
-                raise FormatError('video_view_trimmed', params, response,
+                raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
                                   f'Response should contain key {key}.')
         # response code should be 0
         if response['code'] != 0:
-            raise CodeError('video_view_trimmed', params,
+            raise CodeError('get_video_view_trimmed', VideoViewTrimmed, params,
                             response, response['code'])
         # response data should be a dict
         if type(response['data']) != dict:
-            raise FormatError('video_view_trimmed', params, response,
+            raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
                               'Response data should be a dict.')
         # data should contain keys
         for key in ['bvid', 'aid', 'stat']:
             if key not in response['data'].keys():
-                raise FormatError('video_view_trimmed', params, response,
+                raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
                                   f'Response data should contain key {key}.')
         # response data stat should be a dict
         if type(response['data']['stat']) != dict:
-            raise FormatError('video_view_trimmed', params, response,
+            raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
                               'Response data stat should be a dict.')
         # data stat should contain keys
         for key in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share', 'now_rank', 'his_rank', 'like',
                     'dislike']:
             if key not in response['data']['stat'].keys():
-                raise FormatError('video_view_trimmed', params, response,
+                raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
                                   f'Response data stat should contain key {key}.')
 
         # assemble data
@@ -592,25 +593,25 @@ class Service:
         # response should contain keys
         for key in ['code', 'message', 'ttl']:
             if key not in response.keys():
-                raise FormatError('video_tags', params, response,
+                raise FormatError('get_video_tags', VideoTags, params, response,
                                   f'Response should contain key {key}.')
         # response code should be 0
         if response['code'] != 0:
-            raise CodeError('video_tags', params, response, response['code'])
+            raise CodeError('get_video_tags', VideoTags, params, response, response['code'])
         # response data should be a list
         if type(response['data']) != list:
-            raise FormatError('video_tags', params, response,
+            raise FormatError('get_video_tags', VideoTags, params, response,
                               'Response data should be a list.')
         # for each data item
         for data_item in response['data']:
             # data item should be a dict
             if type(data_item) != dict:
-                raise FormatError('video_tags', params, response,
+                raise FormatError('get_video_tags', VideoTags, params, response,
                                   'Response data item should be a dict.')
             # data item should contain keys
             for key in ['tag_id', 'tag_name']:
                 if key not in data_item.keys():
-                    raise FormatError('video_tags', params, response,
+                    raise FormatError('get_video_tags', VideoTags, params, response,
                                       f'Response data item should contain key {key}.')
 
         # assemble data
@@ -639,28 +640,28 @@ class Service:
         # response should contain keys
         for key in ['code', 'message', 'ttl']:
             if key not in response.keys():
-                raise FormatError('member_card', params, response,
+                raise FormatError('get_member_card', MemberCard, params, response,
                                   f'Response should contain key {key}.')
         # response code should be 0
         if response['code'] != 0:
-            raise CodeError('member_card', params, response, response['code'])
+            raise CodeError('get_member_card', MemberCard, params, response, response['code'])
         # response data should be a dict
         if type(response['data']) != dict:
-            raise FormatError('member_card', params, response,
+            raise FormatError('get_member_card', MemberCard, params, response,
                               'Response data should be a dict.')
         # data should contain keys
         for key in ['card']:
             if key not in response['data'].keys():
-                raise FormatError('member_card', params, response,
+                raise FormatError('get_member_card', MemberCard, params, response,
                                   f'Response data should contain key {key}.')
         # data card should be a dict
         if type(response['data']['card']) != dict:
-            raise FormatError('member_card', params, response,
+            raise FormatError('get_member_card', MemberCard, params, response,
                               'Response data card should be a dict.')
         # data card should contain keys
         for key in ['mid', 'name', 'sex', 'face', 'sign']:
             if key not in response['data']['card'].keys():
-                raise FormatError('member_card', params, response,
+                raise FormatError('get_member_card', MemberCard, params, response,
                                   f'Response data card should contain key {key}.')
 
         # assemble data
@@ -716,62 +717,62 @@ class Service:
         # response should contain keys
         for key in ['code', 'message']:
             if key not in response.keys():
-                raise FormatError('newlist', params, response,
+                raise FormatError('get_newlist', Newlist, params, response,
                                   f'Response should contain key {key}.')
         # response code should be 0
         if response['code'] != 0:
-            raise CodeError('newlist', params, response, response['code'])
+            raise CodeError('get_newlist', Newlist, params, response, response['code'])
         # response data should be a dict
         if type(response['data']) != dict:
-            raise FormatError('newlist', params, response,
+            raise FormatError('get_newlist', Newlist, params, response,
                               'Response data should be a dict.')
         # data should contain keys
         for key in ['archives', 'page']:
             if key not in response['data'].keys():
-                raise FormatError('newlist', params, response,
+                raise FormatError('get_newlist', Newlist, params, response,
                                   f'Response data should contain key {key}.')
         # data archives should be a list
         if type(response['data']['archives']) != list:
-            raise FormatError('newlist', params, response,
+            raise FormatError('get_newlist', Newlist, params, response,
                               'Response data archives should be a list.')
         # for each data archives item
         for data_archives_item in response['data']['archives']:
             # data archives item should be a dict
             if type(data_archives_item) != dict:
-                raise FormatError('newlist', params, response,
+                raise FormatError('get_newlist', Newlist, params, response,
                                   'Response data archives item should be a dict.')
             # data archives item should contain keys
             for key in ['aid', 'videos', 'tid', 'tname', 'copyright', 'pic', 'title', 'stat', 'bvid', 'desc', 'owner']:
                 if key not in data_archives_item.keys():
-                    raise FormatError('newlist', params, response,
+                    raise FormatError('get_newlist', Newlist, params, response,
                                       f'Response data archives item should contain key {key}.')
                 # data archives item stat should be a dict
                 if type(data_archives_item['stat']) != dict:
-                    raise FormatError('newlist', params, response,
+                    raise FormatError('get_newlist', Newlist, params, response,
                                       'Response data archives item stat should be a dict.')
                 # data archives item stat should contain keys
                 for key2 in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share', 'now_rank', 'his_rank',
                              'like', 'dislike', 'vt', 'vv']:
                     if key2 not in data_archives_item['stat'].keys():
-                        raise FormatError('newlist', params, response,
+                        raise FormatError('get_newlist', Newlist, params, response,
                                           f'Response data archives item stat should contain key {key2}.')
                 # data archives item owner should be a dict
                 if type(data_archives_item['owner']) != dict:
-                    raise FormatError('newlist', params, response,
+                    raise FormatError('get_newlist', Newlist, params, response,
                                       'Response data archives item owner should be a dict.')
                 # data archives item stat should contain keys
                 for key2 in ['mid', 'name', 'face']:
                     if key2 not in data_archives_item['owner'].keys():
-                        raise FormatError('newlist', params, response,
+                        raise FormatError('get_newlist', Newlist, params, response,
                                           f'Response data archives item owner should contain key {key2}.')
         # data page should be a dict
         if type(response['data']['page']) != dict:
-            raise FormatError('newlist', params, response,
+            raise FormatError('get_newlist', Newlist, params, response,
                               'Response data page should be a dict.')
         # data page should contain keys
         for key in ['count', 'num', 'size']:
             if key not in response['data']['page'].keys():
-                raise FormatError('newlist', params, response,
+                raise FormatError('get_newlist', Newlist, params, response,
                                   f'Response data page should contain key {key}.')
 
         # assemble data

--- a/service/apistat.py
+++ b/service/apistat.py
@@ -3,7 +3,7 @@ Always-on aggregation of the per-attempt outcome `Service._get` already
 classifies, so `p`, retry recovery and the shape of a run are readable
 without --debug (150 MB+ per hourly run in production).
 
-Dimensions kept: (target, worker, trial, outcome), in fixed-length windows.
+Dimensions kept: (endpoint, worker, trial, outcome), in fixed-length windows.
 Deliberately not kept: aid/mid or any per-request identifier, User-Agent,
 URLs, query strings, headers, bodies. Memory and log size are bounded by the
 number of distinct combinations seen, never by request volume.
@@ -59,7 +59,7 @@ def _exhausted(trials: Dict[int, Counter]) -> int:
     fails trial N either makes a trial N+1 attempt or gives up, so
     `failures(N) - attempts(N+1)` is the number that gave up at N. That holds
     whatever `retry` each call was given, unlike reading the last trial's
-    failures. Only valid per target: a retry may pick a different worker, so
+    failures. Only valid per endpoint: a retry may pick a different worker, so
     the chain does not hold within one worker's counts.
     """
     total = 0
@@ -72,7 +72,7 @@ def _exhausted(trials: Dict[int, Counter]) -> int:
 class NullApiStatTracker:
     """Stand-in so callers never have to test `stats is not None`."""
 
-    def record(self, target, worker, trial, outcome, now=None):
+    def record(self, endpoint, worker, trial, outcome, now=None):
         pass
 
     def totals(self) -> List[dict]:
@@ -97,10 +97,10 @@ class ApiStatTracker:
         self._index = 0
         self._window: Counter = Counter()
         self._totals: Counter = Counter()
-        # (window index) -> {(target, worker): [trial-1 attempts, trial-1 ok]}
+        # (window index) -> {(endpoint, worker): [trial-1 attempts, trial-1 ok]}
         self._series: List[Tuple[int, Dict[Tuple[str, str], List[int]]]] = []
 
-    def record(self, target: str, worker: str, trial: int, outcome: str,
+    def record(self, endpoint: str, worker: str, trial: int, outcome: str,
                now: Optional[float] = None) -> None:
         """One HTTP attempt. Called once per `_get` loop iteration, not once
         per logical call -- that is what makes retry recovery derivable."""
@@ -112,8 +112,8 @@ class ApiStatTracker:
                 if self._window:
                     closed = self._close_locked()
                 self._index = index
-            self._window[(target, worker, trial, outcome)] += 1
-            self._totals[(target, worker, trial, outcome)] += 1
+            self._window[(endpoint, worker, trial, outcome)] += 1
+            self._totals[(endpoint, worker, trial, outcome)] += 1
         # logged outside the lock: a slow handler must not block record()
         if closed is not None:
             self._log_window(*closed)
@@ -122,10 +122,10 @@ class ApiStatTracker:
         """Run totals as run-record metric rows, one per combination seen."""
         with self._lock:
             counts = dict(self._totals)
-        return [{'scope': f'api:{target}:{worker}',
+        return [{'scope': f'api:{endpoint}:{worker}',
                  'name': f't{trial}:{outcome}',
                  'value': float(value)}
-                for (target, worker, trial, outcome), value in counts.items()]
+                for (endpoint, worker, trial, outcome), value in counts.items()]
 
     def log_summary(self, log: Optional[logging.Logger] = None) -> None:
         """Close the last window and emit the end-of-run report."""
@@ -140,10 +140,10 @@ class ApiStatTracker:
         counts = dict(self._window)
         self._window = Counter()
         trial1: Dict[Tuple[str, str], List[int]] = {}
-        for (target, worker, trial, outcome), n in counts.items():
+        for (endpoint, worker, trial, outcome), n in counts.items():
             if trial != 1:
                 continue
-            slot = trial1.setdefault((target, worker), [0, 0])
+            slot = trial1.setdefault((endpoint, worker), [0, 0])
             slot[0] += n
             if outcome == OK:
                 slot[1] += n
@@ -151,14 +151,14 @@ class ApiStatTracker:
         return self._index, counts
 
     def _log_window(self, index: int, counts: Dict[Tuple[str, str, int, str], int]) -> None:
-        by_target: Dict[str, Counter] = {}
-        for (target, _w, _t, outcome), n in counts.items():
-            by_target.setdefault(target, Counter())[outcome] += n
+        by_endpoint: Dict[str, Counter] = {}
+        for (endpoint, _w, _t, outcome), n in counts.items():
+            by_endpoint.setdefault(endpoint, Counter())[outcome] += n
         parts = []
-        for target in sorted(by_target):
-            outcomes = by_target[target]
+        for endpoint in sorted(by_endpoint):
+            outcomes = by_endpoint[endpoint]
             rejected = ' '.join(f'{k}={v}' for k, v in sorted(outcomes.items()) if k != OK)
-            parts.append(f'{target}: n={sum(outcomes.values())} ok={outcomes.get(OK, 0)}'
+            parts.append(f'{endpoint}: n={sum(outcomes.values())} ok={outcomes.get(OK, 0)}'
                          + (f' {rejected}' if rejected else ''))
         elapsed = int(index * self._window_s)
         logger.info(f'API stat window #{index} (t+{format_ts_s(elapsed)}, '
@@ -169,16 +169,16 @@ class ApiStatTracker:
             counts = dict(self._totals)
             series = list(self._series)
         grouped: Dict[Tuple[str, str], Dict[int, Counter]] = {}
-        for (target, worker, trial, outcome), n in counts.items():
-            grouped.setdefault((target, worker), {}).setdefault(trial, Counter())[outcome] += n
+        for (endpoint, worker, trial, outcome), n in counts.items():
+            grouped.setdefault((endpoint, worker), {}).setdefault(trial, Counter())[outcome] += n
 
         lines = [f'## api stat summary (window={self._window_s:.0f}s, '
                  f'windows={len(series)})']
         if not grouped:
             return lines + ['(no requests recorded)']
-        for target, worker in sorted(grouped):
-            trials = grouped[(target, worker)]
-            lines.append(f'- {target} / {worker}')
+        for endpoint, worker in sorted(grouped):
+            trials = grouped[(endpoint, worker)]
+            lines.append(f'- {endpoint} / {worker}')
             for trial in sorted(trials):
                 outcomes = trials[trial]
                 detail = ' '.join(f'{k}={v}' for k, v in sorted(outcomes.items()))
@@ -188,16 +188,16 @@ class ApiStatTracker:
             lines.append(f'  - derived: p={p} (n={d["n1"]}), '
                          f'retry_recovered={d["retry_recovered"]}')
 
-        by_target: Dict[str, Dict[int, Counter]] = {}
-        for (target, _worker), trials in grouped.items():
-            per_trial = by_target.setdefault(target, {})
+        by_endpoint: Dict[str, Dict[int, Counter]] = {}
+        for (endpoint, _worker), trials in grouped.items():
+            per_trial = by_endpoint.setdefault(endpoint, {})
             for trial, outcomes in trials.items():
                 per_trial.setdefault(trial, Counter()).update(outcomes)
-        for target in sorted(by_target):
-            trials = by_target[target]
+        for endpoint in sorted(by_endpoint):
+            trials = by_endpoint[endpoint]
             d = _derive(trials)
             p = f'{d["p"] * 100:.2f}%' if d['p'] is not None else 'n/a'
-            lines.append(f'- {target} (all workers): p={p} (n={d["n1"]}), '
+            lines.append(f'- {endpoint} (all workers): p={p} (n={d["n1"]}), '
                          f'retry_recovered={d["retry_recovered"]}, '
                          f'exhausted={_exhausted(trials)}')
 
@@ -216,11 +216,11 @@ class ApiStatTracker:
                 per_key.setdefault(key, {})[index] = [n1, ok1]
         lines = []
         first, last = series[0][0], series[-1][0]
-        for target, worker in sorted(per_key):
-            points = per_key[(target, worker)]
+        for endpoint, worker in sorted(per_key):
+            points = per_key[(endpoint, worker)]
             fractions = []
             for index in range(first, last + 1):
                 n1, ok1 = points.get(index, (0, 0))
                 fractions.append(None if not n1 else (n1 - ok1) / n1)
-            lines.append(f'  {target} / {worker}: {_sparkline(fractions)}')
+            lines.append(f'  {endpoint} / {worker}: {_sparkline(fractions)}')
         return lines

--- a/service/endpoints/get_member_relation.py
+++ b/service/endpoints/get_member_relation.py
@@ -4,6 +4,7 @@ from ..error import CodeError, FormatError
 from ..response import MemberRelation
 
 TARGET = 'get_member_relation'
+RESULT_TYPE = MemberRelation
 
 
 def get(request: Callable[..., dict], params: Optional[dict] = None,
@@ -15,16 +16,16 @@ def get(request: Callable[..., dict], params: Optional[dict] = None,
         colddown_factor=colddown_factor)
     for key in ['code', 'message', 'ttl']:
         if key not in response:
-            raise FormatError('member_relation', params, response,
+            raise FormatError(TARGET, RESULT_TYPE, params, response,
                               f'Response should contain key {key}.')
     if response['code'] != 0:
-        raise CodeError('member_relation', params, response, response['code'])
+        raise CodeError(TARGET, RESULT_TYPE, params, response, response['code'])
     if not isinstance(response['data'], dict):
-        raise FormatError('member_relation', params, response,
+        raise FormatError(TARGET, RESULT_TYPE, params, response,
                           'Response data should be a dict.')
     for key in ['mid', 'following', 'follower']:
         if key not in response['data']:
-            raise FormatError('member_relation', params, response,
+            raise FormatError(TARGET, RESULT_TYPE, params, response,
                               f'Response data should contain key {key}.')
     return MemberRelation(
         mid=response['data']['mid'],

--- a/service/endpoints/get_member_relation.py
+++ b/service/endpoints/get_member_relation.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 from ..error import CodeError, FormatError
 from ..response import MemberRelation
 
-TARGET = 'get_member_relation'
+ENDPOINT = 'get_member_relation'
 RESULT_TYPE = MemberRelation
 
 
@@ -12,20 +12,20 @@ def get(request: Callable[..., dict], params: Optional[dict] = None,
         timeout: Optional[float] = None,
         colddown_factor: Optional[float] = None) -> MemberRelation:
     response = request(
-        TARGET, params=params, headers=headers, retry=retry, timeout=timeout,
+        ENDPOINT, params=params, headers=headers, retry=retry, timeout=timeout,
         colddown_factor=colddown_factor)
     for key in ['code', 'message', 'ttl']:
         if key not in response:
-            raise FormatError(TARGET, RESULT_TYPE, params, response,
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
                               f'Response should contain key {key}.')
     if response['code'] != 0:
-        raise CodeError(TARGET, RESULT_TYPE, params, response, response['code'])
+        raise CodeError(ENDPOINT, RESULT_TYPE, params, response, response['code'])
     if not isinstance(response['data'], dict):
-        raise FormatError(TARGET, RESULT_TYPE, params, response,
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
                           'Response data should be a dict.')
     for key in ['mid', 'following', 'follower']:
         if key not in response['data']:
-            raise FormatError(TARGET, RESULT_TYPE, params, response,
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
                               f'Response data should contain key {key}.')
     return MemberRelation(
         mid=response['data']['mid'],

--- a/service/error.py
+++ b/service/error.py
@@ -15,53 +15,63 @@ class ServiceError(TddError):
 
 
 class ResponseError(ServiceError):
-    def __init__(self, target: str, params: dict,
+    def __init__(self, endpoint: str, params: dict,
                  reason: Optional[str] = None, trials: int = 0):
         super().__init__()
-        self.target = target
+        self.endpoint = endpoint
         self.params = params
         self.reason = reason
         self.trials = trials
 
     def __str__(self):
-        return (f'<ResponseError(target={self.target},params={self.params},'
+        return (f'<ResponseError(endpoint={self.endpoint},params={self.params},'
                 f'reason={self.reason},trials={self.trials})>')
 
 
 class RateLimitError(ServiceError):
-    def __init__(self, target: str, reason: str):
+    def __init__(self, endpoint: str, reason: str):
         super().__init__()
-        self.target = target
+        self.endpoint = endpoint
         self.reason = reason
 
     def __str__(self):
-        return f'<RateLimitError(target={self.target},reason={self.reason})>'
+        return f'<RateLimitError(endpoint={self.endpoint},reason={self.reason})>'
 
 
 class ValidationError(ServiceError):
-    def __init__(self, target: str, params: dict, response: dict):
+    def __init__(self, endpoint: str, result_type: type, params: dict,
+                 response: dict):
         super().__init__()
-        self.target = target
+        self.endpoint = endpoint
+        self.result_type = result_type
         self.params = params
         self.response = response
 
     def __str__(self):
-        return f'<ValidationError(target={self.target},params={self.params},response={self.response})>'
+        return (f'<ValidationError(endpoint={self.endpoint},'
+                f'result_type={self.result_type.__name__},params={self.params},'
+                f'response={self.response})>')
 
 
 class FormatError(ValidationError):
-    def __init__(self, target: str, params: dict, response: dict, message: str):
-        super().__init__(target, params, response)
+    def __init__(self, endpoint: str, result_type: type, params: dict,
+                 response: dict, message: str):
+        super().__init__(endpoint, result_type, params, response)
         self.message = message
 
     def __str__(self):
-        return f'<FormatError(target={self.target},params={self.params},response={self.response},message={self.message})>'
+        return (f'<FormatError(endpoint={self.endpoint},'
+                f'result_type={self.result_type.__name__},params={self.params},'
+                f'response={self.response},message={self.message})>')
 
 
 class CodeError(ValidationError):
-    def __init__(self, target: str, params: dict, response: dict, code: int):
-        super().__init__(target, params, response)
+    def __init__(self, endpoint: str, result_type: type, params: dict,
+                 response: dict, code: int):
+        super().__init__(endpoint, result_type, params, response)
         self.code = code
 
     def __str__(self):
-        return f'<CodeError(target={self.target},params={self.params},response={self.response},code={self.code})>'
+        return (f'<CodeError(endpoint={self.endpoint},'
+                f'result_type={self.result_type.__name__},params={self.params},'
+                f'response={self.response},code={self.code})>')

--- a/service/worker.py
+++ b/service/worker.py
@@ -33,35 +33,35 @@ class WorkerSelector:
     def __init__(self, endpoints: Mapping[str, dict]):
         self._workers: dict[str, tuple[WorkerEndpoint, ...]] = {}
 
-        for target, endpoint_config in endpoints.items():
+        for endpoint, endpoint_config in endpoints.items():
             raw_workers = endpoint_config.get('workers', [])
-            workers = tuple(self._parse_worker(target, raw)
+            workers = tuple(self._parse_worker(endpoint, raw)
                             for raw in raw_workers)
             worker_ids = [worker.id for worker in workers]
             if len(worker_ids) != len(set(worker_ids)):
                 raise WorkerConfigurationError(
-                    f'Duplicate worker id for {target!r}.')
+                    f'Duplicate worker id for {endpoint!r}.')
             weighted = self._weighted(workers)
             if not weighted:
                 raise WorkerConfigurationError(
-                    f'Endpoint {target!r} has no enabled worker configured.')
-            self._workers[target] = weighted
+                    f'Endpoint {endpoint!r} has no enabled worker configured.')
+            self._workers[endpoint] = weighted
 
     @staticmethod
-    def _parse_worker(target: str, raw) -> WorkerEndpoint:
+    def _parse_worker(endpoint: str, raw) -> WorkerEndpoint:
         if not isinstance(raw, dict):
             raise WorkerConfigurationError(
-                f'Worker entry for {target!r} must be an object.')
+                f'Worker entry for {endpoint!r} must be an object.')
 
         fields = {'id', 'url', 'platform', 'weight', 'enabled'}
         missing = fields - set(raw)
         if missing:
             raise WorkerConfigurationError(
-                f'Missing worker field(s) for {target!r}: {sorted(missing)!r}.')
+                f'Missing worker field(s) for {endpoint!r}: {sorted(missing)!r}.')
         unknown = set(raw) - fields
         if unknown:
             raise WorkerConfigurationError(
-                f'Unknown worker field(s) for {target!r}: {sorted(unknown)!r}.')
+                f'Unknown worker field(s) for {endpoint!r}: {sorted(unknown)!r}.')
 
         worker_id = raw['id']
         url = raw['url']
@@ -70,7 +70,7 @@ class WorkerSelector:
         enabled = raw['enabled']
         if not isinstance(worker_id, str) or not worker_id:
             raise WorkerConfigurationError(
-                f'Worker id for {target!r} must be a non-empty string.')
+                f'Worker id for {endpoint!r} must be a non-empty string.')
         if not isinstance(url, str) or not url:
             raise WorkerConfigurationError(
                 f'Worker URL for {worker_id!r} must be a non-empty string.')
@@ -85,14 +85,14 @@ class WorkerSelector:
                 f'Worker enabled for {worker_id!r} must be a boolean.')
         return WorkerEndpoint(worker_id, url, platform, weight, enabled)
 
-    def select(self, target: str) -> WorkerEndpoint:
-        return random.choice(self._enabled_workers(target))
+    def select(self, endpoint: str) -> WorkerEndpoint:
+        return random.choice(self._enabled_workers(endpoint))
 
-    def _enabled_workers(self, target: str) -> tuple[WorkerEndpoint, ...]:
-        workers = self._workers.get(target, ())
+    def _enabled_workers(self, endpoint: str) -> tuple[WorkerEndpoint, ...]:
+        workers = self._workers.get(endpoint, ())
         if not workers:
             raise WorkerConfigurationError(
-                f'Endpoint {target!r} has no enabled worker configured.')
+                f'Endpoint {endpoint!r} has no enabled worker configured.')
         return workers
 
     @staticmethod

--- a/tests/test_api_debug_line.py
+++ b/tests/test_api_debug_line.py
@@ -8,14 +8,14 @@ from test_worker_selector import (ScriptedSession, endpoints_for, response,
 
 
 class ApiDebugLineTest(TestCase):
-    def make_service(self, target, workers, responses):
+    def make_service(self, endpoint, workers, responses):
         service = Service(
             mode='worker', retry=3, colddown_factor=0,
-            endpoints=endpoints_for(target, workers))
+            endpoints=endpoints_for(endpoint, workers))
         service._session = ScriptedSession(responses)
         return service
 
-    def test_one_line_per_attempt_names_target_worker_and_result(self):
+    def test_one_line_per_attempt_names_endpoint_worker_and_result(self):
         service = self.make_service('view', [
             worker('only', 'https://only.invalid/'),
         ], {'https://only.invalid/': [
@@ -27,11 +27,11 @@ class ApiDebugLineTest(TestCase):
                 self.assertLogs('Service', level=logging.DEBUG) as logs:
             service._get('view')
 
-        api_lines = [line for line in logs.output if 'API target: ' in line]
+        api_lines = [line for line in logs.output if 'API endpoint: ' in line]
         self.assertEqual(len(api_lines), 2)
-        self.assertIn('target: view, worker: only, status: 500, result: ok',
+        self.assertIn('endpoint: view, worker: only, status: 500, result: ok',
                       api_lines[0])
-        self.assertIn('target: view, worker: only, status: 200, result: ok',
+        self.assertIn('endpoint: view, worker: only, status: 200, result: ok',
                       api_lines[1])
 
     def test_every_rate_limited_attempt_gets_its_own_line(self):
@@ -44,7 +44,7 @@ class ApiDebugLineTest(TestCase):
             with self.assertRaises(RateLimitError):
                 service._get('view', retry=3)
 
-        api_lines = [line for line in logs.output if 'API target: ' in line]
+        api_lines = [line for line in logs.output if 'API endpoint: ' in line]
         self.assertEqual(len(api_lines), 3)
         self.assertTrue(all('status: 412, result: http_412' in line
                             for line in api_lines))
@@ -59,7 +59,7 @@ class ApiDebugLineTest(TestCase):
             with self.assertRaises(RateLimitError):
                 service._get('get_member_card', retry=1)
 
-        api_lines = [line for line in logs.output if 'API target: ' in line]
+        api_lines = [line for line in logs.output if 'API endpoint: ' in line]
         self.assertEqual(len(api_lines), 1)
         self.assertIn('status: 200, result: code_-352', api_lines[0])
 
@@ -73,6 +73,6 @@ class ApiDebugLineTest(TestCase):
         with self.assertLogs('Service', level=logging.DEBUG) as logs:
             service._get('view')
 
-        api_lines = [line for line in logs.output if 'API target: ' in line]
+        api_lines = [line for line in logs.output if 'API endpoint: ' in line]
         self.assertEqual(len(api_lines), 1)
         self.assertIn('worker: direct, status: 200, result: ok', api_lines[0])

--- a/tests/test_api_stat.py
+++ b/tests/test_api_stat.py
@@ -41,9 +41,9 @@ class DimensionTest(unittest.TestCase):
     def test_record_accepts_only_low_cardinality_dimensions(self):
         # a future change that starts passing aid/mid or a URL must touch this
         params = list(inspect.signature(ApiStatTracker.record).parameters)
-        self.assertEqual(params, ['self', 'target', 'worker', 'trial', 'outcome', 'now'])
+        self.assertEqual(params, ['self', 'endpoint', 'worker', 'trial', 'outcome', 'now'])
 
-    def test_targets_and_workers_do_not_share_counters(self):
+    def test_endpoints_and_workers_do_not_share_counters(self):
         t = ApiStatTracker(clock=FakeClock())
         t.record('get_member_card', 'card-aws', 1, 'code_-352')
         t.record('get_video_view_trimmed', 'vv-aws', 1, 'http_412')
@@ -115,7 +115,7 @@ class DerivedTest(unittest.TestCase):
         self.assertIn('exhausted=2', '\n'.join(report(t)))
 
     def test_exhaustion_chains_across_workers(self):
-        # a retry may land on another worker, so the count is per target
+        # a retry may land on another worker, so the count is per endpoint
         t = ApiStatTracker(clock=FakeClock())
         t.record('view', 'w-a', 1, 'http_412')
         t.record('view', 'w-b', 2, 'http_412')

--- a/tests/test_endpoint_get_member_relation.py
+++ b/tests/test_endpoint_get_member_relation.py
@@ -35,8 +35,9 @@ class GetMemberRelationEndpointTest(unittest.TestCase):
             get_member_relation.get(lambda *args, **kwargs: response,
                                     params={'vmid': 7})
 
-        self.assertEqual((raised.exception.target, raised.exception.code),
-                         ('member_relation', -404))
+        self.assertEqual((raised.exception.endpoint, raised.exception.result_type,
+                          raised.exception.code),
+                         ('get_member_relation', MemberRelation, -404))
 
     def test_invalid_shape_keeps_the_existing_format_error(self):
         response = valid_response()
@@ -46,7 +47,8 @@ class GetMemberRelationEndpointTest(unittest.TestCase):
             get_member_relation.get(lambda *args, **kwargs: response,
                                     params={'vmid': 7})
 
-        self.assertEqual(raised.exception.target, 'member_relation')
+        self.assertEqual(raised.exception.endpoint, 'get_member_relation')
+        self.assertIs(raised.exception.result_type, MemberRelation)
 
     def test_service_public_method_delegates_to_the_adapter(self):
         service = Service(mode='direct', endpoints={})

--- a/tests/test_service_api_stat.py
+++ b/tests/test_service_api_stat.py
@@ -41,10 +41,10 @@ def raising_response(exc):
 
 
 class ServiceApiStatWiringTest(unittest.TestCase):
-    def make_service(self, target, workers, responses, **kwargs):
+    def make_service(self, endpoint, workers, responses, **kwargs):
         service = Service(mode='worker', retry=kwargs.pop('retry', 3),
                           colddown_factor=0,
-                          endpoints=endpoints_for(target, workers), **kwargs)
+                          endpoints=endpoints_for(endpoint, workers), **kwargs)
         service._session = ScriptedSession(responses)
         return service
 

--- a/tests/test_service_error.py
+++ b/tests/test_service_error.py
@@ -1,0 +1,34 @@
+import unittest
+
+from service import (CodeError, FormatError, MemberCard, RateLimitError,
+                     ResponseError)
+
+
+class ServiceErrorTest(unittest.TestCase):
+    def test_response_and_rate_limit_errors_identify_only_the_endpoint(self):
+        response = ResponseError('get_member_card', {'mid': 7}, 'http_503', 3)
+        rate_limit = RateLimitError('get_member_card', 'code_-352')
+
+        self.assertEqual(response.endpoint, 'get_member_card')
+        self.assertEqual(rate_limit.endpoint, 'get_member_card')
+        self.assertNotIn('target=', str(response))
+        self.assertNotIn('target=', str(rate_limit))
+
+    def test_validation_errors_identify_endpoint_and_result_type(self):
+        response = {'code': -404}
+        code_error = CodeError(
+            'get_member_card', MemberCard, {'mid': 7}, response, -404)
+        format_error = FormatError(
+            'get_member_card', MemberCard, {'mid': 7}, response,
+            'Response data should be a dict.')
+
+        for error in (code_error, format_error):
+            self.assertEqual(error.endpoint, 'get_member_card')
+            self.assertIs(error.result_type, MemberCard)
+            self.assertIn('endpoint=get_member_card', str(error))
+            self.assertIn('result_type=MemberCard', str(error))
+            self.assertNotIn('target=', str(error))
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_user_agent.py
+++ b/tests/test_user_agent.py
@@ -70,7 +70,7 @@ class UserAgentTest(TestCase):
 
 
 class UserAgentPoolTest(TestCase):
-    """The pool comes from endpoints.json; UA_LIST is what a target that
+    """The pool comes from endpoints.json; UA_LIST is what an endpoint that
     configures none uses."""
 
     def endpoints_with_agents(self, agents):
@@ -89,7 +89,7 @@ class UserAgentPoolTest(TestCase):
             service._get('view')
         self.assertEqual(set(service._session.sent_agents), {'x-1', 'x-2'})
 
-    def test_a_target_without_a_pool_uses_ua_list(self):
+    def test_an_endpoint_without_a_pool_uses_ua_list(self):
         service = self.make_service(
             endpoints_for('view', [worker('a', 'https://a.invalid/')]))
         for _ in range(40):

--- a/tests/test_worker_selector.py
+++ b/tests/test_worker_selector.py
@@ -22,8 +22,8 @@ def worker(worker_id, url, platform='test', weight=1, enabled=True):
     }
 
 
-def endpoints_for(target, workers):
-    return {target: {'direct': 'https://direct.invalid/', 'workers': workers}}
+def endpoints_for(endpoint, workers):
+    return {endpoint: {'direct': 'https://direct.invalid/', 'workers': workers}}
 
 
 class FakeClock:
@@ -119,7 +119,7 @@ class WorkerSelectorConfigTest(TestCase):
         with self.assertRaisesRegex(ValueError, 'Unknown worker field'):
             WorkerSelector(endpoints_for('view', [item]))
 
-    def test_worker_ids_only_need_to_be_unique_within_a_target(self):
+    def test_worker_ids_only_need_to_be_unique_within_an_endpoint(self):
         endpoints = {
             'view': {'workers': [worker('same', 'https://one.invalid/')]},
             'card': {'workers': [worker('same', 'https://two.invalid/')]},
@@ -246,10 +246,10 @@ class RateLimitCheckerTest(TestCase):
 
 
 class ServiceWorkerRoutingTest(TestCase):
-    def make_service(self, target, workers, responses):
+    def make_service(self, endpoint, workers, responses):
         service = Service(
             mode='worker', retry=3, colddown_factor=0,
-            endpoints=endpoints_for(target, workers))
+            endpoints=endpoints_for(endpoint, workers))
         service._session = ScriptedSession(responses)
         return service
 
@@ -427,7 +427,7 @@ class ServiceWorkerRoutingTest(TestCase):
 
         self.assertEqual(raised.exception.reason, 'http_503')
         self.assertEqual(raised.exception.trials, 3)
-        self.assertEqual(raised.exception.target, 'view')
+        self.assertEqual(raised.exception.endpoint, 'view')
 
     def test_exhaustion_reason_tracks_the_last_failure_not_the_first(self):
         service = self.make_service('view', [


### PR DESCRIPTION
## Summary
- replace ambiguous Service `target` terminology with `endpoint` across request routing, workers, API stats, logs, and errors
- attach the adapter result NamedTuple type to `CodeError` and `FormatError`
- update existing adapters, consumers, and tests; add direct error-model tests

## Tests
- `venv-3.11/bin/python -m unittest discover -s tests`