### PR TITLE
refactor: extract newlist endpoint adapter

### DIFF
--- a/service/Service.py
+++ b/service/Service.py
@@ -13,12 +13,12 @@ from .worker import WorkerConfigurationError, WorkerSelector
 from .apistat import ApiStatTracker, NullApiStatTracker
 from .ua import UA_LIST
 from .endpoints import (get_member_card, get_member_relation, get_video_tags,
-                        get_video_view, get_video_view_trimmed)
+                        get_video_view, get_video_view_trimmed, get_newlist)
 from .response import \
     VideoView, VideoViewTrimmed, VideoTags, \
     MemberCard, \
     MemberRelation, \
-    NewlistPage, NewlistArchiveStat, NewlistArchiveOwner, NewlistArchive, Newlist
+    Newlist
 from util import a2b
 import logging
 
@@ -429,134 +429,6 @@ class Service:
             retry: Optional[int] = None, timeout: Optional[float] = None,
             colddown_factor: Optional[float] = None
     ) -> Newlist:
-        """
-        params: { rid: int, pn: int, ps: int }
-        """
-        # get endpoint url
-        # define parser
-        def parser(text: str) -> Optional[dict]:
-            logger.debug(f'Try to parse newlist response text. text: {text}.')
-            parsed_response = None
-            try:
-                parsed_response = json.loads(text)
-            except json.JSONDecodeError:
-                logger.debug(f'Fail to decode text to json. Return None.')
-            if parsed_response is not None:
-                code = parsed_response['code']
-                if code in [-40002]:
-                    logger.debug(
-                        f'Status code {code} found. Server timeout occurred, return None for retry.')
-                    parsed_response = None
-            return parsed_response
-
-        # get response
-        response = self._get('get_newlist', params=params, headers=headers,
-                             retry=retry, timeout=timeout, colddown_factor=colddown_factor,
-                             parser=parser)
-
-        # validate format
-
-        # response should contain keys
-        for key in ['code', 'message']:
-            if key not in response.keys():
-                raise FormatError('get_newlist', Newlist, params, response,
-                                  f'Response should contain key {key}.')
-        # response code should be 0
-        if response['code'] != 0:
-            raise CodeError('get_newlist', Newlist, params, response, response['code'])
-        # response data should be a dict
-        if type(response['data']) != dict:
-            raise FormatError('get_newlist', Newlist, params, response,
-                              'Response data should be a dict.')
-        # data should contain keys
-        for key in ['archives', 'page']:
-            if key not in response['data'].keys():
-                raise FormatError('get_newlist', Newlist, params, response,
-                                  f'Response data should contain key {key}.')
-        # data archives should be a list
-        if type(response['data']['archives']) != list:
-            raise FormatError('get_newlist', Newlist, params, response,
-                              'Response data archives should be a list.')
-        # for each data archives item
-        for data_archives_item in response['data']['archives']:
-            # data archives item should be a dict
-            if type(data_archives_item) != dict:
-                raise FormatError('get_newlist', Newlist, params, response,
-                                  'Response data archives item should be a dict.')
-            # data archives item should contain keys
-            for key in ['aid', 'videos', 'tid', 'tname', 'copyright', 'pic', 'title', 'stat', 'bvid', 'desc', 'owner']:
-                if key not in data_archives_item.keys():
-                    raise FormatError('get_newlist', Newlist, params, response,
-                                      f'Response data archives item should contain key {key}.')
-                # data archives item stat should be a dict
-                if type(data_archives_item['stat']) != dict:
-                    raise FormatError('get_newlist', Newlist, params, response,
-                                      'Response data archives item stat should be a dict.')
-                # data archives item stat should contain keys
-                for key2 in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share', 'now_rank', 'his_rank',
-                             'like', 'dislike', 'vt', 'vv']:
-                    if key2 not in data_archives_item['stat'].keys():
-                        raise FormatError('get_newlist', Newlist, params, response,
-                                          f'Response data archives item stat should contain key {key2}.')
-                # data archives item owner should be a dict
-                if type(data_archives_item['owner']) != dict:
-                    raise FormatError('get_newlist', Newlist, params, response,
-                                      'Response data archives item owner should be a dict.')
-                # data archives item stat should contain keys
-                for key2 in ['mid', 'name', 'face']:
-                    if key2 not in data_archives_item['owner'].keys():
-                        raise FormatError('get_newlist', Newlist, params, response,
-                                          f'Response data archives item owner should contain key {key2}.')
-        # data page should be a dict
-        if type(response['data']['page']) != dict:
-            raise FormatError('get_newlist', Newlist, params, response,
-                              'Response data page should be a dict.')
-        # data page should contain keys
-        for key in ['count', 'num', 'size']:
-            if key not in response['data']['page'].keys():
-                raise FormatError('get_newlist', Newlist, params, response,
-                                  f'Response data page should contain key {key}.')
-
-        # assemble data
-        newlistPage = NewlistPage(
-            count=response['data']['page']['count'],
-            num=response['data']['page']['num'],
-            size=response['data']['page']['size']
-        )
-        newlistArchives = []
-        for data_archives_item in response['data']['archives']:
-            newlistArchives.append(NewlistArchive(
-                aid=data_archives_item['aid'],
-                videos=data_archives_item['videos'],
-                tid=data_archives_item['tid'],
-                tname=data_archives_item['tname'],
-                copyright=data_archives_item['copyright'],
-                pic=data_archives_item['pic'],
-                title=data_archives_item['title'],
-                stat=NewlistArchiveStat(
-                    aid=data_archives_item['stat']['aid'],
-                    view=data_archives_item['stat']['view'],
-                    danmaku=data_archives_item['stat']['danmaku'],
-                    reply=data_archives_item['stat']['reply'],
-                    favorite=data_archives_item['stat']['favorite'],
-                    coin=data_archives_item['stat']['coin'],
-                    share=data_archives_item['stat']['share'],
-                    now_rank=data_archives_item['stat']['now_rank'],
-                    his_rank=data_archives_item['stat']['his_rank'],
-                    like=data_archives_item['stat']['like'],
-                    dislike=data_archives_item['stat']['dislike'],
-                    vt=data_archives_item['stat']['vt'],
-                    vv=data_archives_item['stat']['vv']
-                ),
-                bvid=data_archives_item['bvid'],
-                desc=data_archives_item['desc'],
-                owner=NewlistArchiveOwner(
-                    mid=data_archives_item['owner']['mid'],
-                    name=data_archives_item['owner']['name'],
-                    face=data_archives_item['owner']['face']
-                ),
-            ))
-        return Newlist(
-            archives=newlistArchives,
-            page=newlistPage
-        )
+        return get_newlist.get(
+            self._get, params=params, headers=headers, retry=retry,
+            timeout=timeout, colddown_factor=colddown_factor)

