### PR TITLE
refactor: extract trimmed video view endpoint adapter

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -13,7 +13,7 @@ from .worker import WorkerConfigurationError, WorkerSelector
 from .apistat import ApiStatTracker, NullApiStatTracker
 from .ua import UA_LIST
 from .endpoints import (get_member_card, get_member_relation, get_video_tags,
-                        get_video_view)
+                        get_video_view, get_video_view_trimmed)
 from .response import \
     VideoView, VideoViewTrimmed, VideoTags, \
     MemberCard, \
@@ -393,61 +393,9 @@ class Service:
                             f'Use get_video_view for direct mode.')
             raise SystemExit(1)
 
-        # get response
-        response = self._get('get_video_view_trimmed', params=params, headers=headers,
-                             retry=retry, timeout=timeout, colddown_factor=colddown_factor)
-
-        # validate format
-
-        # response should contain keys
-        for key in ['code', 'message', 'ttl']:
-            if key not in response.keys():
-                raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
-                                  f'Response should contain key {key}.')
-        # response code should be 0
-        if response['code'] != 0:
-            raise CodeError('get_video_view_trimmed', VideoViewTrimmed, params,
-                            response, response['code'])
-        # response data should be a dict
-        if type(response['data']) != dict:
-            raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
-                              'Response data should be a dict.')
-        # data should contain keys
-        for key in ['bvid', 'aid', 'stat']:
-            if key not in response['data'].keys():
-                raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
-                                  f'Response data should contain key {key}.')
-        # response data stat should be a dict
-        if type(response['data']['stat']) != dict:
-            raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
-                              'Response data stat should be a dict.')
-        # data stat should contain keys
-        for key in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share', 'now_rank', 'his_rank', 'like',
-                    'dislike']:
-            if key not in response['data']['stat'].keys():
-                raise FormatError('get_video_view_trimmed', VideoViewTrimmed, params, response,
-                                  f'Response data stat should contain key {key}.')
-
-        # assemble data
-        return VideoViewTrimmed(
-            bvid=response['data']['bvid'],
-            aid=response['data']['aid'],
-            stat=VideoViewStat(
-                aid=response['data']['stat']['aid'],
-                view=response['data']['stat']['view'],
-                danmaku=response['data']['stat']['danmaku'],
-                reply=response['data']['stat']['reply'],
-                favorite=response['data']['stat']['favorite'],
-                coin=response['data']['stat']['coin'],
-                share=response['data']['stat']['share'],
-                now_rank=response['data']['stat']['now_rank'],
-                his_rank=response['data']['stat']['his_rank'],
-                like=response['data']['stat']['like'],
-                dislike=response['data']['stat']['dislike'],
-                vt=response['data']['stat'].get('vt', None),
-                vv=response['data']['stat'].get('vv', None),
-            ),
-        )
+        return get_video_view_trimmed.get(
+            self._get, params=params, headers=headers, retry=retry,
+            timeout=timeout, colddown_factor=colddown_factor)
 
     def get_video_tags(
             self, params: Optional[dict] = None, headers: Optional[dict] = None,

--- a/service/endpoints/__init__.py
+++ b/service/endpoints/__init__.py
@@ -1,1 +1,2 @@
-from . import get_member_card, get_member_relation, get_video_tags, get_video_view
+from . import (get_member_card, get_member_relation, get_video_tags, get_video_view,
+               get_video_view_trimmed)

--- a/service/endpoints/get_video_view_trimmed.py
+++ b/service/endpoints/get_video_view_trimmed.py
@@ -1,0 +1,48 @@
+from typing import Callable, Optional
+
+from ..error import CodeError, FormatError
+from ..response import VideoViewStat, VideoViewTrimmed
+
+ENDPOINT = 'get_video_view_trimmed'
+RESULT_TYPE = VideoViewTrimmed
+
+
+def get(request: Callable[..., dict], params: Optional[dict] = None,
+        headers: Optional[dict] = None, retry: Optional[int] = None,
+        timeout: Optional[float] = None,
+        colddown_factor: Optional[float] = None) -> VideoViewTrimmed:
+    response = request(
+        ENDPOINT, params=params, headers=headers, retry=retry, timeout=timeout,
+        colddown_factor=colddown_factor)
+    for key in ['code', 'message', 'ttl']:
+        if key not in response:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response should contain key {key}.')
+    if response['code'] != 0:
+        raise CodeError(ENDPOINT, RESULT_TYPE, params, response, response['code'])
+    if type(response['data']) != dict:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data should be a dict.')
+    data = response['data']
+    for key in ['bvid', 'aid', 'stat']:
+        if key not in data:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response data should contain key {key}.')
+    if type(data['stat']) != dict:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data stat should be a dict.')
+    for key in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share',
+                'now_rank', 'his_rank', 'like', 'dislike']:
+        if key not in data['stat']:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response data stat should contain key {key}.')
+    return VideoViewTrimmed(
+        bvid=data['bvid'], aid=data['aid'],
+        stat=VideoViewStat(
+            aid=data['stat']['aid'], view=data['stat']['view'],
+            danmaku=data['stat']['danmaku'], reply=data['stat']['reply'],
+            favorite=data['stat']['favorite'], coin=data['stat']['coin'],
+            share=data['stat']['share'], now_rank=data['stat']['now_rank'],
+            his_rank=data['stat']['his_rank'], like=data['stat']['like'],
+            dislike=data['stat']['dislike'], vt=data['stat'].get('vt'),
+            vv=data['stat'].get('vv')))

