### PR TITLE
refactor: extract video view endpoint adapter

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -12,10 +12,10 @@ from .error import (ResponseError, RateLimitError,
 from .worker import WorkerConfigurationError, WorkerSelector
 from .apistat import ApiStatTracker, NullApiStatTracker
 from .ua import UA_LIST
-from .endpoints import get_member_card, get_member_relation, get_video_tags
+from .endpoints import (get_member_card, get_member_relation, get_video_tags,
+                        get_video_view)
 from .response import \
-    VideoViewOwner, VideoViewStat, VideoViewStaffItem, VideoView, VideoViewTrimmed, \
-    VideoTags, \
+    VideoView, VideoViewTrimmed, VideoTags, \
     MemberCard, \
     MemberRelation, \
     NewlistPage, NewlistArchiveStat, NewlistArchiveOwner, NewlistArchive, Newlist
@@ -366,118 +366,9 @@ class Service:
             retry: Optional[int] = None, timeout: Optional[float] = None,
             colddown_factor: Optional[float] = None
     ) -> VideoView:
-        """
-        params: { aid: int }
-        """
-        # get response
-        response = self._get('get_video_view', params=params, headers=headers,
-                             retry=retry, timeout=timeout, colddown_factor=colddown_factor)
-
-        # validate format
-
-        # response should contain keys
-        for key in ['code', 'message', 'ttl']:
-            if key not in response.keys():
-                raise FormatError('get_video_view', VideoView, params, response,
-                                  f'Response should contain key {key}.')
-        # response code should be 0
-        if response['code'] != 0:
-            raise CodeError('get_video_view', VideoView, params, response, response['code'])
-        # response data should be a dict
-        if type(response['data']) != dict:
-            raise FormatError('get_video_view', VideoView, params, response,
-                              'Response data should be a dict.')
-        # data should contain keys
-        for key in ['bvid', 'aid', 'videos', 'tid', 'tname', 'copyright', 'pic', 'title', 'pubdate', 'ctime', 'desc',
-                    'state', 'duration', 'owner', 'stat']:
-            if key not in response['data'].keys():
-                raise FormatError('get_video_view', VideoView, params, response,
-                                  f'Response data should contain key {key}.')
-        # response data owner should be a dict
-        if type(response['data']['owner']) != dict:
-            raise FormatError('get_video_view', VideoView, params, response,
-                              'Response data owner should be a dict.')
-        # data owner should contain keys
-        for key in ['mid', 'name', 'face']:
-            if key not in response['data']['owner'].keys():
-                raise FormatError('get_video_view', VideoView, params, response,
-                                  f'Response data owner should contain key {key}.')
-        # response data stat should be a dict
-        if type(response['data']['stat']) != dict:
-            raise FormatError('get_video_view', VideoView, params, response,
-                              'Response data stat should be a dict.')
-        # data stat should contain keys
-        for key in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share', 'now_rank', 'his_rank', 'like',
-                    'dislike']:
-            if key not in response['data']['stat'].keys():
-                raise FormatError('get_video_view', VideoView, params, response,
-                                  f'Response data stat should contain key {key}.')
-        # response data staff should be a list if exists
-        if 'staff' in response['data'].keys():
-            if type(response['data']['staff']) != list:
-                raise FormatError('get_video_view', VideoView, params, response,
-                                  'Response data staff should be a list.')
-            # staff item should be a dict
-            for staff_item in response['data']['staff']:
-                if type(staff_item) != dict:
-                    raise FormatError(
-                        'get_video_view', VideoView, params, response,
-                        'Response data staff item should be a dict.')
-                # staff item should contain keys
-                for key in ['mid', 'title', 'name', 'face']:
-                    if key not in staff_item.keys():
-                        raise FormatError('get_video_view', VideoView, params, response,
-                                          f'Response data staff item should contain key {key}.')
-
-        # assemble data
-        staff = None
-        if 'staff' in response['data'].keys():
-            staff = []
-            for staff_item in response['data']['staff']:
-                staff.append(VideoViewStaffItem(
-                    mid=staff_item['mid'],
-                    title=staff_item['title'],
-                    name=staff_item['name'],
-                    face=staff_item['face']
-                ))
-        return VideoView(
-            bvid=response['data']['bvid'],
-            aid=response['data']['aid'],
-            videos=response['data']['videos'],
-            tid=response['data']['tid'],
-            tname=response['data']['tname'],
-            copyright=response['data']['copyright'],
-            pic=response['data']['pic'],
-            title=response['data']['title'],
-            pubdate=response['data']['pubdate'],
-            ctime=response['data']['ctime'],
-            desc=response['data']['desc'],
-            state=response['data']['state'],
-            duration=response['data']['duration'],
-            owner=VideoViewOwner(
-                mid=response['data']['owner']['mid'],
-                name=response['data']['owner']['name'],
-                face=response['data']['owner']['face']
-            ),
-            stat=VideoViewStat(
-                aid=response['data']['stat']['aid'],
-                view=response['data']['stat']['view'],
-                danmaku=response['data']['stat']['danmaku'],
-                reply=response['data']['stat']['reply'],
-                favorite=response['data']['stat']['favorite'],
-                coin=response['data']['stat']['coin'],
-                share=response['data']['stat']['share'],
-                now_rank=response['data']['stat']['now_rank'],
-                his_rank=response['data']['stat']['his_rank'],
-                like=response['data']['stat']['like'],
-                dislike=response['data']['stat']['dislike'],
-                vt=response['data']['stat'].get('vt', None),
-                vv=response['data']['stat'].get('vv', None),
-            ),
-            attribute=response['data'].get('attribute', None),
-            forward=response['data'].get('forward', None),
-            staff=staff
-        )
+        return get_video_view.get(
+            self._get, params=params, headers=headers, retry=retry,
+            timeout=timeout, colddown_factor=colddown_factor)
 
     def get_video_view_trimmed(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,

--- a/service/endpoints/__init__.py
+++ b/service/endpoints/__init__.py
@@ -1,1 +1,1 @@
-from . import get_member_card, get_member_relation, get_video_tags
+from . import get_member_card, get_member_relation, get_video_tags, get_video_view

--- a/service/endpoints/get_video_view.py
+++ b/service/endpoints/get_video_view.py
@@ -1,0 +1,81 @@
+from typing import Callable, Optional
+
+from ..error import CodeError, FormatError
+from ..response import VideoView, VideoViewOwner, VideoViewStaffItem, VideoViewStat
+
+ENDPOINT = 'get_video_view'
+RESULT_TYPE = VideoView
+
+
+def get(request: Callable[..., dict], params: Optional[dict] = None,
+        headers: Optional[dict] = None, retry: Optional[int] = None,
+        timeout: Optional[float] = None,
+        colddown_factor: Optional[float] = None) -> VideoView:
+    response = request(
+        ENDPOINT, params=params, headers=headers, retry=retry, timeout=timeout,
+        colddown_factor=colddown_factor)
+    for key in ['code', 'message', 'ttl']:
+        if key not in response:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response should contain key {key}.')
+    if response['code'] != 0:
+        raise CodeError(ENDPOINT, RESULT_TYPE, params, response, response['code'])
+    if type(response['data']) != dict:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data should be a dict.')
+    data = response['data']
+    for key in ['bvid', 'aid', 'videos', 'tid', 'tname', 'copyright', 'pic', 'title',
+                'pubdate', 'ctime', 'desc', 'state', 'duration', 'owner', 'stat']:
+        if key not in data:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response data should contain key {key}.')
+    if type(data['owner']) != dict:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data owner should be a dict.')
+    for key in ['mid', 'name', 'face']:
+        if key not in data['owner']:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response data owner should contain key {key}.')
+    if type(data['stat']) != dict:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data stat should be a dict.')
+    for key in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share',
+                'now_rank', 'his_rank', 'like', 'dislike']:
+        if key not in data['stat']:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response data stat should contain key {key}.')
+
+    staff = None
+    if 'staff' in data:
+        if type(data['staff']) != list:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              'Response data staff should be a list.')
+        staff = []
+        for staff_item in data['staff']:
+            if type(staff_item) != dict:
+                raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                                  'Response data staff item should be a dict.')
+            for key in ['mid', 'title', 'name', 'face']:
+                if key not in staff_item:
+                    raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                                      f'Response data staff item should contain key {key}.')
+            staff.append(VideoViewStaffItem(
+                mid=staff_item['mid'], title=staff_item['title'],
+                name=staff_item['name'], face=staff_item['face']))
+
+    return VideoView(
+        bvid=data['bvid'], aid=data['aid'], videos=data['videos'], tid=data['tid'],
+        tname=data['tname'], copyright=data['copyright'], pic=data['pic'],
+        title=data['title'], pubdate=data['pubdate'], ctime=data['ctime'],
+        desc=data['desc'], state=data['state'], duration=data['duration'],
+        owner=VideoViewOwner(
+            mid=data['owner']['mid'], name=data['owner']['name'], face=data['owner']['face']),
+        stat=VideoViewStat(
+            aid=data['stat']['aid'], view=data['stat']['view'],
+            danmaku=data['stat']['danmaku'], reply=data['stat']['reply'],
+            favorite=data['stat']['favorite'], coin=data['stat']['coin'],
+            share=data['stat']['share'], now_rank=data['stat']['now_rank'],
+            his_rank=data['stat']['his_rank'], like=data['stat']['like'],
+            dislike=data['stat']['dislike'], vt=data['stat'].get('vt'),
+            vv=data['stat'].get('vv')),
+        attribute=data.get('attribute'), forward=data.get('forward'), staff=staff)