--- a/service/endpoints/__init__.py
+++ b/service/endpoints/__init__.py
@@ -1,2 +1,2 @@
-from . import (get_member_card, get_member_relation, get_video_tags, get_video_view,
+from . import (get_member_card, get_member_relation, get_newlist, get_video_tags, get_video_view,
                get_video_view_trimmed)

--- a/service/endpoints/get_newlist.py
+++ b/service/endpoints/get_newlist.py
@@ -1,0 +1,89 @@
+import json
+import logging
+from typing import Callable, Optional
+
+from ..error import CodeError, FormatError
+from ..response import (Newlist, NewlistArchive, NewlistArchiveOwner,
+                         NewlistArchiveStat, NewlistPage)
+
+logger = logging.getLogger('Service')
+ENDPOINT = 'get_newlist'
+RESULT_TYPE = Newlist
+
+
+def parse(text: str) -> Optional[dict]:
+    logger.debug(f'Try to parse newlist response text. text: {text}.')
+    try:
+        response = json.loads(text)
+    except json.JSONDecodeError:
+        logger.debug('Fail to decode text to json. Return None.')
+        return None
+    if response['code'] == -40002:
+        logger.debug(f'Status code {response["code"]} found. Return None for retry.')
+        return None
+    return response
+
+
+def get(request: Callable[..., dict], params: Optional[dict] = None,
+        headers: Optional[dict] = None, retry: Optional[int] = None,
+        timeout: Optional[float] = None,
+        colddown_factor: Optional[float] = None) -> Newlist:
+    response = request(ENDPOINT, params=params, headers=headers, retry=retry,
+                       timeout=timeout, colddown_factor=colddown_factor, parser=parse)
+    for key in ['code', 'message']:
+        if key not in response:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response should contain key {key}.')
+    if response['code'] != 0:
+        raise CodeError(ENDPOINT, RESULT_TYPE, params, response, response['code'])
+    if type(response['data']) != dict:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data should be a dict.')
+    data = response['data']
+    for key in ['archives', 'page']:
+        if key not in data:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response data should contain key {key}.')
+    if type(data['archives']) != list:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data archives should be a list.')
+    archives = []
+    for item in data['archives']:
+        if type(item) != dict:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              'Response data archives item should be a dict.')
+        for key in ['aid', 'videos', 'tid', 'tname', 'copyright', 'pic', 'title', 'stat', 'bvid', 'desc', 'owner']:
+            if key not in item:
+                raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                                  f'Response data archives item should contain key {key}.')
+        if type(item['stat']) != dict:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              'Response data archives item stat should be a dict.')
+        for key in ['aid', 'view', 'danmaku', 'reply', 'favorite', 'coin', 'share', 'now_rank', 'his_rank', 'like', 'dislike', 'vt', 'vv']:
+            if key not in item['stat']:
+                raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                                  f'Response data archives item stat should contain key {key}.')
+        if type(item['owner']) != dict:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              'Response data archives item owner should be a dict.')
+        for key in ['mid', 'name', 'face']:
+            if key not in item['owner']:
+                raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                                  f'Response data archives item owner should contain key {key}.')
+        stat = item['stat']
+        archives.append(NewlistArchive(
+            aid=item['aid'], videos=item['videos'], tid=item['tid'], tname=item['tname'],
+            copyright=item['copyright'], pic=item['pic'], title=item['title'],
+            stat=NewlistArchiveStat(stat['aid'], stat['view'], stat['danmaku'], stat['reply'],
+                                    stat['favorite'], stat['coin'], stat['share'], stat['now_rank'],
+                                    stat['his_rank'], stat['like'], stat['dislike'], stat['vt'], stat['vv']),
+            bvid=item['bvid'], desc=item['desc'],
+            owner=NewlistArchiveOwner(item['owner']['mid'], item['owner']['name'], item['owner']['face'])))
+    if type(data['page']) != dict:
+        raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                          'Response data page should be a dict.')
+    for key in ['count', 'num', 'size']:
+        if key not in data['page']:
+            raise FormatError(ENDPOINT, RESULT_TYPE, params, response,
+                              f'Response data page should contain key {key}.')
+    return Newlist(archives, NewlistPage(data['page']['count'], data['page']['num'], data['page']['size']))

