### PR TITLE
refactor: extract video tags endpoint adapter

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -12,10 +12,10 @@ from .error import (ResponseError, RateLimitError,
 from .worker import WorkerConfigurationError, WorkerSelector
 from .apistat import ApiStatTracker, NullApiStatTracker
 from .ua import UA_LIST
-from .endpoints import get_member_card, get_member_relation
+from .endpoints import get_member_card, get_member_relation, get_video_tags
 from .response import \
     VideoViewOwner, VideoViewStat, VideoViewStaffItem, VideoView, VideoViewTrimmed, \
-    VideoTag, VideoTags, \
+    VideoTags, \
     MemberCard, \
     MemberRelation, \
     NewlistPage, NewlistArchiveStat, NewlistArchiveOwner, NewlistArchive, Newlist
@@ -563,65 +563,9 @@ class Service:
             retry: Optional[int] = None, timeout: Optional[float] = None,
             colddown_factor: Optional[float] = None
     ) -> VideoTags:
-        """
-        params: { aid: int }
-        """
-        # define parser
-        def parser(text: str) -> Optional[dict]:
-            logger.debug(
-                f'Try to parse video tags response text. text: {text}.')
-            parsed_response = None
-            try:
-                parsed_response = json.loads(text)
-            except json.JSONDecodeError:
-                logger.debug(f'Fail to decode text to json. Return None.')
-            if parsed_response is not None:
-                code = parsed_response['code']
-                if code in [-500, -504]:
-                    logger.debug(
-                        f'Status code {code} found. Server timeout occurred, return None for retry.')
-                    parsed_response = None
-            return parsed_response
-
-        # get response
-        response = self._get('get_video_tags', params=params, headers=headers,
-                             retry=retry, timeout=timeout, colddown_factor=colddown_factor,
-                             parser=parser)
-
-        # validate format
-
-        # response should contain keys
-        for key in ['code', 'message', 'ttl']:
-            if key not in response.keys():
-                raise FormatError('get_video_tags', VideoTags, params, response,
-                                  f'Response should contain key {key}.')
-        # response code should be 0
-        if response['code'] != 0:
-            raise CodeError('get_video_tags', VideoTags, params, response, response['code'])
-        # response data should be a list
-        if type(response['data']) != list:
-            raise FormatError('get_video_tags', VideoTags, params, response,
-                              'Response data should be a list.')
-        # for each data item
-        for data_item in response['data']:
-            # data item should be a dict
-            if type(data_item) != dict:
-                raise FormatError('get_video_tags', VideoTags, params, response,
-                                  'Response data item should be a dict.')
-            # data item should contain keys
-            for key in ['tag_id', 'tag_name']:
-                if key not in data_item.keys():
-                    raise FormatError('get_video_tags', VideoTags, params, response,
-                                      f'Response data item should contain key {key}.')
-
-        # assemble data
-        videoTags = VideoTags(tags=[])
-        for data_item in response['data']:
-            videoTags.tags.append(VideoTag(
-                tag_id=data_item['tag_id'],
-                tag_name=data_item['tag_name']
-            ))
-        return videoTags
+        return get_video_tags.get(
+            self._get, params=params, headers=headers, retry=retry,
+            timeout=timeout, colddown_factor=colddown_factor)
 
     def get_member_card(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,

--- a/service/endpoints/__init__.py
+++ b/service/endpoints/__init__.py
@@ -1,1 +1,1 @@
-from . import get_member_card, get_member_relation
+from . import get_member_card, get_member_relation, get_video_tags

--- a/service/endpoints/get_video_tags.py
+++ b/service/endpoints/get_video_tags.py
@@ -1,0 +1,53 @@
+import json
+import logging
+from typing import Callable, Optional
+
+from ..error import CodeError, FormatError
+from ..response import VideoTag, VideoTags
+
+logger = logging.getLogger('Service')
+
+ENDPOINT = 'get_video_tags'
+RESULT_TYPE = VideoTags
+
+
+def parse(text: str) -> Optional[dict]:
+    logger.debug(f'Try to parse video tags response text. text: {text}.')
+    try:
+        response = json.loads(text)
+    except json.JSONDecodeError:
+        logger.debug('Fail to decode text to json. Return None.')
+        return None
+    if response['code'] in [-500, -504]:
+        logger.debug(f'Status code {response["code"]} found. Return None for retry.')
+        return None
+    return response
+
+
+def get(request: Callable[..., dict], params: Optional[dict] = None,
+        headers: Optional[dict] = None, retry: Optional[int] = None,
+        timeout: Optional[float] = None,
+        colddown_factor: Optional[float] = None) -> VideoTags:
+    response = request(
+        ENDPOINT, params=params, headers=headers, retry=retry, timeout=timeout,
+        colddown_factor=colddown_factor, parser=parse)
+    for key in ['code', 'message', 'ttl']:
+        if key not in response:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response should contain key {key}.')
+    if response['code'] != 0:
+        raise CodeError(ENDPOINT, RESULT_TYPE, params, response, response['code'])
+    if type(response['data']) != list:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data should be a list.')
+    for data_item in response['data']:
+        if type(data_item) != dict:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              'Response data item should be a dict.')
+        for key in ['tag_id', 'tag_name']:
+            if key not in data_item:
+                raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                                  f'Response data item should contain key {key}.')
+    return VideoTags(tags=[
+        VideoTag(tag_id=data_item['tag_id'], tag_name=data_item['tag_name'])
+        for data_item in response['data']])