--- a/tests/test_endpoint_get_video_view.py
+++ b/tests/test_endpoint_get_video_view.py
@@ -1,0 +1,102 @@
+import unittest
+from unittest import mock
+
+from service import (CodeError, FormatError, Service, VideoView, VideoViewOwner,
+                     VideoViewStaffItem, VideoViewStat)
+from service.endpoints import get_video_view
+
+
+def valid_response():
+    return {
+        'code': 0,
+        'message': '0',
+        'ttl': 1,
+        'data': {
+            'bvid': 'BV1', 'aid': 7, 'videos': 1, 'tid': 3, 'tname': 'music',
+            'copyright': 1, 'pic': 'pic-url', 'title': 'title', 'pubdate': 10,
+            'ctime': 9, 'desc': 'desc', 'state': 0, 'duration': 60,
+            'owner': {'mid': 8, 'name': 'owner', 'face': 'face-url'},
+            'stat': {
+                'aid': 7, 'view': 1, 'danmaku': 2, 'reply': 3, 'favorite': 4,
+                'coin': 5, 'share': 6, 'now_rank': 0, 'his_rank': 0, 'like': 7,
+                'dislike': 0, 'vt': 8, 'vv': 9,
+            },
+            'attribute': 16,
+            'forward': 17,
+            'staff': [{'mid': 10, 'title': 'producer', 'name': 'staff', 'face': 'staff-face'}],
+        },
+    }
+
+
+def expected_result():
+    return VideoView(
+        bvid='BV1', aid=7, videos=1, tid=3, tname='music', copyright=1,
+        pic='pic-url', title='title', pubdate=10, ctime=9, desc='desc', state=0,
+        duration=60, owner=VideoViewOwner(8, 'owner', 'face-url'),
+        stat=VideoViewStat(7, 1, 2, 3, 4, 5, 6, 0, 0, 7, 0, 8, 9),
+        attribute=16, forward=17,
+        staff=[VideoViewStaffItem(10, 'producer', 'staff', 'staff-face')])
+
+
+class GetVideoViewEndpointTest(unittest.TestCase):
+    def test_adapts_a_valid_response_and_passes_request_options(self):
+        request = mock.Mock(return_value=valid_response())
+
+        result = get_video_view.get(
+            request, params={'aid': 7}, headers={'X-Test': 'yes'}, retry=2,
+            timeout=3.0, colddown_factor=0.0)
+
+        self.assertEqual(result, expected_result())
+        request.assert_called_once_with(
+            'get_video_view', params={'aid': 7}, headers={'X-Test': 'yes'},
+            retry=2, timeout=3.0, colddown_factor=0.0)
+
+    def test_missing_optional_values_leave_none_and_no_staff(self):
+        response = valid_response()
+        del response['data']['attribute']
+        del response['data']['forward']
+        del response['data']['staff']
+        del response['data']['stat']['vt']
+        del response['data']['stat']['vv']
+
+        result = get_video_view.get(lambda *args, **kwargs: response)
+
+        self.assertIsNone(result.attribute)
+        self.assertIsNone(result.forward)
+        self.assertIsNone(result.staff)
+        self.assertIsNone(result.stat.vt)
+        self.assertIsNone(result.stat.vv)
+
+    def test_nonzero_api_code_keeps_the_existing_business_error(self):
+        response = valid_response()
+        response['code'] = -404
+
+        with self.assertRaises(CodeError) as raised:
+            get_video_view.get(lambda *args, **kwargs: response, params={'aid': 7})
+
+        self.assertEqual((raised.exception.endpoint, raised.exception.result_type,
+                          raised.exception.code),
+                         ('get_video_view', VideoView, -404))
+
+    def test_invalid_shape_keeps_the_existing_format_error(self):
+        response = valid_response()
+        del response['data']['staff'][0]['face']
+
+        with self.assertRaises(FormatError) as raised:
+            get_video_view.get(lambda *args, **kwargs: response, params={'aid': 7})
+
+        self.assertEqual(raised.exception.endpoint, 'get_video_view')
+        self.assertIs(raised.exception.result_type, VideoView)
+
+    def test_service_public_method_delegates_to_the_adapter(self):
+        service = Service(mode='direct', endpoints={})
+        service._get = mock.Mock(return_value=valid_response())
+
+        self.assertEqual(service.get_video_view({'aid': 7}), expected_result())
+        service._get.assert_called_once_with(
+            'get_video_view', params={'aid': 7}, headers=None,
+            retry=None, timeout=None, colddown_factor=None)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Moves get_video_view response validation and VideoView construction into service/endpoints/get_video_view.py.

Service.get_video_view remains the public facade and delegates to the adapter; request, retry, worker selection, and API statistics remain in Service._get.

Tests: python -m unittest discover -s tests (291 passed).