--- a/tests/test_endpoint_get_video_view_trimmed.py
+++ b/tests/test_endpoint_get_video_view_trimmed.py
@@ -1,0 +1,78 @@
+import unittest
+from unittest import mock
+
+from service import CodeError, FormatError, Service, VideoViewStat, VideoViewTrimmed
+from service.endpoints import get_video_view_trimmed
+
+
+def valid_response():
+    return {
+        'code': 0, 'message': '0', 'ttl': 1,
+        'data': {
+            'bvid': 'BV1', 'aid': 7,
+            'stat': {
+                'aid': 7, 'view': 1, 'danmaku': 2, 'reply': 3, 'favorite': 4,
+                'coin': 5, 'share': 6, 'now_rank': 0, 'his_rank': 0, 'like': 7,
+                'dislike': 0, 'vt': 8, 'vv': 9,
+            },
+        },
+    }
+
+
+class GetVideoViewTrimmedEndpointTest(unittest.TestCase):
+    def test_adapts_valid_response_and_passes_request_options(self):
+        request = mock.Mock(return_value=valid_response())
+
+        result = get_video_view_trimmed.get(
+            request, params={'aid': 7}, headers={'X-Test': 'yes'}, retry=2,
+            timeout=3.0, colddown_factor=0.0)
+
+        self.assertEqual(result, VideoViewTrimmed(
+            'BV1', 7, VideoViewStat(7, 1, 2, 3, 4, 5, 6, 0, 0, 7, 0, 8, 9)))
+        request.assert_called_once_with(
+            'get_video_view_trimmed', params={'aid': 7}, headers={'X-Test': 'yes'},
+            retry=2, timeout=3.0, colddown_factor=0.0)
+
+    def test_optional_stat_values_are_none_when_absent(self):
+        response = valid_response()
+        del response['data']['stat']['vt']
+        del response['data']['stat']['vv']
+
+        result = get_video_view_trimmed.get(lambda *args, **kwargs: response)
+
+        self.assertIsNone(result.stat.vt)
+        self.assertIsNone(result.stat.vv)
+
+    def test_nonzero_api_code_keeps_existing_business_error(self):
+        response = valid_response()
+        response['code'] = -404
+
+        with self.assertRaises(CodeError) as raised:
+            get_video_view_trimmed.get(lambda *args, **kwargs: response)
+
+        self.assertEqual((raised.exception.endpoint, raised.exception.result_type,
+                          raised.exception.code),
+                         ('get_video_view_trimmed', VideoViewTrimmed, -404))
+
+    def test_invalid_shape_keeps_existing_format_error(self):
+        response = valid_response()
+        del response['data']['stat']['view']
+
+        with self.assertRaises(FormatError) as raised:
+            get_video_view_trimmed.get(lambda *args, **kwargs: response)
+
+        self.assertEqual(raised.exception.endpoint, 'get_video_view_trimmed')
+        self.assertIs(raised.exception.result_type, VideoViewTrimmed)
+
+    def test_direct_mode_remains_rejected_before_request(self):
+        service = Service(mode='direct', endpoints={})
+        service._get = mock.Mock(return_value=valid_response())
+
+        with self.assertRaises(SystemExit):
+            service.get_video_view_trimmed({'aid': 7})
+
+        service._get.assert_not_called()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Moves get_video_view_trimmed response validation and VideoViewTrimmed construction into service/endpoints/get_video_view_trimmed.py.

The Service facade retains the worker-only mode check. Request, retry, worker selection, and API statistics remain in Service._get.

Tests: python -m unittest discover -s tests (296 passed).