--- a/tests/test_endpoint_get_video_tags.py
+++ b/tests/test_endpoint_get_video_tags.py
@@ -1,0 +1,83 @@
+import unittest
+from unittest import mock
+
+from service import CodeError, FormatError, Service, VideoTag, VideoTags
+from service.endpoints import get_video_tags
+
+
+def valid_response():
+    return {
+        'code': 0,
+        'message': '0',
+        'ttl': 1,
+        'data': [
+            {'tag_id': 7, 'tag_name': 'tag'},
+            {'tag_id': 11, 'tag_name': 'next'},
+        ],
+    }
+
+
+class GetVideoTagsEndpointTest(unittest.TestCase):
+    def test_adapts_a_valid_response_and_passes_request_options(self):
+        request = mock.Mock(return_value=valid_response())
+
+        result = get_video_tags.get(
+            request, params={'aid': 7}, headers={'X-Test': 'yes'}, retry=2,
+            timeout=3.0, colddown_factor=0.0)
+
+        self.assertEqual(result, VideoTags([
+            VideoTag(7, 'tag'), VideoTag(11, 'next')]))
+        self.assertEqual(request.call_args.args, ('get_video_tags',))
+        self.assertEqual(request.call_args.kwargs, {
+            'params': {'aid': 7}, 'headers': {'X-Test': 'yes'}, 'retry': 2,
+            'timeout': 3.0, 'colddown_factor': 0.0,
+            'parser': get_video_tags.parse,
+        })
+
+    def test_parser_retries_invalid_json_and_configured_codes(self):
+        self.assertIsNone(get_video_tags.parse('not json'))
+        self.assertIsNone(get_video_tags.parse('{"code": -500}'))
+        self.assertIsNone(get_video_tags.parse('{"code": -504}'))
+        self.assertEqual(get_video_tags.parse('{"code": 0}'), {'code': 0})
+
+    def test_nonzero_api_code_keeps_the_existing_business_error(self):
+        response = valid_response()
+        response['code'] = -404
+
+        with self.assertRaises(CodeError) as raised:
+            get_video_tags.get(lambda *args, **kwargs: response,
+                               params={'aid': 7})
+
+        self.assertEqual((raised.exception.endpoint, raised.exception.result_type,
+                          raised.exception.code),
+                         ('get_video_tags', VideoTags, -404))
+
+    def test_invalid_shape_keeps_the_existing_format_error(self):
+        response = valid_response()
+        del response['data'][0]['tag_name']
+
+        with self.assertRaises(FormatError) as raised:
+            get_video_tags.get(lambda *args, **kwargs: response,
+                               params={'aid': 7})
+
+        self.assertEqual(raised.exception.endpoint, 'get_video_tags')
+        self.assertIs(raised.exception.result_type, VideoTags)
+
+    def test_service_public_method_delegates_to_the_adapter(self):
+        service = Service(mode='direct', endpoints={})
+        service._get = mock.Mock(return_value=valid_response())
+
+        result = service.get_video_tags({'aid': 7})
+
+        self.assertEqual(result, VideoTags([
+            VideoTag(7, 'tag'), VideoTag(11, 'next')]))
+        self.assertEqual(service._get.call_args.args, ('get_video_tags',))
+        self.assertEqual(service._get.call_args.kwargs, {
+            'params': {'aid': 7}, 'headers': None, 'retry': None,
+            'timeout': None, 'colddown_factor': None,
+            'parser': get_video_tags.parse,
+        })
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- move video-tags parsing, response validation, and `VideoTags` conversion into its endpoint adapter
- keep the `Service.get_video_tags` facade and shared request path unchanged
- preserve the endpoint parser that retries invalid JSON and its configured retryable provider codes

## Tests
- `venv-3.11/bin/python -m unittest discover -s tests -p test_endpoint_get_video_tags.py`
- `venv-3.11/bin/python -m unittest discover -s tests`