--- a/tests/test_endpoint_get_newlist.py
+++ b/tests/test_endpoint_get_newlist.py
@@ -1,0 +1,69 @@
+import unittest
+from unittest import mock
+
+from service import CodeError, FormatError, Newlist, Service
+from service.endpoints import get_newlist
+
+
+def valid_response():
+    return {
+        'code': 0, 'message': '0',
+        'data': {
+            'archives': [{
+                'aid': 7, 'videos': 1, 'tid': 3, 'tname': 'music', 'copyright': 1,
+                'pic': 'pic', 'title': 'title', 'bvid': 'BV1', 'desc': 'desc',
+                'stat': {'aid': 7, 'view': 1, 'danmaku': 2, 'reply': 3, 'favorite': 4,
+                         'coin': 5, 'share': 6, 'now_rank': 0, 'his_rank': 0,
+                         'like': 7, 'dislike': 0, 'vt': 8, 'vv': 9},
+                'owner': {'mid': 8, 'name': 'owner', 'face': 'face'},
+            }],
+            'page': {'count': 1, 'num': 1, 'size': 50},
+        },
+    }
+
+
+class GetNewlistEndpointTest(unittest.TestCase):
+    def test_adapts_response_and_passes_options(self):
+        request = mock.Mock(return_value=valid_response())
+        result = get_newlist.get(request, params={'rid': 3, 'pn': 1, 'ps': 50},
+                                 headers={'X-Test': 'yes'}, retry=2, timeout=3.0,
+                                 colddown_factor=0.0)
+        self.assertIsInstance(result, Newlist)
+        self.assertEqual(result.archives[0].owner.name, 'owner')
+        self.assertEqual(result.archives[0].stat.vv, 9)
+        self.assertEqual(result.page.size, 50)
+        self.assertEqual(request.call_args.args, ('get_newlist',))
+        self.assertEqual(request.call_args.kwargs['parser'], get_newlist.parse)
+
+    def test_parser_retries_invalid_json_and_configured_code(self):
+        self.assertIsNone(get_newlist.parse('not json'))
+        self.assertIsNone(get_newlist.parse('{"code": -40002}'))
+        self.assertEqual(get_newlist.parse('{"code": 0}'), {'code': 0})
+
+    def test_nonzero_code_keeps_business_error(self):
+        response = valid_response()
+        response['code'] = -404
+        with self.assertRaises(CodeError) as raised:
+            get_newlist.get(lambda *args, **kwargs: response)
+        self.assertEqual((raised.exception.endpoint, raised.exception.result_type,
+                          raised.exception.code), ('get_newlist', Newlist, -404))
+
+    def test_invalid_shape_keeps_format_error(self):
+        response = valid_response()
+        del response['data']['archives'][0]['owner']['face']
+        with self.assertRaises(FormatError) as raised:
+            get_newlist.get(lambda *args, **kwargs: response)
+        self.assertEqual(raised.exception.endpoint, 'get_newlist')
+        self.assertIs(raised.exception.result_type, Newlist)
+
+    def test_service_method_delegates_to_adapter(self):
+        service = Service(mode='direct', endpoints={})
+        service._get = mock.Mock(return_value=valid_response())
+        result = service.get_newlist({'rid': 3, 'pn': 1, 'ps': 50})
+        self.assertIsInstance(result, Newlist)
+        self.assertEqual(service._get.call_args.args, ('get_newlist',))
+        self.assertEqual(service._get.call_args.kwargs['parser'], get_newlist.parse)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Moves get_newlist parsing, response validation, and Newlist construction into service/endpoints/get_newlist.py.

Service.get_newlist remains the public facade; request, retry, worker selection, and API statistics remain in Service._get.

Tests: python -m unittest discover -s tests (301 passed).